### PR TITLE
feat(update): implement update notification system and status indicator

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -355,9 +355,14 @@ The status bar at the bottom shows (left to right on the main strip, then indica
 | Health | App health indicator — click to open Health Center |
 | Build status | Current or last build — click to switch to the Build tab |
 | MCP | MCP integration — click to open the MCP activity panel (setup, copy command, activity log) |
+| Update | New Keynobi version indicator — click to open the GitHub release download page |
 | Variant pill | Active build variant (when a project is open) — click to change |
 | App memory | Approximate app memory use (right side) |
 | Log folder size | Log folder size vs configured cap (right side); tooltip shows rotation when applicable |
+
+### Update Notification
+
+On startup, Keynobi checks the latest GitHub release at `thiagodmont/keynobi`. When a newer version is available, a modal offers **Download** or **Later**. **Download** opens the GitHub release page. **Later** dismisses that release's modal permanently, but the status bar still shows the update indicator so you can open the release page later.
 
 ---
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost https://*.ingest.sentry.io https://*.ingest.us.sentry.io; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; font-src 'self' data:;"
+      "csp": "default-src 'self'; connect-src ipc: http://ipc.localhost https://api.github.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; font-src 'self' data:;"
     }
   },
   "bundle": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/stores/ui.store";
 import TitleBar from "@/components/layout/TitleBar";
 import StatusBar from "@/components/layout/StatusBar";
-import { ToastContainer, showToast } from "@/components/ui";
+import { ToastContainer, showDialog, showToast } from "@/components/ui";
 import { DialogHost } from "@/components/ui";
 import { AppErrorBoundary } from "@/components/common/ErrorBoundary";
 import { CommandPalette, openPalette } from "@/components/ui";
@@ -39,6 +39,12 @@ import { openVariantPicker } from "@/components/build/VariantSelector";
 import { formatError, sendNativeSentryTestEvent } from "@/lib/tauri-api";
 import { projectState } from "@/stores/project.store";
 import { openMcpPanel } from "@/components/mcp/McpPanel";
+import {
+  dismissUpdate,
+  openUpdateRelease,
+  refreshAppUpdate,
+  shouldDismissUpdatePrompt,
+} from "@/services/update.service";
 
 function formatShortcut(opts: {
   key: string;
@@ -96,6 +102,33 @@ export function App(): JSX.Element {
     initKeybindings();
     await loadSettings();
     tryOpenOnboardingAfterLoad();
+
+    refreshAppUpdate()
+      .then(async (update) => {
+        if (!update.available || update.dismissed || !update.tagName) return;
+        const result = await showDialog({
+          title: "New Keynobi Version Available",
+          message: `Keynobi ${update.latestVersion} is available. You are running ${update.currentVersion}. Download the latest release from GitHub when you are ready.`,
+          buttons: [
+            { label: "Later", value: "later", style: "secondary" },
+            { label: "Download", value: "download", style: "primary" },
+          ],
+        });
+
+        if (result === "download") {
+          await openUpdateRelease(update).catch((err) => {
+            showToast(`Failed to open release page: ${formatError(err)}`, "error");
+          });
+          return;
+        }
+
+        if (shouldDismissUpdatePrompt(result)) {
+          dismissUpdate(update.tagName);
+        }
+      })
+      .catch((err) => {
+        console.warn("[updates] release check failed", err);
+      });
 
     // Initialize MCP lifecycle event listeners.
     import("@/stores/mcp.store").then(({ initMcpListeners, loadMcpActivity }) => {

--- a/src/components/layout/StatusBar.tsx
+++ b/src/components/layout/StatusBar.tsx
@@ -12,6 +12,7 @@ import { openMcpPanel } from "@/components/mcp/McpPanel";
 import { Icon } from "@/components/ui";
 import { appMemoryBytes, logFolderBytes, rotationTriggered } from "@/stores/monitor.store";
 import { settingsState } from "@/stores/settings.store";
+import { AppUpdateStatusIndicator } from "@/components/update/AppUpdateStatusIndicator";
 
 async function startDrag(e: MouseEvent) {
   if (e.button !== 0) return;
@@ -453,6 +454,9 @@ export function StatusBar(): JSX.Element {
 
         {/* MCP server indicator */}
         <McpStatusIndicator />
+
+        {/* App update indicator */}
+        <AppUpdateStatusIndicator />
 
         {/* Variant selector */}
         <Show when={projectState.projectName}>

--- a/src/components/update/AppUpdateStatusIndicator.test.tsx
+++ b/src/components/update/AppUpdateStatusIndicator.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { dismissToast, toasts } from "@/components/ui";
+import { setAppUpdateForTests } from "@/services/update.service";
+import { AppUpdateStatusIndicator } from "./AppUpdateStatusIndicator";
+import type * as UpdateService from "@/services/update.service";
+
+vi.mock("@/services/update.service", async () => {
+  const actual = await vi.importActual<typeof UpdateService>("@/services/update.service");
+  return {
+    ...actual,
+    openUpdateRelease: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe("AppUpdateStatusIndicator", () => {
+  beforeEach(() => {
+    setAppUpdateForTests(null);
+    for (const toast of toasts()) dismissToast(toast.id);
+    vi.clearAllMocks();
+  });
+
+  it("does not render when there is no available update", () => {
+    setAppUpdateForTests({
+      available: false,
+      dismissed: false,
+      currentVersion: "0.1.18",
+    });
+
+    render(() => <AppUpdateStatusIndicator />);
+
+    expect(screen.queryByRole("button", { name: /update available/i })).toBeNull();
+  });
+
+  it("renders when an update is available even after the modal was dismissed", () => {
+    setAppUpdateForTests({
+      available: true,
+      dismissed: true,
+      currentVersion: "0.1.18",
+      latestVersion: "0.1.19",
+      tagName: "v0.1.19",
+      releaseName: "Keynobi 0.1.19",
+      releaseUrl: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+    });
+
+    render(() => <AppUpdateStatusIndicator />);
+
+    expect(screen.getByRole("button", { name: /update available/i }).textContent).toContain(
+      "Update 0.1.19"
+    );
+  });
+
+  it("opens the release link when clicked", async () => {
+    const { openUpdateRelease } = await import("@/services/update.service");
+    setAppUpdateForTests({
+      available: true,
+      dismissed: false,
+      currentVersion: "0.1.18",
+      latestVersion: "0.1.19",
+      tagName: "v0.1.19",
+      releaseName: "Keynobi 0.1.19",
+      releaseUrl: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+    });
+
+    render(() => <AppUpdateStatusIndicator />);
+    fireEvent.click(screen.getByRole("button", { name: /update available/i }));
+
+    expect(openUpdateRelease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        releaseUrl: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+      })
+    );
+  });
+
+  it("shows a toast when opening the release link fails", async () => {
+    const { openUpdateRelease } = await import("@/services/update.service");
+    vi.mocked(openUpdateRelease).mockRejectedValueOnce(new Error("blocked"));
+    setAppUpdateForTests({
+      available: true,
+      dismissed: false,
+      currentVersion: "0.1.18",
+      latestVersion: "0.1.19",
+      tagName: "v0.1.19",
+      releaseName: "Keynobi 0.1.19",
+      releaseUrl: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+    });
+
+    render(() => <AppUpdateStatusIndicator />);
+    fireEvent.click(screen.getByRole("button", { name: /update available/i }));
+    await Promise.resolve();
+
+    expect(toasts()).toEqual([
+      expect.objectContaining({
+        kind: "error",
+        message: "Failed to open release page: blocked",
+      }),
+    ]);
+  });
+});

--- a/src/components/update/AppUpdateStatusIndicator.tsx
+++ b/src/components/update/AppUpdateStatusIndicator.tsx
@@ -1,0 +1,57 @@
+import { type JSX, Show } from "solid-js";
+import { Icon, showToast } from "@/components/ui";
+import { formatError } from "@/lib/tauri-api";
+import { openUpdateRelease, updateState } from "@/services/update.service";
+
+export function AppUpdateStatusIndicator(): JSX.Element {
+  const update = () => updateState.update;
+
+  return (
+    <Show when={update()?.available ? update() : null}>
+      {(availableUpdate) => (
+        <button
+          type="button"
+          aria-label="Update available"
+          title={`Keynobi ${availableUpdate().latestVersion} is available — click to open downloads`}
+          onClick={() => {
+            openUpdateRelease(availableUpdate()).catch((err) => {
+              showToast(`Failed to open release page: ${formatError(err)}`, "error");
+            });
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            display: "flex",
+            "align-items": "center",
+            gap: "4px",
+            padding: "0 6px",
+            height: "18px",
+            background: "rgba(255,255,255,0.12)",
+            border: "1px solid rgba(255,255,255,0.24)",
+            "border-radius": "3px",
+            cursor: "pointer",
+            "flex-shrink": "0",
+            color: "#ffffff",
+            transition: "background 0.1s",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.background = "rgba(255,255,255,0.2)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.background = "rgba(255,255,255,0.12)";
+          }}
+        >
+          <Icon name="download" size={11} />
+          <span
+            style={{
+              "font-size": "11px",
+              "line-height": "1",
+              "white-space": "nowrap",
+            }}
+          >
+            Update {availableUpdate().latestVersion}
+          </span>
+        </button>
+      )}
+    </Show>
+  );
+}

--- a/src/services/update.service.test.ts
+++ b/src/services/update.service.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  checkForAppUpdate,
+  clearDismissedUpdateForTests,
+  compareVersions,
+  dismissUpdate,
+  getDismissedUpdateTag,
+  normalizeRelease,
+  shouldDismissUpdatePrompt,
+} from "./update.service";
+
+describe("update.service", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearDismissedUpdateForTests();
+    vi.unstubAllGlobals();
+  });
+
+  it("compares semantic versions with optional v prefixes", () => {
+    expect(compareVersions("v0.1.19", "0.1.18")).toBe(1);
+    expect(compareVersions("0.2.0", "v0.1.99")).toBe(1);
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("0.1.17", "0.1.18")).toBe(-1);
+  });
+
+  it("ignores prerelease suffixes for update comparison", () => {
+    expect(compareVersions("v0.2.0-beta.1", "0.1.18")).toBe(1);
+    expect(compareVersions("v0.1.18-beta.1", "0.1.18")).toBe(0);
+  });
+
+  it("normalizes a GitHub release payload", () => {
+    const release = normalizeRelease({
+      tag_name: "v0.1.19",
+      name: "Keynobi 0.1.19",
+      html_url: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+      draft: false,
+      prerelease: false,
+    });
+
+    expect(release).toEqual({
+      tagName: "v0.1.19",
+      version: "0.1.19",
+      name: "Keynobi 0.1.19",
+      releaseUrl: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+      prerelease: false,
+    });
+  });
+
+  it("returns an available update when latest release is newer", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            tag_name: "v0.1.19",
+            name: "Keynobi 0.1.19",
+            html_url: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+            draft: false,
+            prerelease: false,
+          }),
+      })
+    );
+
+    const update = await checkForAppUpdate("0.1.18");
+
+    expect(update).toMatchObject({
+      available: true,
+      dismissed: false,
+      currentVersion: "0.1.18",
+      latestVersion: "0.1.19",
+      tagName: "v0.1.19",
+    });
+  });
+
+  it("marks an available update as dismissed after Later is clicked", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            tag_name: "v0.1.19",
+            name: "Keynobi 0.1.19",
+            html_url: "https://github.com/thiagodmont/keynobi/releases/tag/v0.1.19",
+            draft: false,
+            prerelease: false,
+          }),
+      })
+    );
+
+    dismissUpdate("v0.1.19");
+    const update = await checkForAppUpdate("0.1.18");
+
+    expect(getDismissedUpdateTag()).toBe("v0.1.19");
+    expect(update.available).toBe(true);
+    expect(update.dismissed).toBe(true);
+  });
+
+  it("only persists update dismissal for the explicit Later action", () => {
+    expect(shouldDismissUpdatePrompt("later")).toBe(true);
+    expect(shouldDismissUpdatePrompt("cancel")).toBe(false);
+    expect(shouldDismissUpdatePrompt("download")).toBe(false);
+  });
+
+  it("returns unavailable when GitHub cannot be reached", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+
+    const update = await checkForAppUpdate("0.1.18");
+
+    expect(update).toEqual({
+      available: false,
+      dismissed: false,
+      currentVersion: "0.1.18",
+      error: "offline",
+    });
+  });
+});

--- a/src/services/update.service.ts
+++ b/src/services/update.service.ts
@@ -1,0 +1,178 @@
+import { createStore } from "solid-js/store";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+const LATEST_RELEASE_URL = "https://api.github.com/repos/thiagodmont/keynobi/releases/latest";
+const RELEASES_PAGE_URL = "https://github.com/thiagodmont/keynobi/releases";
+const DISMISSED_UPDATE_TAG_KEY = "keynobi.dismissedUpdateTag";
+
+export interface NormalizedRelease {
+  tagName: string;
+  version: string;
+  name: string;
+  releaseUrl: string;
+  prerelease: boolean;
+}
+
+export interface AppUpdateInfo {
+  available: boolean;
+  dismissed: boolean;
+  currentVersion: string;
+  latestVersion?: string;
+  tagName?: string;
+  releaseName?: string;
+  releaseUrl?: string;
+  error?: string;
+}
+
+interface AppUpdateState {
+  checking: boolean;
+  update: AppUpdateInfo | null;
+}
+
+const [updateState, setUpdateState] = createStore<AppUpdateState>({
+  checking: false,
+  update: null,
+});
+
+export { updateState };
+
+export function setAppUpdateForTests(update: AppUpdateInfo | null): void {
+  setUpdateState({ checking: false, update });
+}
+
+interface GithubReleasePayload {
+  tag_name?: unknown;
+  name?: unknown;
+  html_url?: unknown;
+  draft?: unknown;
+  prerelease?: unknown;
+}
+
+function parseVersion(value: string): [number, number, number] | null {
+  const match = value.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/i);
+  if (!match) return null;
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function versionCore(value: string): string {
+  const parsed = parseVersion(value);
+  return parsed ? parsed.join(".") : value.trim().replace(/^v/i, "");
+}
+
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const left = parseVersion(a);
+  const right = parseVersion(b);
+  if (!left || !right) return 0;
+
+  for (let i = 0; i < 3; i += 1) {
+    if (left[i] > right[i]) return 1;
+    if (left[i] < right[i]) return -1;
+  }
+  return 0;
+}
+
+export function normalizeRelease(payload: GithubReleasePayload): NormalizedRelease | null {
+  if (payload.draft === true) return null;
+  if (typeof payload.tag_name !== "string" || payload.tag_name.trim().length === 0) return null;
+  if (typeof payload.html_url !== "string" || payload.html_url.trim().length === 0) return null;
+
+  const version = versionCore(payload.tag_name);
+  if (!parseVersion(version)) return null;
+
+  return {
+    tagName: payload.tag_name,
+    version,
+    name: typeof payload.name === "string" && payload.name.trim() ? payload.name : payload.tag_name,
+    releaseUrl: payload.html_url,
+    prerelease: payload.prerelease === true,
+  };
+}
+
+export function getDismissedUpdateTag(): string | null {
+  try {
+    return localStorage.getItem(DISMISSED_UPDATE_TAG_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function dismissUpdate(tagName: string): void {
+  try {
+    localStorage.setItem(DISMISSED_UPDATE_TAG_KEY, tagName);
+  } catch {
+    // Ignore persistence failures; the modal can still be closed for this session.
+  }
+}
+
+export function shouldDismissUpdatePrompt(result: string): boolean {
+  return result === "later";
+}
+
+export function clearDismissedUpdateForTests(): void {
+  try {
+    localStorage.removeItem(DISMISSED_UPDATE_TAG_KEY);
+  } catch {
+    // Test helper only.
+  }
+}
+
+function errorMessage(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message;
+  if (typeof err === "string") return err;
+  return "Unable to check for updates";
+}
+
+export async function checkForAppUpdate(
+  currentVersion = import.meta.env.VITE_APP_VERSION
+): Promise<AppUpdateInfo> {
+  try {
+    const response = await fetch(LATEST_RELEASE_URL, {
+      headers: {
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    if (!response.ok) {
+      return {
+        available: false,
+        dismissed: false,
+        currentVersion,
+        error: `GitHub release check failed: HTTP ${response.status}`,
+      };
+    }
+
+    const release = normalizeRelease(await response.json());
+    if (!release || compareVersions(release.version, currentVersion) <= 0) {
+      return { available: false, dismissed: false, currentVersion };
+    }
+
+    const dismissed = getDismissedUpdateTag() === release.tagName;
+    return {
+      available: true,
+      dismissed,
+      currentVersion,
+      latestVersion: release.version,
+      tagName: release.tagName,
+      releaseName: release.name,
+      releaseUrl: release.releaseUrl,
+    };
+  } catch (err) {
+    return {
+      available: false,
+      dismissed: false,
+      currentVersion,
+      error: errorMessage(err),
+    };
+  }
+}
+
+export async function refreshAppUpdate(): Promise<AppUpdateInfo> {
+  setUpdateState("checking", true);
+  const update = await checkForAppUpdate();
+  setUpdateState({ checking: false, update });
+  return update;
+}
+
+export async function openUpdateRelease(update: Pick<AppUpdateInfo, "releaseUrl">): Promise<void> {
+  await openUrl(update.releaseUrl ?? RELEASES_PAGE_URL);
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -35,3 +35,8 @@ vi.mock("@tauri-apps/plugin-fs", () => ({}));
 
 // Mock @tauri-apps/plugin-shell
 vi.mock("@tauri-apps/plugin-shell", () => ({}));
+
+// Mock @tauri-apps/plugin-opener
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));


### PR DESCRIPTION
## Summary

- Added a new Keynobi version indicator in the status bar.
- Implemented a modal dialog that checks for updates on startup, allowing users to download the latest version or dismiss the notification.
- Created an AppUpdateStatusIndicator component to display update availability.
- Enhanced update service with functions to manage update checks and dismissals.
- Added unit tests for the update service and AppUpdateStatusIndicator component.

This update improves user experience by keeping users informed about the latest releases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add in-app update notifications with a startup modal and a status bar indicator that links to the latest GitHub release. This keeps users informed and provides a quick path to download new versions.

- New Features
  - Status bar indicator shows when a new Keynobi version is available and opens the release page.
  - Startup check fetches the latest GitHub release and shows a modal with Download or Later; dismissal is remembered per release.
  - Update service handles release fetch, semantic version compare, local dismissal, and opening the release URL.
  - Added unit tests for the update service and status indicator; updated the user manual.

- Dependencies
  - Updated Tauri CSP to allow `https://api.github.com` in `connect-src` for release checks.

<sup>Written for commit dab60acaddb63853ad02bdeb06ab1b7278448328. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

