### PR TITLE
Feat/refact local llm

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -197,6 +197,7 @@ Shows all error-or-above logs from `MyApp` **or** any crash entry from any proce
 
 **Building compound filters:**
 - Click **+ AND** to append `&&` to the active group (makes the AND relationship explicit).
+- Press **Enter** after typing a condition to commit it as a filter pill. If an autocomplete suggestion is highlighted, Enter accepts that suggestion first.
 - Click **+ OR** to start a new OR group with ` | `.
 - You can mix both: `tag:App && level:warn | is:crash | package:mine && age:5m`.
 - The query bar shows an **N OR** badge when multiple OR groups are active.

--- a/src/components/common/LogViewer.test.ts
+++ b/src/components/common/LogViewer.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from "vitest";
 import type { LogEntry, LogLevel } from "@/bindings";
+import { matchesLogViewerFilter, uniqueLogViewerSources } from "./log-viewer-filter";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -18,33 +19,11 @@ function makeEntry(
   return { id, timestamp: new Date().toISOString(), level, source, message };
 }
 
-/** Re-implements the matchesFilter logic from LogViewer so we can test it. */
-function matchesFilter(
-  entry: LogEntry,
-  level: string,
-  source: string,
-  search: string
-): boolean {
-  if (level !== "all" && entry.level !== level) return false;
-  if (source !== "all" && entry.source !== source) return false;
-  if (search && !entry.message.toLowerCase().includes(search.toLowerCase())) return false;
-  return true;
-}
-
-/** Re-implements uniqueSources derivation from LogViewer. */
-function uniqueSources(entries: LogEntry[]): string[] {
-  const seen = new Set<string>();
-  for (const e of entries) {
-    if (e.source) seen.add(e.source);
-  }
-  return Array.from(seen).sort();
-}
-
 // ── uniqueSources ─────────────────────────────────────────────────────────────
 
 describe("uniqueSources", () => {
   it("returns empty array when no entries", () => {
-    expect(uniqueSources([])).toEqual([]);
+    expect(uniqueLogViewerSources([])).toEqual([]);
   });
 
   it("returns sorted unique sources", () => {
@@ -54,15 +33,12 @@ describe("uniqueSources", () => {
       makeEntry(3, "lsp:server"),
       makeEntry(4, "lsp:progress"),
     ];
-    expect(uniqueSources(entries)).toEqual(["lsp:navigate", "lsp:progress", "lsp:server"]);
+    expect(uniqueLogViewerSources(entries)).toEqual(["lsp:navigate", "lsp:progress", "lsp:server"]);
   });
 
   it("ignores entries with empty source", () => {
-    const entries = [
-      makeEntry(1, "lsp:server"),
-      { ...makeEntry(2, ""), source: "" },
-    ];
-    expect(uniqueSources(entries)).toEqual(["lsp:server"]);
+    const entries = [makeEntry(1, "lsp:server"), { ...makeEntry(2, ""), source: "" }];
+    expect(uniqueLogViewerSources(entries)).toEqual(["lsp:server"]);
   });
 
   it("all expected LSP sources are surfaced", () => {
@@ -74,7 +50,7 @@ describe("uniqueSources", () => {
       makeEntry(5, "lsp:progress"),
       makeEntry(6, "lsp:navigate"),
     ];
-    const sources = uniqueSources(entries);
+    const sources = uniqueLogViewerSources(entries);
     expect(sources).toContain("lsp:startup");
     expect(sources).toContain("lsp:server");
     expect(sources).toContain("lsp:stderr");
@@ -91,41 +67,44 @@ describe("matchesFilter (with source)", () => {
   const entry = makeEntry(1, "lsp:navigate", "info", "definition not found");
 
   it("passes with all filters set to all", () => {
-    expect(matchesFilter(entry, "all", "all", "")).toBe(true);
+    expect(matchesLogViewerFilter(entry, "all", "all", "")).toBe(true);
   });
 
   it("passes when source matches", () => {
-    expect(matchesFilter(entry, "all", "lsp:navigate", "")).toBe(true);
+    expect(matchesLogViewerFilter(entry, "all", "lsp:navigate", "")).toBe(true);
   });
 
   it("fails when source does not match", () => {
-    expect(matchesFilter(entry, "all", "lsp:server", "")).toBe(false);
+    expect(matchesLogViewerFilter(entry, "all", "lsp:server", "")).toBe(false);
   });
 
-  it("passes when level matches", () => {
-    expect(matchesFilter(entry, "info", "all", "")).toBe(true);
+  it("passes when level is at or above the selected minimum", () => {
+    expect(matchesLogViewerFilter(entry, "info", "all", "")).toBe(true);
+    expect(matchesLogViewerFilter(makeEntry(2, "build", "error"), "warn", "all", "")).toBe(true);
+    expect(matchesLogViewerFilter(makeEntry(3, "build", "warn"), "info", "all", "")).toBe(true);
   });
 
-  it("fails when level does not match", () => {
-    expect(matchesFilter(entry, "error", "all", "")).toBe(false);
+  it("fails when level is below the selected minimum", () => {
+    expect(matchesLogViewerFilter(entry, "error", "all", "")).toBe(false);
+    expect(matchesLogViewerFilter(makeEntry(2, "build", "trace"), "debug", "all", "")).toBe(false);
   });
 
   it("passes when search matches message", () => {
-    expect(matchesFilter(entry, "all", "all", "definition")).toBe(true);
+    expect(matchesLogViewerFilter(entry, "all", "all", "definition")).toBe(true);
   });
 
   it("fails when search does not match message", () => {
-    expect(matchesFilter(entry, "all", "all", "compile error")).toBe(false);
+    expect(matchesLogViewerFilter(entry, "all", "all", "compile error")).toBe(false);
   });
 
   it("search is case-insensitive", () => {
-    expect(matchesFilter(entry, "all", "all", "DEFINITION")).toBe(true);
+    expect(matchesLogViewerFilter(entry, "all", "all", "DEFINITION")).toBe(true);
   });
 
   it("applies all three filters simultaneously", () => {
-    expect(matchesFilter(entry, "info", "lsp:navigate", "not found")).toBe(true);
-    expect(matchesFilter(entry, "info", "lsp:server", "not found")).toBe(false);
-    expect(matchesFilter(entry, "error", "lsp:navigate", "not found")).toBe(false);
-    expect(matchesFilter(entry, "info", "lsp:navigate", "compile")).toBe(false);
+    expect(matchesLogViewerFilter(entry, "info", "lsp:navigate", "not found")).toBe(true);
+    expect(matchesLogViewerFilter(entry, "info", "lsp:server", "not found")).toBe(false);
+    expect(matchesLogViewerFilter(entry, "error", "lsp:navigate", "not found")).toBe(false);
+    expect(matchesLogViewerFilter(entry, "info", "lsp:navigate", "compile")).toBe(false);
   });
 });

--- a/src/components/common/LogViewer.tsx
+++ b/src/components/common/LogViewer.tsx
@@ -1,17 +1,19 @@
-import {
-  type JSX,
-  For,
-  Show,
-  createMemo,
-  createSignal,
-} from "solid-js";
+import { type JSX, Show, createMemo, createSignal, onCleanup } from "solid-js";
 import { VirtualList } from "@/components/ui";
+import { copyToClipboard } from "@/utils/clipboard";
+import { debounce } from "@/utils/debounce";
 import { formatBuildLogToolbarCount } from "./log-viewer-toolbar-count";
-import type { LogEntry, LogLevel } from "@/bindings";
+import { formatLogViewerEntry } from "./log-viewer-format";
+import { LogViewerRow } from "./LogViewerRow";
+import { LogViewerToolbar } from "./LogViewerToolbar";
+import {
+  matchesLogViewerFilter,
+  uniqueLogViewerSources,
+  type LogViewerLevelFilter,
+} from "./log-viewer-filter";
+import type { LogEntry } from "@/bindings";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-
-type LevelFilter = "all" | LogLevel;
 
 export interface LogViewerProps {
   /** Reactive array of log entries (from a log store). */
@@ -26,178 +28,55 @@ export interface LogViewerProps {
   defaultAutoScroll?: boolean;
 }
 
-// ── Level metadata ─────────────────────────────────────────────────────────────
-
-interface LevelMeta {
-  label: string;
-  color: string;
-  badgeBg: string;
-}
-
-const LEVEL_META: Record<LogLevel, LevelMeta> = {
-  error: { label: "ERR",   color: "var(--error)",          badgeBg: "rgba(241,76,76,0.15)"  },
-  warn:  { label: "WARN",  color: "var(--warning)",        badgeBg: "rgba(204,167,0,0.15)"  },
-  info:  { label: "INFO",  color: "var(--info)",           badgeBg: "rgba(117,190,255,0.12)"},
-  debug: { label: "DBG",   color: "var(--text-secondary)", badgeBg: "rgba(255,255,255,0.06)"},
-  trace: { label: "TRC",   color: "var(--text-disabled)",  badgeBg: "rgba(255,255,255,0.03)"},
-};
-
-const LEVEL_FILTERS: { id: LevelFilter; label: string; color?: string }[] = [
-  { id: "all",   label: "ALL" },
-  { id: "error", label: "ERR",  color: "var(--error)"          },
-  { id: "warn",  label: "WARN", color: "var(--warning)"        },
-  { id: "info",  label: "INFO", color: "var(--info)"           },
-  { id: "debug", label: "DBG",  color: "var(--text-secondary)" },
-];
-
-// ── Helpers ────────────────────────────────────────────────────────────────────
-
-function formatTime(iso: string): string {
-  try {
-    const d = new Date(iso);
-    const hh = String(d.getHours()).padStart(2, "0");
-    const mm = String(d.getMinutes()).padStart(2, "0");
-    const ss = String(d.getSeconds()).padStart(2, "0");
-    const ms = String(d.getMilliseconds()).padStart(3, "0");
-    return `${hh}:${mm}:${ss}.${ms}`;
-  } catch {
-    return iso;
-  }
-}
-
-function matchesFilter(entry: LogEntry, level: LevelFilter, source: string, search: string): boolean {
-  if (level !== "all" && entry.level !== level) return false;
-  if (source !== "all" && entry.source !== source) return false;
-  if (search && !entry.message.toLowerCase().includes(search)) return false;
-  return true;
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    // Fallback: create a temporary textarea
-    const el = document.createElement("textarea");
-    el.value = text;
-    document.body.appendChild(el);
-    el.select();
-    document.execCommand("copy");
-    document.body.removeChild(el);
-  }
-}
-
-// ── Sub-components ─────────────────────────────────────────────────────────────
-
-function ToolbarButton(props: {
-  title: string;
-  active?: boolean;
-  activeColor?: string;
-  onClick: () => void;
-  children: JSX.Element;
-}): JSX.Element {
-  return (
-    <button
-      title={props.title}
-      onClick={() => props.onClick()}
-      style={{
-        display: "flex",
-        "align-items": "center",
-        "justify-content": "center",
-        height: "22px",
-        padding: "0 6px",
-        "border-radius": "3px",
-        border: "none",
-        background: props.active
-          ? (props.activeColor ? `${props.activeColor}22` : "var(--bg-active)")
-          : "transparent",
-        color: props.active
-          ? (props.activeColor ?? "var(--text-primary)")
-          : "var(--text-muted)",
-        cursor: "pointer",
-        "font-size": "11px",
-        "line-height": "1",
-        transition: "background 0.1s, color 0.1s",
-        "flex-shrink": "0",
-      }}
-    >
-      {props.children}
-    </button>
-  );
-}
-
-function LevelBadge(props: { level: LogLevel }): JSX.Element {
-  const meta = () => LEVEL_META[props.level];
-  return (
-    <span
-      style={{
-        display: "inline-flex",
-        "align-items": "center",
-        "font-size": "10px",
-        "font-weight": "600",
-        "letter-spacing": "0.03em",
-        padding: "1px 5px",
-        "border-radius": "3px",
-        background: meta().badgeBg,
-        color: meta().color,
-        "flex-shrink": "0",
-        "min-width": "30px",
-        "justify-content": "center",
-      }}
-    >
-      {meta().label}
-    </span>
-  );
-}
-
 // ── Main component ─────────────────────────────────────────────────────────────
 
 export function LogViewer(props: LogViewerProps): JSX.Element {
   const showSource = () => props.showSource ?? true;
 
   // UI state
-  const [levelFilter, setLevelFilter] = createSignal<LevelFilter>("all");
+  const [levelFilter, setLevelFilter] = createSignal<LogViewerLevelFilter>("all");
   const [sourceFilter, setSourceFilter] = createSignal<string>("all");
-  const [search, setSearch] = createSignal("");
+  const [rawSearch, setRawSearch] = createSignal("");
+  const [debouncedSearch, setDebouncedSearch] = createSignal("");
   const [showTimestamps, setShowTimestamps] = createSignal(true);
   const [autoScroll, setAutoScroll] = createSignal(props.defaultAutoScroll !== false);
   const [copiedAll, setCopiedAll] = createSignal(false);
 
+  const updateDebouncedSearch = debounce((q: string) => setDebouncedSearch(q), 150);
+  let copyTimeout: ReturnType<typeof setTimeout> | undefined;
+
   // Derive unique sorted sources from the current entries.
-  const uniqueSources = createMemo(() => {
-    const seen = new Set<string>();
-    for (const e of props.entries) {
-      if (e.source) seen.add(e.source);
-    }
-    return Array.from(seen).sort();
+  const uniqueSources = createMemo(() => uniqueLogViewerSources(props.entries));
+
+  onCleanup(() => {
+    updateDebouncedSearch.cancel();
+    clearTimeout(copyTimeout);
   });
 
   // Filtered view
   const filtered = createMemo(() => {
-    const q = search().toLowerCase();
+    const q = debouncedSearch().toLowerCase();
     const lf = levelFilter();
     const sf = sourceFilter();
-    return props.entries.filter((e) => matchesFilter(e, lf, sf, q));
+    return props.entries.filter((e) => matchesLogViewerFilter(e, lf, sf, q));
   });
 
   async function handleCopyAll(): Promise<void> {
     const text = filtered()
-      .map((e) => {
-        const parts: string[] = [];
-        if (showTimestamps()) parts.push(formatTime(e.timestamp));
-        parts.push(`[${e.level.toUpperCase()}]`);
-        if (showSource()) parts.push(`[${e.source}]`);
-        parts.push(e.message);
-        return parts.join(" ");
-      })
+      .map((e) =>
+        formatLogViewerEntry(e, { showTimestamp: showTimestamps(), showSource: showSource() })
+      )
       .join("\n");
     await copyToClipboard(text);
     setCopiedAll(true);
-    setTimeout(() => setCopiedAll(false), 1500);
+    clearTimeout(copyTimeout);
+    copyTimeout = setTimeout(() => setCopiedAll(false), 1500);
   }
 
   const totalCount = () => props.entries.length;
   const filteredCount = () => filtered().length;
-  const isFiltered = () => levelFilter() !== "all" || sourceFilter() !== "all" || search() !== "";
+  const isFiltered = () =>
+    levelFilter() !== "all" || sourceFilter() !== "all" || debouncedSearch() !== "";
   const buildLogToolbarCount = createMemo(() =>
     formatBuildLogToolbarCount({
       filterActive: isFiltered(),
@@ -205,6 +84,19 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
       total: totalCount(),
     })
   );
+
+  function handleSearchInput(q: string): void {
+    setRawSearch(q);
+    updateDebouncedSearch(q);
+  }
+
+  function handleClear(): void {
+    props.onClear?.();
+    updateDebouncedSearch.cancel();
+    setSourceFilter("all");
+    setRawSearch("");
+    setDebouncedSearch("");
+  }
 
   return (
     <div
@@ -218,170 +110,25 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
         background: "var(--bg-secondary)",
       }}
     >
-      {/* ── Toolbar ── */}
-      <div
-        style={{
-          display: "flex",
-          "align-items": "center",
-          gap: "4px",
-          padding: "4px 8px",
-          background: "var(--bg-tertiary)",
-          "border-bottom": "1px solid var(--border)",
-          "flex-shrink": "0",
-          "flex-wrap": "nowrap",
-          overflow: "hidden",
-        }}
-      >
-        {/* Level filter pills */}
-        <div style={{ display: "flex", gap: "2px", "flex-shrink": "0" }}>
-          <For each={LEVEL_FILTERS}>
-            {(f) => (
-              <ToolbarButton
-                title={`Show ${f.label === "ALL" ? "all levels" : f.label + " and above"}`}
-                active={levelFilter() === f.id}
-                activeColor={f.color}
-                onClick={() => setLevelFilter(f.id)}
-              >
-                {f.label}
-              </ToolbarButton>
-            )}
-          </For>
-        </div>
-
-        {/* Divider */}
-        <div
-          style={{
-            width: "1px",
-            height: "16px",
-            background: "var(--border)",
-            "flex-shrink": "0",
-            margin: "0 2px",
-          }}
-        />
-
-        {/* Source filter — dropdown appears once there are 2+ distinct sources */}
-        <Show when={uniqueSources().length > 1}>
-          <select
-            value={sourceFilter()}
-            onChange={(e) => setSourceFilter(e.currentTarget.value)}
-            title="Filter by log source"
-            style={{
-              height: "22px",
-              padding: "0 4px",
-              background: "var(--bg-quaternary)",
-              border: `1px solid ${sourceFilter() !== "all" ? "var(--accent)" : "var(--border)"}`,
-              "border-radius": "3px",
-              color: sourceFilter() !== "all" ? "var(--accent)" : "var(--text-muted)",
-              "font-family": "var(--font-ui)",
-              "font-size": "11px",
-              cursor: "pointer",
-              "flex-shrink": "0",
-              outline: "none",
-            }}
-          >
-            <option value="all" style={{ background: "var(--bg-secondary)", color: "var(--text-primary)" }}>
-              All sources
-            </option>
-            <For each={uniqueSources()}>
-              {(src) => (
-                <option value={src} style={{ background: "var(--bg-secondary)", color: "var(--text-primary)" }}>
-                  {src}
-                </option>
-              )}
-            </For>
-          </select>
-          {/* Divider after source filter */}
-          <div
-            style={{
-              width: "1px",
-              height: "16px",
-              background: "var(--border)",
-              "flex-shrink": "0",
-              margin: "0 2px",
-            }}
-          />
-        </Show>
-
-        {/* Search box */}
-        <input
-          type="text"
-          placeholder="Filter logs…"
-          value={search()}
-          onInput={(e) => setSearch(e.currentTarget.value)}
-          style={{
-            flex: "1",
-            "min-width": "80px",
-            "max-width": "200px",
-            height: "22px",
-            padding: "0 8px",
-            background: "var(--bg-quaternary)",
-            border: "1px solid var(--border)",
-            "border-radius": "3px",
-            color: "var(--text-primary)",
-            "font-family": "var(--font-ui)",
-            "font-size": "11px",
-            outline: "none",
-          }}
-        />
-
-        {/* Entry count — labeled visible vs total in panel */}
-        <span
-          title={buildLogToolbarCount().title}
-          style={{
-            "font-family": "var(--font-ui)",
-            "font-size": "11px",
-            color: "var(--text-muted)",
-            "white-space": "nowrap",
-            "flex-shrink": "0",
-            "cursor": "default",
-          }}
-        >
-          {buildLogToolbarCount().text}
-        </span>
-
-        {/* Spacer */}
-        <div style={{ flex: "1" }} />
-
-        {/* Timestamp toggle */}
-        <ToolbarButton
-          title={showTimestamps() ? "Hide timestamps" : "Show timestamps"}
-          active={showTimestamps()}
-          onClick={() => setShowTimestamps((v) => !v)}
-        >
-          TS
-        </ToolbarButton>
-
-        {/* Auto-scroll toggle */}
-        <ToolbarButton
-          title={autoScroll() ? "Auto-scroll on (click to pause)" : "Auto-scroll paused (click to resume)"}
-          active={autoScroll()}
-          activeColor="var(--accent)"
-          onClick={() => setAutoScroll((v) => !v)}
-        >
-          ↓
-        </ToolbarButton>
-
-        {/* Copy all */}
-        <ToolbarButton
-          title="Copy visible logs to clipboard"
-          onClick={handleCopyAll}
-        >
-          {copiedAll() ? "✓" : "⎘"}
-        </ToolbarButton>
-
-        {/* Clear */}
-        <Show when={props.onClear}>
-          <ToolbarButton
-            title="Clear all logs"
-            onClick={() => {
-              props.onClear?.();
-              setSourceFilter("all");
-            }}
-          >
-            ⊘
-          </ToolbarButton>
-        </Show>
-      </div>
+      <LogViewerToolbar
+        levelFilter={levelFilter()}
+        onLevelFilterChange={setLevelFilter}
+        sourceFilter={sourceFilter()}
+        onSourceFilterChange={setSourceFilter}
+        sources={uniqueSources()}
+        rawSearch={rawSearch()}
+        onRawSearchChange={handleSearchInput}
+        countText={buildLogToolbarCount().text}
+        countTitle={buildLogToolbarCount().title}
+        showTimestamps={showTimestamps()}
+        onToggleTimestamps={() => setShowTimestamps((v) => !v)}
+        autoScroll={autoScroll()}
+        onToggleAutoScroll={() => setAutoScroll((v) => !v)}
+        copiedAll={copiedAll()}
+        onCopyAll={handleCopyAll}
+        canClear={props.onClear !== undefined}
+        onClear={handleClear}
+      />
 
       {/* ── Log list ── */}
       <div style={{ flex: "1", overflow: "hidden" }}>
@@ -413,7 +160,7 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
             onScrolledUp={() => setAutoScroll(false)}
             onScrolledToBottom={() => setAutoScroll(true)}
             renderRow={(entry, index) => (
-              <LogRow
+              <LogViewerRow
                 entry={entry}
                 index={index}
                 showTimestamp={showTimestamps()}
@@ -424,107 +171,6 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
           />
         </Show>
       </div>
-    </div>
-  );
-}
-
-// ── Log row ────────────────────────────────────────────────────────────────────
-
-interface LogRowProps {
-  entry: LogEntry;
-  index: number;
-  showTimestamp: boolean;
-  showSource: boolean;
-}
-
-function LogRow(props: LogRowProps): JSX.Element {
-  const meta = () => LEVEL_META[props.entry.level];
-  const isEven = () => props.index % 2 === 0;
-
-  async function handleClick(): Promise<void> {
-    await copyToClipboard(props.entry.message);
-  }
-
-  return (
-    <div
-      title="Click to copy message"
-      onClick={handleClick}
-      style={{
-        display: "flex",
-        "align-items": "center",
-        gap: "6px",
-        padding: "0 8px",
-        height: "20px",
-        overflow: "hidden",
-        background: isEven() ? "transparent" : "rgba(255,255,255,0.018)",
-        cursor: "pointer",
-        "border-left": `2px solid ${
-          props.entry.level === "error"
-            ? "var(--error)"
-            : props.entry.level === "warn"
-            ? "var(--warning)"
-            : "transparent"
-        }`,
-        transition: "background 0.05s",
-      }}
-      onMouseEnter={(e) => {
-        (e.currentTarget as HTMLDivElement).style.background = "var(--bg-hover)";
-      }}
-      onMouseLeave={(e) => {
-        (e.currentTarget as HTMLDivElement).style.background = isEven()
-          ? "transparent"
-          : "rgba(255,255,255,0.018)";
-      }}
-    >
-      {/* Timestamp */}
-      <Show when={props.showTimestamp}>
-        <span
-          style={{
-            color: "var(--text-disabled)",
-            "flex-shrink": "0",
-            "user-select": "none",
-            "font-size": "11px",
-          }}
-        >
-          {formatTime(props.entry.timestamp)}
-        </span>
-      </Show>
-
-      {/* Level badge */}
-      <LevelBadge level={props.entry.level} />
-
-      {/* Source chip */}
-      <Show when={props.showSource && props.entry.source}>
-        <span
-          style={{
-            color: "var(--text-muted)",
-            "flex-shrink": "0",
-            "font-size": "10px",
-            "max-width": "120px",
-            overflow: "hidden",
-            "text-overflow": "ellipsis",
-            "white-space": "nowrap",
-          }}
-        >
-          {props.entry.source}
-        </span>
-      </Show>
-
-      {/* Message */}
-      <span
-        style={{
-          color: meta().color,
-          overflow: "hidden",
-          "text-overflow": "ellipsis",
-          "white-space": "nowrap",
-          flex: "1",
-          "min-width": "0",
-          "line-height": "20px",
-        }}
-        title={props.entry.message}
-      >
-        {props.entry.message}
-      </span>
     </div>
   );
 }

--- a/src/components/common/LogViewerRow.tsx
+++ b/src/components/common/LogViewerRow.tsx
@@ -1,0 +1,133 @@
+import { type JSX, Show } from "solid-js";
+import { copyToClipboard } from "@/utils/clipboard";
+import type { LogEntry, LogLevel } from "@/bindings";
+import { formatLogViewerTime } from "./log-viewer-format";
+
+interface LevelMeta {
+  label: string;
+  color: string;
+  badgeBg: string;
+}
+
+const LEVEL_META: Record<LogLevel, LevelMeta> = {
+  error: { label: "ERR", color: "var(--error)", badgeBg: "rgba(241,76,76,0.15)" },
+  warn: { label: "WARN", color: "var(--warning)", badgeBg: "rgba(204,167,0,0.15)" },
+  info: { label: "INFO", color: "var(--info)", badgeBg: "rgba(117,190,255,0.12)" },
+  debug: { label: "DBG", color: "var(--text-secondary)", badgeBg: "rgba(255,255,255,0.06)" },
+  trace: { label: "TRC", color: "var(--text-disabled)", badgeBg: "rgba(255,255,255,0.03)" },
+};
+
+function LevelBadge(props: { level: LogLevel }): JSX.Element {
+  const meta = () => LEVEL_META[props.level];
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        "align-items": "center",
+        "font-size": "10px",
+        "font-weight": "600",
+        "letter-spacing": "0.03em",
+        padding: "1px 5px",
+        "border-radius": "3px",
+        background: meta().badgeBg,
+        color: meta().color,
+        "flex-shrink": "0",
+        "min-width": "30px",
+        "justify-content": "center",
+      }}
+    >
+      {meta().label}
+    </span>
+  );
+}
+
+export function LogViewerRow(props: {
+  entry: LogEntry;
+  index: number;
+  showTimestamp: boolean;
+  showSource: boolean;
+}): JSX.Element {
+  const meta = () => LEVEL_META[props.entry.level];
+  const isEven = () => props.index % 2 === 0;
+
+  async function handleClick(): Promise<void> {
+    await copyToClipboard(props.entry.message);
+  }
+
+  return (
+    <div
+      title="Click to copy message"
+      onClick={handleClick}
+      style={{
+        display: "flex",
+        "align-items": "center",
+        gap: "6px",
+        padding: "0 8px",
+        height: "20px",
+        overflow: "hidden",
+        background: isEven() ? "transparent" : "rgba(255,255,255,0.018)",
+        cursor: "pointer",
+        "border-left": `2px solid ${
+          props.entry.level === "error"
+            ? "var(--error)"
+            : props.entry.level === "warn"
+              ? "var(--warning)"
+              : "transparent"
+        }`,
+        transition: "background 0.05s",
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.background = "var(--bg-hover)";
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.background = isEven() ? "transparent" : "rgba(255,255,255,0.018)";
+      }}
+    >
+      <Show when={props.showTimestamp}>
+        <span
+          style={{
+            color: "var(--text-disabled)",
+            "flex-shrink": "0",
+            "user-select": "none",
+            "font-size": "11px",
+          }}
+        >
+          {formatLogViewerTime(props.entry.timestamp)}
+        </span>
+      </Show>
+
+      <LevelBadge level={props.entry.level} />
+
+      <Show when={props.showSource && props.entry.source}>
+        <span
+          style={{
+            color: "var(--text-muted)",
+            "flex-shrink": "0",
+            "font-size": "10px",
+            "max-width": "120px",
+            overflow: "hidden",
+            "text-overflow": "ellipsis",
+            "white-space": "nowrap",
+          }}
+        >
+          {props.entry.source}
+        </span>
+      </Show>
+
+      <span
+        style={{
+          color: meta().color,
+          overflow: "hidden",
+          "text-overflow": "ellipsis",
+          "white-space": "nowrap",
+          flex: "1",
+          "min-width": "0",
+          "line-height": "20px",
+        }}
+        title={props.entry.message}
+      >
+        {props.entry.message}
+      </span>
+    </div>
+  );
+}

--- a/src/components/common/LogViewerToolbar.test.tsx
+++ b/src/components/common/LogViewerToolbar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { LogViewerToolbar, activeToolbarButtonBackground } from "./LogViewerToolbar";
+
+const noop = vi.fn();
+
+function renderToolbar(overrides: Partial<Parameters<typeof LogViewerToolbar>[0]> = {}) {
+  return render(() => (
+    <LogViewerToolbar
+      levelFilter="all"
+      onLevelFilterChange={noop}
+      sourceFilter="all"
+      onSourceFilterChange={noop}
+      sources={[]}
+      rawSearch=""
+      onRawSearchChange={noop}
+      countText="0"
+      countTitle="0 logs"
+      showTimestamps={true}
+      onToggleTimestamps={noop}
+      autoScroll={true}
+      onToggleAutoScroll={noop}
+      copiedAll={false}
+      onCopyAll={noop}
+      canClear={false}
+      onClear={noop}
+      {...overrides}
+    />
+  ));
+}
+
+describe("LogViewerToolbar", () => {
+  it("uses a valid color function for active colored buttons", () => {
+    expect(activeToolbarButtonBackground(true, "var(--error)")).toBe(
+      "color-mix(in srgb, var(--error) 14%, transparent)"
+    );
+  });
+
+  it("keeps the source selector visible while a source filter is active", () => {
+    renderToolbar({
+      sourceFilter: "lsp:server",
+      sources: ["lsp:server"],
+    });
+
+    expect(screen.getByTitle("Filter by log source")).not.toBeNull();
+  });
+});

--- a/src/components/common/LogViewerToolbar.tsx
+++ b/src/components/common/LogViewerToolbar.tsx
@@ -48,11 +48,7 @@ function ToolbarButton(props: {
         padding: "0 6px",
         "border-radius": "3px",
         border: "none",
-        background: props.active
-          ? props.activeColor
-            ? `${props.activeColor}22`
-            : "var(--bg-active)"
-          : "transparent",
+        background: activeToolbarButtonBackground(props.active, props.activeColor),
         color: props.active ? (props.activeColor ?? "var(--text-primary)") : "var(--text-muted)",
         cursor: "pointer",
         "font-size": "11px",
@@ -64,6 +60,12 @@ function ToolbarButton(props: {
       {props.children}
     </button>
   );
+}
+
+export function activeToolbarButtonBackground(active?: boolean, activeColor?: string): string {
+  if (!active) return "transparent";
+  if (!activeColor) return "var(--bg-active)";
+  return `color-mix(in srgb, ${activeColor} 14%, transparent)`;
 }
 
 function ToolbarDivider(): JSX.Element {
@@ -112,7 +114,7 @@ export function LogViewerToolbar(props: LogViewerToolbarProps): JSX.Element {
 
       <ToolbarDivider />
 
-      <Show when={props.sources.length > 1}>
+      <Show when={props.sources.length > 1 || props.sourceFilter !== "all"}>
         <select
           value={props.sourceFilter}
           onChange={(e) => props.onSourceFilterChange(e.currentTarget.value)}

--- a/src/components/common/LogViewerToolbar.tsx
+++ b/src/components/common/LogViewerToolbar.tsx
@@ -1,0 +1,223 @@
+import { type JSX, For, Show } from "solid-js";
+import type { LogViewerLevelFilter } from "./log-viewer-filter";
+
+const LEVEL_FILTERS: { id: LogViewerLevelFilter; label: string; color?: string }[] = [
+  { id: "all", label: "ALL" },
+  { id: "error", label: "ERR", color: "var(--error)" },
+  { id: "warn", label: "WARN", color: "var(--warning)" },
+  { id: "info", label: "INFO", color: "var(--info)" },
+  { id: "debug", label: "DBG", color: "var(--text-secondary)" },
+];
+
+interface LogViewerToolbarProps {
+  levelFilter: LogViewerLevelFilter;
+  onLevelFilterChange: (level: LogViewerLevelFilter) => void;
+  sourceFilter: string;
+  onSourceFilterChange: (source: string) => void;
+  sources: string[];
+  rawSearch: string;
+  onRawSearchChange: (search: string) => void;
+  countText: string;
+  countTitle: string;
+  showTimestamps: boolean;
+  onToggleTimestamps: () => void;
+  autoScroll: boolean;
+  onToggleAutoScroll: () => void;
+  copiedAll: boolean;
+  onCopyAll: () => void | Promise<void>;
+  canClear: boolean;
+  onClear: () => void;
+}
+
+function ToolbarButton(props: {
+  title: string;
+  active?: boolean;
+  activeColor?: string;
+  onClick: () => void | Promise<void>;
+  children: JSX.Element;
+}): JSX.Element {
+  return (
+    <button
+      title={props.title}
+      onClick={() => void props.onClick()}
+      style={{
+        display: "flex",
+        "align-items": "center",
+        "justify-content": "center",
+        height: "22px",
+        padding: "0 6px",
+        "border-radius": "3px",
+        border: "none",
+        background: props.active
+          ? props.activeColor
+            ? `${props.activeColor}22`
+            : "var(--bg-active)"
+          : "transparent",
+        color: props.active ? (props.activeColor ?? "var(--text-primary)") : "var(--text-muted)",
+        cursor: "pointer",
+        "font-size": "11px",
+        "line-height": "1",
+        transition: "background 0.1s, color 0.1s",
+        "flex-shrink": "0",
+      }}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+function ToolbarDivider(): JSX.Element {
+  return (
+    <div
+      style={{
+        width: "1px",
+        height: "16px",
+        background: "var(--border)",
+        "flex-shrink": "0",
+        margin: "0 2px",
+      }}
+    />
+  );
+}
+
+export function LogViewerToolbar(props: LogViewerToolbarProps): JSX.Element {
+  return (
+    <div
+      style={{
+        display: "flex",
+        "align-items": "center",
+        gap: "4px",
+        padding: "4px 8px",
+        background: "var(--bg-tertiary)",
+        "border-bottom": "1px solid var(--border)",
+        "flex-shrink": "0",
+        "flex-wrap": "nowrap",
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ display: "flex", gap: "2px", "flex-shrink": "0" }}>
+        <For each={LEVEL_FILTERS}>
+          {(filter) => (
+            <ToolbarButton
+              title={`Show ${filter.label === "ALL" ? "all levels" : filter.label + " and above"}`}
+              active={props.levelFilter === filter.id}
+              activeColor={filter.color}
+              onClick={() => props.onLevelFilterChange(filter.id)}
+            >
+              {filter.label}
+            </ToolbarButton>
+          )}
+        </For>
+      </div>
+
+      <ToolbarDivider />
+
+      <Show when={props.sources.length > 1}>
+        <select
+          value={props.sourceFilter}
+          onChange={(e) => props.onSourceFilterChange(e.currentTarget.value)}
+          title="Filter by log source"
+          style={{
+            height: "22px",
+            padding: "0 4px",
+            background: "var(--bg-quaternary)",
+            border: `1px solid ${props.sourceFilter !== "all" ? "var(--accent)" : "var(--border)"}`,
+            "border-radius": "3px",
+            color: props.sourceFilter !== "all" ? "var(--accent)" : "var(--text-muted)",
+            "font-family": "var(--font-ui)",
+            "font-size": "11px",
+            cursor: "pointer",
+            "flex-shrink": "0",
+            outline: "none",
+          }}
+        >
+          <option
+            value="all"
+            style={{ background: "var(--bg-secondary)", color: "var(--text-primary)" }}
+          >
+            All sources
+          </option>
+          <For each={props.sources}>
+            {(source) => (
+              <option
+                value={source}
+                style={{ background: "var(--bg-secondary)", color: "var(--text-primary)" }}
+              >
+                {source}
+              </option>
+            )}
+          </For>
+        </select>
+        <ToolbarDivider />
+      </Show>
+
+      <input
+        type="text"
+        placeholder="Filter logs…"
+        value={props.rawSearch}
+        onInput={(e) => props.onRawSearchChange(e.currentTarget.value)}
+        style={{
+          flex: "1",
+          "min-width": "80px",
+          "max-width": "200px",
+          height: "22px",
+          padding: "0 8px",
+          background: "var(--bg-quaternary)",
+          border: "1px solid var(--border)",
+          "border-radius": "3px",
+          color: "var(--text-primary)",
+          "font-family": "var(--font-ui)",
+          "font-size": "11px",
+          outline: "none",
+        }}
+      />
+
+      <span
+        title={props.countTitle}
+        style={{
+          "font-family": "var(--font-ui)",
+          "font-size": "11px",
+          color: "var(--text-muted)",
+          "white-space": "nowrap",
+          "flex-shrink": "0",
+          cursor: "default",
+        }}
+      >
+        {props.countText}
+      </span>
+
+      <div style={{ flex: "1" }} />
+
+      <ToolbarButton
+        title={props.showTimestamps ? "Hide timestamps" : "Show timestamps"}
+        active={props.showTimestamps}
+        onClick={props.onToggleTimestamps}
+      >
+        TS
+      </ToolbarButton>
+
+      <ToolbarButton
+        title={
+          props.autoScroll
+            ? "Auto-scroll on (click to pause)"
+            : "Auto-scroll paused (click to resume)"
+        }
+        active={props.autoScroll}
+        activeColor="var(--accent)"
+        onClick={props.onToggleAutoScroll}
+      >
+        ↓
+      </ToolbarButton>
+
+      <ToolbarButton title="Copy visible logs to clipboard" onClick={props.onCopyAll}>
+        {props.copiedAll ? "✓" : "⎘"}
+      </ToolbarButton>
+
+      <Show when={props.canClear}>
+        <ToolbarButton title="Clear all logs" onClick={props.onClear}>
+          ⊘
+        </ToolbarButton>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/common/log-viewer-filter.ts
+++ b/src/components/common/log-viewer-filter.ts
@@ -1,0 +1,31 @@
+import type { LogEntry, LogLevel } from "@/bindings";
+
+export type LogViewerLevelFilter = "all" | LogLevel;
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};
+
+export function uniqueLogViewerSources(entries: LogEntry[]): string[] {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (entry.source) seen.add(entry.source);
+  }
+  return Array.from(seen).sort();
+}
+
+export function matchesLogViewerFilter(
+  entry: LogEntry,
+  level: LogViewerLevelFilter,
+  source: string,
+  search: string
+): boolean {
+  if (level !== "all" && LEVEL_RANK[entry.level] < LEVEL_RANK[level]) return false;
+  if (source !== "all" && entry.source !== source) return false;
+  if (search && !entry.message.toLowerCase().includes(search.toLowerCase())) return false;
+  return true;
+}

--- a/src/components/common/log-viewer-format.test.ts
+++ b/src/components/common/log-viewer-format.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { formatLogViewerEntry, formatLogViewerTime } from "./log-viewer-format";
+import type { LogEntry } from "@/bindings";
+
+function makeEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    id: 1,
+    timestamp: "2026-04-25T12:34:56.789Z",
+    level: "warn",
+    source: "build",
+    message: "compile warning",
+    ...overrides,
+  };
+}
+
+describe("log viewer formatting", () => {
+  it("formats timestamps as local time with milliseconds", () => {
+    const timestamp = new Date(2026, 3, 25, 12, 34, 56, 789).toISOString();
+
+    expect(formatLogViewerTime(timestamp)).toBe("12:34:56.789");
+  });
+
+  it("formats copied rows with optional timestamp and source", () => {
+    expect(formatLogViewerEntry(makeEntry(), { showTimestamp: false, showSource: true })).toBe(
+      "[WARN] [build] compile warning"
+    );
+    expect(formatLogViewerEntry(makeEntry(), { showTimestamp: false, showSource: false })).toBe(
+      "[WARN] compile warning"
+    );
+  });
+});

--- a/src/components/common/log-viewer-format.test.ts
+++ b/src/components/common/log-viewer-format.test.ts
@@ -20,6 +20,10 @@ describe("log viewer formatting", () => {
     expect(formatLogViewerTime(timestamp)).toBe("12:34:56.789");
   });
 
+  it("returns the original timestamp when the date is invalid", () => {
+    expect(formatLogViewerTime("not-a-date")).toBe("not-a-date");
+  });
+
   it("formats copied rows with optional timestamp and source", () => {
     expect(formatLogViewerEntry(makeEntry(), { showTimestamp: false, showSource: true })).toBe(
       "[WARN] [build] compile warning"

--- a/src/components/common/log-viewer-format.ts
+++ b/src/components/common/log-viewer-format.ts
@@ -3,6 +3,7 @@ import type { LogEntry } from "@/bindings";
 export function formatLogViewerTime(iso: string): string {
   try {
     const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
     const hh = String(d.getHours()).padStart(2, "0");
     const mm = String(d.getMinutes()).padStart(2, "0");
     const ss = String(d.getSeconds()).padStart(2, "0");

--- a/src/components/common/log-viewer-format.ts
+++ b/src/components/common/log-viewer-format.ts
@@ -1,0 +1,26 @@
+import type { LogEntry } from "@/bindings";
+
+export function formatLogViewerTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mm = String(d.getMinutes()).padStart(2, "0");
+    const ss = String(d.getSeconds()).padStart(2, "0");
+    const ms = String(d.getMilliseconds()).padStart(3, "0");
+    return `${hh}:${mm}:${ss}.${ms}`;
+  } catch {
+    return iso;
+  }
+}
+
+export function formatLogViewerEntry(
+  entry: LogEntry,
+  options: { showTimestamp: boolean; showSource: boolean }
+): string {
+  const parts: string[] = [];
+  if (options.showTimestamp) parts.push(formatLogViewerTime(entry.timestamp));
+  parts.push(`[${entry.level.toUpperCase()}]`);
+  if (options.showSource) parts.push(`[${entry.source}]`);
+  parts.push(entry.message);
+  return parts.join(" ");
+}

--- a/src/components/logcat/QueryBar.test.ts
+++ b/src/components/logcat/QueryBar.test.ts
@@ -15,13 +15,72 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { parseQueryState, buildQuery } from "./QueryBar";
+import { fireEvent, render } from "@solidjs/testing-library";
+import { QueryBar, parseQueryState, buildQuery } from "./QueryBar";
 import {
   rebuildCommittedAfterRemovingPill,
   quoteMessageTokenForEditDraft,
   setPackageInQuery,
   setAgeInQuery,
 } from "@/lib/logcat-query";
+
+// ── QueryBar keyboard behavior ───────────────────────────────────────────────
+
+describe("QueryBar — Enter keyboard commit", () => {
+  it("commits the typed draft as a pill when no autocomplete suggestion is selected", () => {
+    const changes: string[] = [];
+    const { container } = render(() =>
+      QueryBar({
+        value: "tag:OkHttp",
+        onChange: (q) => changes.push(q),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(changes[changes.length - 1]).toBe("tag:OkHttp ");
+  });
+
+  it("balances a multi-word message draft and commits it as one pill", () => {
+    const changes: string[] = [];
+    const { container } = render(() =>
+      QueryBar({
+        value: 'message:"hello world',
+        onChange: (q) => changes.push(q),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(changes[changes.length - 1]).toBe('message:"hello world" ');
+  });
+
+  it("keeps Enter accepting the selected autocomplete suggestion", () => {
+    const changes: string[] = [];
+    const { container } = render(() =>
+      QueryBar({
+        value: "tag:Ok",
+        onChange: (q) => changes.push(q),
+        knownTags: ["OkHttp"],
+        knownPackages: [],
+      })
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(changes[changes.length - 1]).toBe("tag:OkHttp ");
+  });
+});
 
 // ── parseQueryState — trailing-space convention ───────────────────────────────
 

--- a/src/components/logcat/QueryBar.tsx
+++ b/src/components/logcat/QueryBar.tsx
@@ -22,7 +22,7 @@
  *   Tab / Enter                — apply selected suggestion
  */
 
-import { type JSX, createSignal, createMemo, For, Show } from "solid-js";
+import { type JSX, createSignal, createMemo, For, Show, untrack } from "solid-js";
 import {
   QUERY_KEYS,
   LEVEL_NAMES,
@@ -453,7 +453,9 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
 
   function handleInlineBlur() {
     queueMicrotask(() => {
-      if (inlineEdit()) commitInlineEdit();
+      untrack(() => {
+        if (inlineEdit()) commitInlineEdit();
+      });
     });
   }
 

--- a/src/components/logcat/QueryBar.tsx
+++ b/src/components/logcat/QueryBar.tsx
@@ -39,6 +39,7 @@ import {
   serializeQueryBarCommittedPart,
   insertPillAtGroupPosition,
   applyInlineEditCommit,
+  commitQueryBarDraft,
 } from "@/lib/logcat-query";
 
 // ── Props ─────────────────────────────────────────────────────────────────────
@@ -365,6 +366,18 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
         props.onChange("");
       }
       return;
+    }
+
+    if (e.key === "Enter" && draft().trim() !== "") {
+      const selectedSuggestion = open() ? suggs[selectedIdx()] : undefined;
+      if (!selectedSuggestion) {
+        e.preventDefault();
+        const next = commitQueryBarDraft(committed(), draft());
+        props.onChange(buildQuery(next, ""));
+        setOpen(false);
+        setSelectedIdx(0);
+        return;
+      }
     }
 
     if (!open() || suggs.length === 0) {

--- a/src/components/ui-hierarchy/LayoutViewerPanel.tsx
+++ b/src/components/ui-hierarchy/LayoutViewerPanel.tsx
@@ -1,12 +1,4 @@
-import {
-  type JSX,
-  For,
-  Show,
-  createEffect,
-  createMemo,
-  createSignal,
-  onCleanup,
-} from "solid-js";
+import { type JSX, For, Show, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 import type { UiNode } from "@/bindings";
 import { Icon } from "@/components/ui";
 import {
@@ -44,6 +36,7 @@ import {
 import { selectedDevice } from "@/stores/device.store";
 import { LayoutWireframe } from "@/components/ui-hierarchy/LayoutWireframe";
 import { layoutDetailGetNode } from "@/components/ui-hierarchy/layout-detail-get-node";
+import { copyToClipboard } from "@/utils/clipboard";
 
 function displayRoot(): UiNode | null {
   const snap = layoutViewerState.snapshot;
@@ -63,14 +56,6 @@ function displayRoot(): UiNode | null {
     return f;
   }
   return r;
-}
-
-async function copyToClipboard(text: string): Promise<void> {
-  try {
-    await navigator.clipboard.writeText(text);
-  } catch {
-    // ignore
-  }
 }
 
 function HierarchyTree(props: {
@@ -290,8 +275,8 @@ function HierarchyTree(props: {
       </div>
       <Show when={hasChildren() && open()}>
         <div role="group">
-        <For each={props.node.children}>
-          {(child, i) => (
+          <For each={props.node.children}>
+            {(child, i) => (
               <HierarchyTree
                 node={child}
                 path={props.path === "" ? String(i()) : `${props.path}.${i()}`}
@@ -303,8 +288,8 @@ function HierarchyTree(props: {
                 isOpen={props.isOpen}
                 toggle={props.toggle}
               />
-          )}
-        </For>
+            )}
+          </For>
         </div>
       </Show>
     </div>
@@ -505,9 +490,7 @@ function NodeDetailPanel(props: {
           type="button"
           style={{
             ...miniBtnStyle,
-            ...(parentPath() === null
-              ? { opacity: 0.45, cursor: "not-allowed" as const }
-              : {}),
+            ...(parentPath() === null ? { opacity: 0.45, cursor: "not-allowed" as const } : {}),
           }}
           disabled={parentPath() === null}
           title={
@@ -530,8 +513,8 @@ function NodeDetailPanel(props: {
         </button>
       </div>
       <p style={{ margin: 0, color: "var(--text-muted)", "font-size": "10px" }}>
-        Scrollable and other flags can be wrong in dumps (e.g. HorizontalScrollView sometimes reports
-        scrollable=false). Treat as hints, not ground truth.
+        Scrollable and other flags can be wrong in dumps (e.g. HorizontalScrollView sometimes
+        reports scrollable=false). Treat as hints, not ground truth.
       </p>
     </div>
   );
@@ -582,7 +565,11 @@ export function LayoutViewerPanel(): JSX.Element {
   const toggle = (path: string, depth: number): void => {
     const g = globalExpand();
     const cur =
-      g === "all" ? true : g === "none" ? false : pathOverrides()[path] ?? depth < expandBasis().depth;
+      g === "all"
+        ? true
+        : g === "none"
+          ? false
+          : (pathOverrides()[path] ?? depth < expandBasis().depth);
     setGlobalExpand("auto");
     setPathOverrides((prev) => ({ ...prev, [path]: !cur }));
   };
@@ -781,7 +768,9 @@ export function LayoutViewerPanel(): JSX.Element {
           <button type="button" style={toolbarBtnStyle} onClick={() => goSearchMatch(-1)}>
             Prev
           </button>
-          <span style={{ "font-size": "11px", color: "var(--text-muted)" }}>{searchMatchLabel()}</span>
+          <span style={{ "font-size": "11px", color: "var(--text-muted)" }}>
+            {searchMatchLabel()}
+          </span>
           <button type="button" style={toolbarBtnStyle} onClick={() => goSearchMatch(1)}>
             Next
           </button>
@@ -794,7 +783,11 @@ export function LayoutViewerPanel(): JSX.Element {
         </button>
         <select
           title="Auto-refresh interval"
-          value={layoutViewerState.autoRefreshIntervalMs === null ? "off" : String(layoutViewerState.autoRefreshIntervalMs)}
+          value={
+            layoutViewerState.autoRefreshIntervalMs === null
+              ? "off"
+              : String(layoutViewerState.autoRefreshIntervalMs)
+          }
           onChange={(e) => {
             const v = e.currentTarget.value;
             setAutoRefreshInterval(v === "off" ? null : Number(v));
@@ -803,7 +796,10 @@ export function LayoutViewerPanel(): JSX.Element {
             padding: "4px 6px",
             "font-size": "12px",
             background: "var(--bg-secondary)",
-            color: layoutViewerState.autoRefreshIntervalMs !== null ? "var(--accent)" : "var(--text-muted)",
+            color:
+              layoutViewerState.autoRefreshIntervalMs !== null
+                ? "var(--accent)"
+                : "var(--text-muted)",
             border: "1px solid var(--border)",
             "border-radius": "4px",
             cursor: "pointer",
@@ -825,15 +821,21 @@ export function LayoutViewerPanel(): JSX.Element {
           "flex-shrink": "0",
         }}
       >
-        <Show when={selectedDevice()} fallback={<span>No device selected — use the Devices sidebar.</span>}>
+        <Show
+          when={selectedDevice()}
+          fallback={<span>No device selected — use the Devices sidebar.</span>}
+        >
           {(d) => (
             <span>
-              Device: <span style={{ color: "var(--text-primary)" }}>{d().name}</span> ({d().serial})
+              Device: <span style={{ color: "var(--text-primary)" }}>{d().name}</span> ({d().serial}
+              )
               <Show when={dominantPkg()}>
                 {(pkgName) => (
                   <span style={{ "margin-left": "10px" }}>
                     Package:{" "}
-                    <span style={{ color: "var(--text-primary)", "font-family": "var(--font-mono)" }}>
+                    <span
+                      style={{ color: "var(--text-primary)", "font-family": "var(--font-mono)" }}
+                    >
                       {pkgName()}
                     </span>{" "}
                     <span style={{ opacity: 0.8 }}>(omitted on rows when unchanged)</span>
@@ -891,14 +893,14 @@ export function LayoutViewerPanel(): JSX.Element {
                     when={layoutViewerState.snapshot}
                     fallback={
                       <p style={{ margin: 0 }}>
-                        Press <strong>Refresh</strong> to capture the focused window hierarchy from the
-                        device (native Views and Jetpack Compose via accessibility).
+                        Press <strong>Refresh</strong> to capture the focused window hierarchy from
+                        the device (native Views and Jetpack Compose via accessibility).
                       </p>
                     }
                   >
                     <p style={{ margin: "0 0 8px 0" }}>
-                      No nodes match the current filter — try turning off filters, clear the search box, or
-                      refresh after navigating on the device.
+                      No nodes match the current filter — try turning off filters, clear the search
+                      box, or refresh after navigating on the device.
                     </p>
                   </Show>
                   <p style={{ margin: "8px 0 0 0", "font-size": "11px" }}>
@@ -938,21 +940,22 @@ export function LayoutViewerPanel(): JSX.Element {
                           "margin-bottom": "8px",
                         }}
                       >
-                        Snapshot was truncated (size or node limits). Check warnings in metadata below.
+                        Snapshot was truncated (size or node limits). Check warnings in metadata
+                        below.
                       </div>
                     </Show>
                     <div role="tree" aria-label="UI hierarchy tree">
-                    <HierarchyTree
-                      node={r}
-                      path=""
-                      depth={0}
-                      dominantPackage={dominantPkg()}
-                      interactiveOnly={layoutViewerState.interactiveOnly}
-                      selectedPath={layoutViewerState.selectedLayoutPath}
-                      onSelectPath={(p) => setLayoutSelectedPath(p)}
-                      isOpen={isOpen}
-                      toggle={toggle}
-                    />
+                      <HierarchyTree
+                        node={r}
+                        path=""
+                        depth={0}
+                        dominantPackage={dominantPkg()}
+                        interactiveOnly={layoutViewerState.interactiveOnly}
+                        selectedPath={layoutViewerState.selectedLayoutPath}
+                        onSelectPath={(p) => setLayoutSelectedPath(p)}
+                        isOpen={isOpen}
+                        toggle={toggle}
+                      />
                     </div>
                     <Show when={(layoutViewerState.snapshot?.warnings.length ?? 0) > 0}>
                       <div
@@ -983,7 +986,9 @@ export function LayoutViewerPanel(): JSX.Element {
                       <div>Interactive nodes: {layoutViewerState.snapshot?.interactiveCount}</div>
                       <Show when={layoutViewerState.snapshot?.foregroundActivity}>
                         {(fa) => (
-                          <div style={{ "margin-top": "4px", "word-break": "break-all" }}>{fa()}</div>
+                          <div style={{ "margin-top": "4px", "word-break": "break-all" }}>
+                            {fa()}
+                          </div>
                         )}
                       </Show>
                     </div>

--- a/src/components/ui/Alert/Alert.tsx
+++ b/src/components/ui/Alert/Alert.tsx
@@ -33,7 +33,7 @@ export function Alert(props: AlertProps): JSX.Element {
           type="button"
           class={styles.closeBtn}
           aria-label="Dismiss"
-          onClick={props.onDismiss}
+          onClick={() => props.onDismiss?.()}
         >
           ×
         </button>

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -27,7 +27,7 @@ export function Button(props: ButtonProps): JSX.Element {
         props.class ?? "",
       ].join(" ")}
       disabled={props.disabled || props.loading}
-      onClick={props.onClick}
+      onClick={(e) => props.onClick?.(e)}
     >
       <Show when={props.loading}>
         <Spinner size="sm" />

--- a/src/components/ui/FormField/FormField.tsx
+++ b/src/components/ui/FormField/FormField.tsx
@@ -12,13 +12,18 @@ export interface FormFieldProps {
 }
 
 export function FormField(props: FormFieldProps): JSX.Element {
-  const fieldId = props.id ?? createUniqueId();
+  const fallbackId = createUniqueId();
+  const fieldId = () => props.id ?? fallbackId;
   return (
     <div class={[styles.root, props.class].filter(Boolean).join(" ")}>
       <div class={styles.header}>
-        <label for={fieldId} class={styles.label}>{props.label}</label>
+        <label for={fieldId()} class={styles.label}>
+          {props.label}
+        </label>
         <Show when={props.required}>
-          <span class={styles.required} aria-hidden="true">*</span>
+          <span class={styles.required} aria-hidden="true">
+            *
+          </span>
         </Show>
       </div>
       <Show when={props.description}>
@@ -26,7 +31,9 @@ export function FormField(props: FormFieldProps): JSX.Element {
       </Show>
       {props.children}
       <Show when={props.error}>
-        <div class={styles.error} role="alert">{props.error}</div>
+        <div class={styles.error} role="alert">
+          {props.error}
+        </div>
       </Show>
     </div>
   );

--- a/src/components/ui/IconButton/IconButton.tsx
+++ b/src/components/ui/IconButton/IconButton.tsx
@@ -26,7 +26,7 @@ export function IconButton(props: IconButtonProps): JSX.Element {
       ]
         .filter(Boolean)
         .join(" ")}
-      onClick={props.onClick}
+      onClick={() => props.onClick()}
     >
       {props.children}
     </button>

--- a/src/components/ui/Input/Input.tsx
+++ b/src/components/ui/Input/Input.tsx
@@ -30,7 +30,9 @@ export function Input(props: InputProps): JSX.Element {
         isError() ? styles.error : "",
         isDisabled() ? styles.disabled : "",
         props.class,
-      ].filter(Boolean).join(" ")}
+      ]
+        .filter(Boolean)
+        .join(" ")}
     >
       <Show when={props.prefix}>
         <div class={styles.prefix}>{props.prefix}</div>
@@ -52,7 +54,7 @@ export function Input(props: InputProps): JSX.Element {
         <button
           type="button"
           class={styles.clearBtn}
-          onClick={props.onClear}
+          onClick={() => props.onClear?.()}
           aria-label="Clear"
         >
           ×

--- a/src/lib/logcat-query.test.ts
+++ b/src/lib/logcat-query.test.ts
@@ -29,6 +29,7 @@ import {
   quoteMessageTokenForEditDraft,
   serializeQueryBarCommittedPart,
   splitRawQueryParts,
+  commitQueryBarDraft,
   setMinePackage,
   isStackTraceLine,
   parseStackFrame,
@@ -683,6 +684,35 @@ describe("pasteIntoMessageKeyDraft", () => {
       newDraft: 'message~:"a b"',
       cursor: 14,
     });
+  });
+});
+
+describe("commitQueryBarDraft", () => {
+  it("appends a plain draft token to committed pills", () => {
+    expect(commitQueryBarDraft(["level:error"], "tag:OkHttp")).toEqual([
+      "level:error",
+      "tag:OkHttp",
+    ]);
+  });
+
+  it("commits a message draft with spaces as one token", () => {
+    expect(commitQueryBarDraft([], 'message:"hello world"')).toEqual(["message:hello world"]);
+  });
+
+  it("balances an unclosed message quote before committing", () => {
+    expect(commitQueryBarDraft([], 'message:"hello world')).toEqual(["message:hello world"]);
+  });
+
+  it("splits multi-token draft input with quote-aware parsing", () => {
+    expect(commitQueryBarDraft(["package:mine"], 'level:error message:"socket timeout"')).toEqual([
+      "package:mine",
+      "level:error",
+      "message:socket timeout",
+    ]);
+  });
+
+  it("leaves committed pills unchanged for an empty draft", () => {
+    expect(commitQueryBarDraft(["level:error"], "   ")).toEqual(["level:error"]);
   });
 });
 

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -691,6 +691,23 @@ export function pasteIntoMessageKeyDraft(
   return { newDraft, cursor: prefix.length + wrapped.length };
 }
 
+/**
+ * Commit the current QueryBar draft into the committed pill array.
+ *
+ * Enter uses this when it is not accepting an autocomplete suggestion. Message
+ * drafts are quote-balanced first so `message:"hello world` becomes one pill
+ * instead of remaining an unterminated draft.
+ */
+export function commitQueryBarDraft(committed: string[], draft: string): string[] {
+  const balanced = balanceMessageDraftQuotes(draft.trim());
+  if (!balanced) return committed;
+
+  const pieces = splitRawQueryParts(balanced);
+  if (pieces.length === 0) return committed;
+
+  return [...committed, ...pieces];
+}
+
 function normalizeGroupParenTokens(group: string[]): string[] {
   if (group.length === 0) return group;
   const result = [...group];

--- a/src/utils/clipboard.test.ts
+++ b/src/utils/clipboard.test.ts
@@ -4,6 +4,7 @@ import { copyToClipboard } from "./clipboard";
 describe("copyToClipboard", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("uses navigator clipboard when available", async () => {
@@ -27,6 +28,18 @@ describe("copyToClipboard", () => {
     await copyToClipboard("fallback");
 
     expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("throws when the fallback copy command fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: vi.fn().mockReturnValue(false),
+    });
+
+    await expect(copyToClipboard("fallback")).rejects.toThrow("Failed to copy to clipboard");
     expect(document.querySelector("textarea")).toBeNull();
   });
 });

--- a/src/utils/clipboard.test.ts
+++ b/src/utils/clipboard.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "./clipboard";
+
+describe("copyToClipboard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses navigator clipboard when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await copyToClipboard("hello");
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to a temporary textarea when navigator clipboard fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    const execCommand = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+
+    await copyToClipboard("fallback");
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,12 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const el = document.createElement("textarea");
+    el.value = text;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand("copy");
+    document.body.removeChild(el);
+  }
+}

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -5,8 +5,15 @@ export async function copyToClipboard(text: string): Promise<void> {
     const el = document.createElement("textarea");
     el.value = text;
     document.body.appendChild(el);
-    el.select();
-    document.execCommand("copy");
-    document.body.removeChild(el);
+    try {
+      el.select();
+      if (!document.execCommand("copy")) {
+        throw new Error("Failed to copy to clipboard");
+      }
+    } catch {
+      throw new Error("Failed to copy to clipboard");
+    } finally {
+      document.body.removeChild(el);
+    }
   }
 }

--- a/src/utils/debounce.test.ts
+++ b/src/utils/debounce.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { debounce } from "./debounce";
+
+describe("debounce", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("cancels a pending invocation", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const debounced = debounce(fn, 150);
+
+    debounced("stale");
+    debounced.cancel();
+    vi.advanceTimersByTime(150);
+
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,31 @@
+export type Debounced<TArgs extends unknown[]> = ((...args: TArgs) => void) & {
+  cancel: () => void;
+};
+
+/**
+ * Debounce a function so it only fires after `ms` of inactivity.
+ */
+export function debounce<TArgs extends unknown[]>(
+  fn: (...args: TArgs) => void,
+  ms: number
+): Debounced<TArgs> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const cancel = () => {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+  };
+
+  const debounced = ((...args: TArgs) => {
+    cancel();
+    timeout = setTimeout(() => {
+      timeout = undefined;
+      fn(...args);
+    }, ms);
+  }) as Debounced<TArgs>;
+
+  debounced.cancel = cancel;
+  return debounced;
+}


### PR DESCRIPTION
## Summary

was testing the Gemma 4, running it locally for a refactor. It was reviewed later by GTP 5.5.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Log Viewer into smaller components and added UX improvements: debounced search, consistent copy formatting, and minimum-level filtering. The Query Bar now commits the typed draft as a pill on Enter, and the docs reflect this.

- New Features
  - Log Viewer: debounced search; copy visible logs with unified format (optional timestamp/source); level filter shows “and above” levels.
  - Query Bar: Enter commits the current draft when no suggestion is selected; balances message quotes; added tests and updated the user manual.

- Bug Fixes
  - Timestamp formatter now guards invalid dates.
  - Clipboard: reliable copy with a tested fallback and surfaced errors.
  - Toolbar/UI: consistent active styles; source selector stays visible while filtered; cleaned up optional handlers and IDs.

<sup>Written for commit b95896520c88052cbe44eec03e1d1d21e391b228. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

