### PR TITLE
Feat/refact logcat

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,5 +12,5 @@
 - [ ] `cd src-tauri && cargo test --lib --tests` and `cargo clippy -- -D warnings` (and telemetry matrix if you touched Rust: `cargo clippy --features telemetry -- -D warnings`, `cargo test --lib --tests --features telemetry`)
 - [ ] If Rust models / `ts-rs` exports changed: `npm run generate:bindings` and committed `src/bindings/`
 - [ ] User-visible behavior or shortcuts: updated [docs/USER_MANUAL.md](../docs/USER_MANUAL.md)
-- [ ] New cross-cutting patterns: noted for maintainers in [CONTRIBUTING.md](../CONTRIBUTING.md) / [AGENTS.md](../AGENTS.md) session rules (`docs/CODE_PATTERN.md`, `docs/DOMAIN_PATTERN.md`, or `docs/BEST_PRACTICES.md` as appropriate)
+- [ ] New cross-cutting patterns: noted for maintainers in [CONTRIBUTING.md](../CONTRIBUTING.md) / [AGENTS.md](../AGENTS.md) session rules (`docs/CODE_PATTERN.md`, `docs/DOMAIN_PATTERNS.md`, or `docs/BEST_PRACTICES.md` as appropriate)
 - [ ] UI change: screenshot(s) attached (if helpful for reviewers)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 ## Before You Write Code
 
 1. Read `docs/BEST_PRACTICES.md` — architectural principles, security rules, performance targets, and the AI-first design philosophy.
-2. Read `docs/CODE_PATTERN.md` and `docs/DOMAIN_PATTERN.md` — concrete conventions: file naming, store patterns, IPC patterns, testing patterns.
+2. Read `docs/CODE_PATTERN.md` and `docs/DOMAIN_PATTERNS.md` — concrete conventions: file naming, store patterns, IPC patterns, testing patterns.
 3. Read `docs/USER_MANUAL.md` — understand what the user sees and does, so new features integrate naturally.
 
 ## Key Rules
@@ -77,7 +77,7 @@ npm run generate:bindings
 
 At the end of every development session:
 
-- Update `docs/CODE_PATTERN.md` and `docs/DOMAIN_PATTERN.md` when a new code pattern is established.
+- Update `docs/CODE_PATTERN.md` and `docs/DOMAIN_PATTERNS.md` when a new code pattern is established.
 - Update `docs/BEST_PRACTICES.md` if foundational architecture or principles change.
 - Update `docs/USER_MANUAL.md` when new user-visible features or keyboard shortcuts are added.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for helping improve Keynobi. This guide is the entry point; deeper rul
 1. [AGENTS.md](AGENTS.md) — stack, IPC checklist, testing commands, how to add a feature end-to-end.
 2. [docs/BEST_PRACTICES.md](docs/BEST_PRACTICES.md) — security, performance, bounded collections, AI-first design.
 3. [docs/CODE_PATTERN.md](docs/CODE_PATTERN.md) — naming, stores, Tauri patterns, path canonicalization, testing gate.
-4. [docs/DOMAIN_PATTERN.md](docs/DOMAIN_PATTERN.md) — build, logcat, device, MCP domain conventions.
+4. [docs/DOMAIN_PATTERNS.md](docs/DOMAIN_PATTERNS.md) — build, logcat, device, MCP domain conventions.
 5. [docs/USER_MANUAL.md](docs/USER_MANUAL.md) — what users see; update this when behavior or shortcuts change.
 
 **Security:** Do not open public issues for vulnerabilities. See [SECURITY.md](SECURITY.md).
@@ -67,7 +67,7 @@ Large UI surfaces (for example `src/components/logcat/LogcatPanel.tsx`) are hard
 
 ## Session completion (maintainers & regular contributors)
 
-When you establish a new pattern or ship user-visible behavior, align with [AGENTS.md](AGENTS.md) § Session Completion: update `docs/CODE_PATTERN.md`, `docs/DOMAIN_PATTERN.md`, or `docs/BEST_PRACTICES.md` when patterns change, and `docs/USER_MANUAL.md` when users need new docs.
+When you establish a new pattern or ship user-visible behavior, align with [AGENTS.md](AGENTS.md) § Session Completion: update `docs/CODE_PATTERN.md`, `docs/DOMAIN_PATTERNS.md`, or `docs/BEST_PRACTICES.md` when patterns change, and `docs/USER_MANUAL.md` when users need new docs.
 
 ## Questions
 

--- a/docs/BEST_PRACTICES.md
+++ b/docs/BEST_PRACTICES.md
@@ -1,283 +1,158 @@
 # Best Practices
 
-This is a living document covering architectural principles, design decisions, and industry-standard practices for Keynobi. It explains **why** we do things, while `CODE_PATTERN.md` explains **how**.
+Foundational engineering rules for Keynobi. This document explains the project-level principles that should rarely change. `CODE_PATTERN.md` covers concrete implementation patterns; `DOMAIN_PATTERNS.md` covers build, device, logcat, layout, and MCP details.
 
-Update this document when foundational architecture or design decisions change.
-
----
-
-## Table of Contents
-
-1. [Core Principles](#core-principles)
-2. [Security](#security)
-3. [Performance](#performance)
-4. [Modularity & Maintainability](#modularity--maintainability)
-5. [Testing](#testing)
-6. [Developer Experience](#developer-experience)
-7. [Error Handling](#error-handling)
-8. [Observability](#observability)
-9. [AI-First Design](#ai-first-design)
+Update this file only when a broad architecture, security, reliability, or product principle changes.
 
 ---
 
 ## Core Principles
 
-### 1. Correctness Before Optimization
+### Correctness Before Optimization
 
-Write correct code first. Measure, then optimize. Every optimization in this codebase that is not trivially obvious must have a benchmark proving it is necessary. The performance targets (< 500ms build variant discovery, < 2s device list refresh) exist to define "correct enough," not to encourage premature micro-optimization.
+Write correct, observable behavior first. Optimize only after measurement shows a real bottleneck or a project target is at risk.
 
-### 2. Explicit Over Implicit
+Current performance targets:
 
-Every non-obvious behavior must be explicit in code. If a function has a side effect, name it that way (`registerKeyAndAction`, not `register`). If a mutex must be dropped before an I/O call, add a comment explaining the invariant. Clever code that works silently is a maintenance hazard.
+| Operation | Target |
+|-----------|--------|
+| Build variant discovery | < 500ms |
+| Device list refresh | < 2s |
+| ADB install feedback appears | < 1s after command |
+| Logcat rendering | Smooth at 1000 lines/sec |
+| Command palette open | < 50ms |
 
-### 3. Fail Fast, Fail Visibly
+### Single Source of Truth
 
-Security violations and path traversal attempts must fail immediately with a clear error message. Unknown failures must surface to the user via toast notifications or the status bar.
+- Rust models are the source of truth for IPC types; TypeScript bindings are generated.
+- Backend state is authoritative for project roots, devices, build state, and settings.
+- Stores are frontend projections of backend or UI state.
+- The action registry is the source of truth for command-palette actions.
 
-### 4. Single Source of Truth
+Do not duplicate authoritative state. Derive it or fetch it from the owner.
 
-For any piece of data, there is exactly one authoritative source:
-- Rust models are the source of truth for IPC types (TypeScript bindings are generated from them)
-- The Tauri `FsState` is the authoritative backend source for the open project root; `project.store.ts` is its reactive frontend projection populated via IPC
-- The `action-registry.ts` is the source of truth for all discoverable app actions
+### Explicit Over Clever
 
-When something needs to be known in two places, derive it from the source — don't duplicate it.
+Make side effects obvious in names and structure. Keep invariants visible when the code cannot express them, especially around locks, process lifecycle, path validation, and event listeners.
+
+### Fail Visibly
+
+Security violations fail immediately with clear errors. User-actionable failures appear in the UI through toast, status, or panel state. Background failures the user cannot act on are logged with `tracing`.
 
 ---
 
 ## Security
 
-### Path Traversal Prevention
+### Path Boundaries
 
-Every path that enters the system from the frontend is untrusted. Before any file operation, validate the path is inside the open project directory using canonicalization:
+Every path from the frontend, MCP, or an external tool is untrusted. Validate paths against the effective project root before filesystem access.
 
-1. `canonicalize()` the project root (resolves symlinks, removes `..`)
-2. `canonicalize()` the target path (same)
-3. Check `target.starts_with(root)`
+The effective root is `gradle_root` when available, otherwise `project_root`. Use canonical paths so `..` and symlinks cannot escape the sandbox. Never use raw string prefix checks for security.
 
-Never skip step 1 and 2 and use raw string prefix matching — symlinks and `..` components bypass it.
+### Least Privilege
 
-### Principle of Least Privilege
+Tauri capabilities and IPC commands should expose only what the app needs. Prefer narrow commands and typed results over broad filesystem or shell access.
 
-Tauri capabilities are scoped to what is actually needed. The frontend receives only what the Rust layer explicitly chooses to send via IPC.
+### Secrets
 
-### No Secrets in Frontend
-
-API keys, tokens, and credentials must never be stored in the frontend. They must live in Rust and be passed to external services server-side. The frontend knows only that an operation succeeded or failed.
+Do not store API keys, tokens, credentials, or private project data in frontend state, logs, telemetry, fixtures, or docs. Sensitive operations belong in Rust or trusted external tools.
 
 ---
 
 ## Performance
 
-### Measure, Then Target
+### Keep Work Off the UI Thread
 
-The performance targets for this project:
+Anything that can block the frontend for more than one frame belongs in Rust, a worker-like async flow, or a virtualized/batched UI path. CPU-heavy Rust work should use `tokio::task::spawn_blocking` instead of blocking the async executor.
 
-| Operation | Target |
-|-----------|--------|
-| Build variant discovery | < 500ms |
-| Device list refresh | < 2 seconds |
-| ADB install feedback appears | < 1 second after command |
-| Logcat 60fps with 1000 lines/sec | smooth rendering |
-| Command palette open | < 50ms |
+### Bound Growing Data
 
-Run `npm run perf:collect` after changes to track regression against these targets.
+Every long-lived in-memory collection must have an explicit cap. Examples include logcat entries, build logs, build history, recent projects, MCP activity, process maps, autocomplete candidates, and navigation history.
 
-### Keep the Main Thread Free
+### Stream Incremental Results
 
-The UI runs on the frontend's single JavaScript thread. Any operation that could block for > 16ms must be moved to Rust via IPC, and any CPU-heavy Rust work must be on a `tokio::task::spawn_blocking` thread, not the async executor.
-
-### Bound All Collections
-
-Every in-memory collection that grows over time must have an explicit cap. Examples:
-- Logcat ring buffer: 50K entries (drop oldest on overflow)
-- Build history: last 10 builds
-- Recent projects list: 20 entries
-- Build log: bounded `VecDeque`
-- MCP activity log: bounded entry list
-- Process manager: bounded process map
-
-Unbounded growth is a memory leak on a long-lived app process.
+Build output, logcat, device state, MCP activity, and long-running inspections should stream or batch incremental updates. Avoid large all-at-once payloads when partial results are useful.
 
 ### Hold Locks Briefly
 
-Never hold a Mutex across an `await` or I/O call. Lock, clone what you need, drop, then proceed. See `CODE_PATTERN.md` §Mutex Lock Discipline for the concrete pattern.
-
-### SolidJS Reactivity Efficiency
-
-- Use `createMemo` for derived values used in multiple places — prevents redundant recomputation on each render.
-- Do not destructure reactive stores — destructuring breaks fine-grained tracking and causes over-rendering.
-- Use `produce` from `solid-js/store` for mutations involving array splices or nested object deletion.
+Lock, clone or update the minimal state, then release before I/O, process work, event emission, or `await`. Never hold a Mutex across an `await`.
 
 ---
 
-## Modularity & Maintainability
+## Architecture
 
-### Layered Architecture
+### Layering
+
+Use the normal flow unless there is a documented exception:
 
 ```
-Frontend UI components
-    ↓ reads from
-SolidJS Stores (reactive state)
-    ↓ populated by
-Services (async flows, combine IPC + store updates)
-    ↓ calls
-lib/tauri-api.ts (typed IPC wrappers)
-    ↓ invokes
-Rust Commands (thin validation + delegation)
-    ↓ delegates to
-Rust Services (business logic, no Tauri dependency)
+Frontend components
+  -> stores / frontend services
+  -> src/lib/tauri-api.ts
+  -> Tauri commands
+  -> Rust services
 ```
 
-No layer skips another. Components do not call `invoke` directly. Commands do not contain business logic. Services do not import Tauri types (they receive plain Rust types).
+Components do not call `invoke` directly. Commands validate and delegate. Rust services contain business logic and avoid Tauri dependencies.
 
-### Domain-Driven Module Organization
+### Domain Ownership
 
-Code is organized by domain (`editor`, `search`, `lsp`, `filetree`, `symbols`), not by type (`controllers`, `views`, `models`). A new feature adds files to its domain folder; it does not scatter changes across multiple type-based folders.
+Organize by product domain, not generic technical buckets. Keep build, device, logcat, layout, MCP, settings, and project behavior near their domain-specific stores, services, components, commands, models, and tests.
 
-### Dependency Direction
+### AI-First Interfaces
 
-Dependencies flow downward (UI → stores → services → IPC → Rust). If a lower layer needs to communicate upward, it uses events (Tauri emit/listen) or callbacks — never a direct import of a higher-level module.
-
-### Small, Focused Functions
-
-Functions do one thing. If a function has multiple responsibilities, split it. The `registerKeyAndAction` helper is correct — it registers one thing (a keyboard-triggered action) in two systems, not two different things.
-
-### Comments Explain Why, Not What
-
-Code explains what it does. Comments explain why — non-obvious invariants, constraints, or design decisions that the code cannot express.
-
-```rust
-// Mutex is held only for the clone — never during the actual I/O operation.
-// Holding the lock across an await would serialize unrelated commands.
-let root = { let fs = fs_state.0.lock().await; fs.project_root.clone() }?;
-```
+Prefer structured data over raw text for anything an AI or automation client may consume. MCP responses should be compact, typed, bounded, and directly actionable.
 
 ---
 
 ## Testing
 
-### Test Behavior, Not Implementation
+Prioritize tests in this order:
 
-Tests assert on observable behavior (what the function returns, what state it sets), not internal implementation details. If a refactor that preserves behavior breaks a test, the test is wrong.
+1. Security boundaries: path validation, command input validation, shell/tool argument validation.
+2. Backend services: build parsing, device parsing, logcat pipeline, UI hierarchy parsing, MCP tool behavior.
+3. Frontend stores and services: state transitions, async ordering, cancellation, persistence.
+4. Pure utilities: query parsing, formatting, filtering, matching.
+5. UI rendering for shared components and high-risk flows.
 
-### Test Coverage Priorities
+Tests must isolate state, avoid ordering assumptions, and use typed factories for IPC-shaped data.
 
-Cover in this order:
-1. **Security-critical paths**: path validation, zip extraction, content-length cap — these must have tests proving attacks fail
-2. **Business logic in services**: tree-sitter symbol extraction, search engine, LSP client framing
-3. **Store actions**: state transitions, edge cases (close active tab, dirty tab handling)
-4. **Utilities**: fuzzy matching, navigation history, keybindings
-
-UI component rendering tests have lower priority and higher maintenance cost. Prefer testing store logic and services.
-
-### Test Isolation
-
-Each test must set up its own state and clean up after itself. Stores have reset helpers (e.g. `resetBuildState`, `resetDeviceState`, `resetVariantState`). Rust tests use `tempfile::TempDir` for filesystem fixtures. Tests must not rely on the order they run.
-
-### Regression Benchmarks
-
-Performance benchmarks in `src-tauri/benches/` must run in CI. A PR that causes a > 2x regression in any benchmark must justify it or revert the change. Use `npm run perf:report` to compare against the previous captured baseline.
-
----
-
-## Developer Experience
-
-### Keybindings = Actions
-
-Every keyboard shortcut must be registered with `registerKeyAndAction()` so it appears in the command palette (`Cmd+Shift+P`). A shortcut that cannot be discovered via the command palette effectively does not exist for most users.
-
-### Clear Error Messages
-
-Error messages must tell the user what happened and, when possible, what to do about it. Prefer:
-- "Failed to save 'MainActivity.kt': Disk full" over "Write error"
-- "Path is outside the project directory" over "Access denied"
-- "Kotlin LSP is not installed. Download it now?" over "LSP unavailable"
-
-### Optimistic UI
-
-For fast operations (tab switch, file tree expand), update the UI immediately and handle errors after. For slow operations (file save, LSP start), show a progress indicator rather than blocking the interface.
-
-### Non-Blocking Intelligence
-
-Code intelligence (LSP) must not block the editor. If the LSP is starting or unavailable, the editor still works with syntax highlighting and Tree-sitter symbols. LSP features activate progressively as they become available.
-
-### Unsaved Work Protection
-
-Never silently discard user work. The close-tab flow, the close-app flow, and the open-new-project flow all check for unsaved files and prompt with Save / Discard / Cancel before proceeding. There is no scenario where a user's edits disappear without a confirmation.
+Benchmarks live under `src-tauri/benches/` and can be run with `cargo bench`. CI does not currently run Criterion benchmarks; use `npm run perf:collect` / `npm run perf:report` when performance-sensitive code changes.
 
 ---
 
 ## Error Handling
 
-### Error Propagation Strategy
+### Rust
 
-| Layer | Error type | Propagation |
-|-------|-----------|-------------|
-| Rust services | `FsError` / domain-specific | Return `Result<T, E>` |
-| Rust commands | `String` | `.map_err(\|e\| e.to_string())` at the boundary |
-| TypeScript services | `unknown` (from `invoke`) | Caught with `try/catch`, shown via `showToast` |
-| TypeScript stores | Result/error state fields | Stores hold error state (e.g. `buildState.errors`); they do not throw or propagate |
+- Services return typed errors where practical.
+- Commands convert errors to `String` at the IPC boundary.
+- Production Rust must not use `unwrap()`.
+- `expect()` is allowed only for programmer-error invariants with a useful message.
 
-### Error Visibility
+### TypeScript
 
-- Errors that require user action: `showToast("...", "error")` (visible, auto-dismisses)
-- Errors that indicate degraded state: update relevant store (`setLspStatus("error", message)`) + toast
-- Errors the user cannot act on (e.g., file watcher missed event): `tracing::warn!` only
-
-### Never Panic in Production
-
-`unwrap()` is banned in production Rust code. `expect("reason")` is acceptable only when:
-1. The condition is statically guaranteed to be safe (e.g., `Regex::new` on a literal pattern inside a `LazyLock` static)
-2. Or failure truly means a programmer error (e.g., grammar loading on startup fails — the binary is broken)
+- Frontend services catch IPC failures and update UI state or toast.
+- Stores hold error state; they should not throw during normal UI flows.
+- Async listeners and timers must be cleaned up.
 
 ---
 
 ## Observability
 
-### Structured Logging
+Use `tracing` in Rust. Do not use `println!` / `eprintln!` for application logging.
 
-All logging uses `tracing` macros. Log levels are:
-- `error!`: requires investigation; the feature is broken
-- `warn!`: degraded behavior, the system can continue
-- `info!`: milestone events (startup, project open, LSP ready)
-- `debug!`: developer diagnostics (all LSP JSON-RPC traffic, file events)
+Log level guidance:
 
-Enable debug logging via `RUST_LOG=keynobi_lib=debug cargo tauri dev`.
+- `error!`: feature failed or needs investigation.
+- `warn!`: degraded behavior, app can continue.
+- `info!`: lifecycle milestones.
+- `debug!`: developer diagnostics.
 
-### Performance Metrics
+GUI logging reads `KEYNOBI_LOG`:
 
-The `scripts/collect-metrics.mjs` script captures frontend bundle sizes, Rust binary size, and Criterion benchmark results into `perf-metrics/metrics_latest.json`. Commit these snapshots to track trends over time.
-
-### LSP Traffic Debugging
-
-All LSP JSON-RPC messages are logged at `debug` level via `tracing`:
-```
-RUST_LOG=keynobi_lib::services::lsp_client=debug npm run tauri dev
+```bash
+KEYNOBI_LOG=keynobi_lib=debug npm run tauri dev
 ```
 
----
-
-## AI-First Design
-
-This companion app is built AI-first. Every feature should be designed with AI consumption in mind:
-
-### Structured Data Over Raw Text
-
-Prefer structured types (LSP `Diagnostic`, Tree-sitter `SymbolInfo`) over raw strings. AI agents can parse structured data; they struggle with free-form text.
-
-### Action Registry as Tool Discovery
-
-The central `action-registry.ts` is not just for the command palette — it is the foundation for the MCP server. AI agents discover available app actions from this registry. Every action registered here becomes a tool an AI can invoke.
-
-### Navigation History for Context
-
-Navigation history enables AI agents to understand where the user has been, providing context about what they are working on. Every file-open and go-to-location call should go through `openFileAtLocation()` in `project.service.ts` to maintain the navigation stack.
-
-### Open Project Root as Sandbox
-
-The path security model (all operations validated against the open project root) also serves as the AI safety boundary. AI-driven code generation and editing is automatically sandboxed to the project the user opened.
-
-### Streaming Over Blocking
-
-Any feature that produces results over time (search, build output, logcat, LSP indexing progress) must stream results rather than return them in a batch. AI agents benefit from partial results to reason incrementally.
+Headless MCP logging uses the standard tracing env filter (`RUST_LOG`) and writes to stderr so stdout remains reserved for MCP JSON-RPC.

--- a/docs/CODE_PATTERN.md
+++ b/docs/CODE_PATTERN.md
@@ -1,535 +1,231 @@
 # Code Patterns
 
-This document captures the conventions we follow in this repo. These are foundational rules to keep the codebase modular, maintainable, and consistent. See `BEST_PRACTICES.md` for the *why*; this document explains the *how*.
+Concrete implementation rules for Keynobi. `BEST_PRACTICES.md` explains why these rules exist; `DOMAIN_PATTERNS.md` adds per-domain invariants.
+
+Update this file when a cross-cutting implementation pattern changes.
 
 ---
 
-## Table of Contents
+## Repository Layout
 
-1. [Project Structure](#project-structure)
-2. [Rust Patterns](#rust-patterns)
-3. [Frontend Patterns (SolidJS)](#frontend-patterns-solidjs)
-4. [IPC / Tauri Bridge Patterns](#ipc--tauri-bridge-patterns)
-5. [Testing Patterns](#testing-patterns)
-6. [File Naming Conventions](#file-naming-conventions)
-7. [Build / Device / Logcat / MCP Patterns](#build--device--logcat--mcp-patterns) (see also `DOMAIN_PATTERNS.md`)
-
----
-
-## Project Structure
-
-Detailed layout of the repository (high-level map for contributors). The [README](../README.md) links here instead of duplicating this tree.
-
-```
-keynobi/
-├── src/                                # Frontend — SolidJS + TypeScript
-│   ├── App.tsx                         # Root layout + action/keybinding registry
-│   ├── stores/
-│   │   ├── build.store.ts             # Build state, streaming logs, error list
-│   │   ├── device.store.ts            # Connected devices, AVD state
-│   │   ├── health.store.ts            # App health checks
-│   │   ├── project.store.ts           # Project root, name, Gradle root
-│   │   ├── projects.store.ts          # Multi-project registry
-│   │   ├── settings.store.ts          # App settings
-│   │   ├── ui.store.ts                # Active tab, panel visibility
-│   │   ├── variant.store.ts           # Build variants
-│   │   └── log.store.ts               # Generic log store factory
-│   ├── services/
-│   │   ├── build.service.ts           # Build orchestration
-│   │   └── project.service.ts         # Project open + navigation history
-│   ├── components/
-│   │   ├── build/
-│   │   │   ├── BuildPanel.tsx         # Streaming ANSI log + error list
-│   │   │   └── VariantSelector.tsx    # Build variant dropdown in status bar
-│   │   ├── device/
-│   │   │   └── DevicePanel.tsx        # Devices + AVD management (Create/Delete/Wipe)
-│   │   ├── logcat/
-│   │   │   └── LogcatPanel.tsx        # Real-time logcat, filters, crash detection
-│   │   ├── ui-hierarchy/
-│   │   │   └── LayoutViewerPanel.tsx  # UI Automator / accessibility hierarchy tree
-│   │   ├── health/
-│   │   │   └── HealthPanel.tsx        # Java, SDK, ADB, Gradle, disk checks
-│   │   ├── settings/
-│   │   │   ├── SettingsPanel.tsx
-│   │   │   ├── SettingRow.tsx
-│   │   │   └── ToolStatus.tsx         # SDK/Java path pickers
-│   │   ├── projects/
-│   │   │   ├── ProjectSidebar.tsx     # Project registry, Add Project (Cmd+O)
-│   │   │   ├── WelcomePanel.tsx       # Empty state when no project is open
-│   │   │   └── ProjectInfoEditor.tsx  # versionName / versionCode
-│   │   ├── mcp/
-│   │   │   └── McpPanel.tsx           # MCP setup + activity log (Cmd+Shift+M)
-│   │   ├── layout/
-│   │   │   ├── TitleBar.tsx           # Custom title bar (app + project name)
-│   │   │   └── StatusBar.tsx          # Settings, project, health, build, MCP, variant…
-│   │   └── common/
-│   │       ├── CommandPalette.tsx     # Cmd+Shift+P action palette
-│   │       ├── LogViewer.tsx          # Shared ANSI log renderer
-│   │       ├── VirtualList.tsx        # Virtualized list for large buffers
-│   │       ├── Toast.tsx              # Auto-dismiss notifications
-│   │       ├── Dialog.tsx             # Modal dialogs
-│   │       ├── Resizable.tsx          # Drag-to-resize splitter
-│   │       └── Icon.tsx               # Inline SVG icon library
-│   ├── lib/
-│   │   ├── tauri-api.ts              # Typed wrappers for all Tauri IPC calls
-│   │   ├── keybindings.ts            # Global keyboard shortcut registry
-│   │   ├── action-registry.ts        # Command palette action registry
-│   │   ├── fuzzy-match.ts            # Fuzzy matching utility
-│   │   ├── ansi-strip.ts             # ANSI escape code stripping
-│   │   ├── logcat-query.ts           # Logcat filter query parser
-│   │   └── file-utils.ts             # File type utilities
-│   ├── test/                         # Vitest setup and Tauri API mocks
-│   ├── styles/                       # Global CSS and theme variables
-│   └── bindings/                     # Auto-generated TypeScript types (ts-rs) — DO NOT EDIT
-│
-├── src-tauri/                         # Rust backend — Tauri 2.0
-│   ├── Cargo.toml
-│   ├── tauri.conf.json
-│   ├── capabilities/
-│   │   └── default.json              # Tauri 2.0 security permissions
-│   ├── benches/                      # Criterion benchmarks
-│   └── src/
-│       ├── lib.rs                    # Tauri builder, state, command registration
-│       ├── commands/
-│       │   ├── build.rs              # Gradle task commands
-│       │   ├── device.rs             # ADB / AVD commands
-│       │   ├── file_system.rs        # Project open, Gradle root detection
-│       │   ├── health.rs             # Health check commands
-│       │   ├── logcat.rs             # Logcat streaming commands
-│       │   ├── settings.rs           # Settings persistence commands
-│       │   ├── variant.rs            # Build variant commands
-│       │   └── mcp.rs                # MCP setup status, Claude registration helpers
-│       ├── services/
-│       │   ├── mcp_server.rs         # MCP stdio server (tools, prompts, resources)
-│       │   ├── adb_manager.rs        # ADB device polling
-│       │   ├── build_runner.rs       # ./gradlew execution, output parsing
-│       │   ├── fs_manager.rs         # Gradle root detection
-│       │   ├── logcat.rs             # Parser, ring buffer (50K entries)
-│       │   ├── process_manager.rs    # Child process lifecycle + SIGTERM
-│       │   ├── settings_manager.rs   # ~/.keynobi/settings.json
-│       │   └── variant_manager.rs    # buildTypes × productFlavors parsing
-│       └── models/
-│           ├── build.rs
-│           ├── device.rs
-│           ├── error.rs
-│           ├── health.rs
-│           ├── log_entry.rs
-│           ├── settings.rs
-│           └── variant.rs
-│
-├── scripts/
-│   └── build-dmg.sh                  # One-command DMG builder
-├── docs/                             # Architecture and user documentation
-├── package.json
-├── vite.config.ts
-└── tsconfig.json
-```
+- `src/` - SolidJS frontend.
+- `src/components/ui/` - shared design-system primitives, exported from `@/components/ui`.
+- `src/components/{domain}/` - domain UI panels and presentational pieces.
+- `src/stores/` - Solid stores and state actions.
+- `src/services/` - frontend orchestration across stores, IPC, and UI flows.
+- `src/lib/tauri-api.ts` - typed wrappers for Tauri `invoke` calls.
+- `src/lib/` - pure frontend utilities.
+- `src/test/` - Vitest setup, typed factories, and mock backend.
+- `src/bindings/` - generated TypeScript bindings; do not edit manually.
+- `src-tauri/src/commands/` - thin Tauri command handlers.
+- `src-tauri/src/services/` - Rust business logic.
+- `src-tauri/src/models/` - Rust IPC models exported with `ts-rs`.
+- `src-tauri/src/utils/` - shared Rust utilities.
+- `src-tauri/benches/` - Criterion benchmarks.
+- `e2e/` - Playwright web-mode integration tests.
+- `scripts/` - release, versioning, metrics, and packaging scripts.
 
 ---
 
 ## Rust Patterns
 
-### 1. Per-Concern State Structs
+### State
 
-Each service domain owns its own `Mutex`-wrapped state. Never put unrelated fields in the same state struct.
+Each domain owns its own state struct. Avoid unrelated fields in the same Mutex because it creates unnecessary contention.
 
-```rust
-// CORRECT — separate Mutexes, no cross-domain blocking
-pub struct FsState(pub Mutex<FsStateInner>);
-pub struct LspState(pub Mutex<LspStateInner>);
-pub struct TreeSitterState(pub Mutex<TreeSitterService>);
+Implement `Default` by delegating to `new()` when a state type has construction logic.
 
-// WRONG — everything in one state creates contention
-pub struct AppState(pub Mutex<AppStateInner>); // DO NOT DO THIS
-```
+### Mutex Discipline
 
-Always implement `Default` by delegating to `new()`:
+Hold locks for the shortest possible time:
 
 ```rust
-impl Default for FsState {
-    fn default() -> Self { Self::new() }
-}
-```
-
-### 2. Mutex Lock Discipline
-
-Hold the Mutex for the minimum time. Clone what you need and drop the lock before any I/O or `await`.
-
-```rust
-// CORRECT
-let root = {
-    let fs = fs_state.0.lock().await;
-    fs.project_root.clone().ok_or("No project open")?
-}; // lock dropped here
-let tree = build_file_tree(&root); // I/O outside the lock
-
-// WRONG — holding the lock across I/O
-let fs = fs_state.0.lock().await;
-let tree = build_file_tree(fs.project_root.as_ref()?); // lock held during I/O
-```
-
-### 3. Commands Are Thin Wrappers
-
-Tauri command handlers in `commands/` are thin. They validate inputs, delegate to `services/`, and convert errors to strings. No business logic lives in commands.
-
-```rust
-// CORRECT — command validates and delegates
-#[tauri::command]
-pub async fn read_file(path: String, fs_state: State<'_, FsState>) -> Result<String, String> {
-    validate_path(&path, &fs_state).await?;           // validate
-    fs_manager::read_file(Path::new(&path))           // delegate to service
-        .map_err(|e| e.to_string())                   // convert error
-}
-
-// WRONG — business logic in the command handler
-#[tauri::command]
-pub async fn read_file(path: String) -> Result<String, String> {
-    let content = tokio::fs::read_to_string(&path)...; // logic in command
-    // ...
-}
-```
-
-### 4. Path Security — Always Canonicalize
-
-Any command that accepts a path from the frontend must validate it against the **effective project root** using canonicalization before passing it to a service.
-
-The effective root is `gradle_root` (detected Gradle project root) when available, otherwise `project_root`. This allows go-to-definition navigation to reach files in sibling Gradle modules.
-
-The validation pattern (applied inline in each command that needs it):
-
-1. Lock `FsState`, read `gradle_root` or `project_root`, drop lock
-2. `canonicalize()` both root and target path
-3. Check `canonical_target.starts_with(&canonical_root)`
-
-```rust
-// Example: inline path validation in a command
 let root = {
     let fs = fs_state.0.lock().await;
     fs.gradle_root.as_ref().or(fs.project_root.as_ref())
-        .ok_or("No project open")?.clone()
-}; // lock dropped
-let canonical_root = root.canonicalize().map_err(|e| format!("Failed to resolve root: {e}"))?;
-let canonical_target = Path::new(&path).canonicalize().map_err(|e| format!("Failed to resolve path: {e}"))?;
-if !canonical_target.starts_with(&canonical_root) {
-    return Err("Path is outside the project directory".into());
-}
+        .ok_or("No project open")?
+        .clone()
+};
+
+let result = do_io(&root)?;
 ```
 
-Never use `path.starts_with(root)` without canonicalization first. For MCP tools, use the domain-specific validators (e.g. `validate_apk_path` for APK paths).
+Do not hold a Mutex across I/O, process execution, event emission, or `await`.
 
-### 5. Error Handling
+### Commands
 
-- Services return `Result<T, FsError>` (or `Result<T, String>` for simpler domains)
-- Commands convert errors to `String` at the IPC boundary: `.map_err(|e| e.to_string())`
-- Never use `unwrap()` in production code; use `expect()` only when failure truly means programmer error (e.g., grammar loading at startup)
-- Use `#[derive(thiserror::Error)]` for structured error types in services
+Tauri commands:
 
-### 6. Model Types — Derive ts-rs
+- Accept IPC-shaped inputs.
+- Validate paths and other untrusted inputs.
+- Clone required state and drop locks.
+- Delegate business logic to `services/`.
+- Convert errors at the boundary with `.map_err(|e| e.to_string())`.
 
-All types that cross the IPC boundary must derive `Serialize`, `Deserialize`, `Clone`, and `TS` for TypeScript binding generation.
+No business logic belongs in command handlers.
+
+### Path Security
+
+Any command or tool that accepts a path must validate it against the effective project root.
+
+The effective root is `gradle_root` when available, otherwise `project_root`. Canonicalize both root and target, then check the canonical target is within the canonical root. For relative paths, prefer shared validators such as `utils::path::validate_within_root`.
+
+Never use raw `path.starts_with(root)` for security.
+
+MCP tools may have narrower validators, such as APK paths being restricted to build outputs.
+
+### Models and Bindings
+
+Every Rust type crossing IPC derives:
 
 ```rust
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, TS)]
+#[derive(Debug, Serialize, Deserialize, Clone, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export, export_to = "../../src/bindings/")]
-pub struct FileNode {
-    pub name: String,
-    pub path: String,
-    pub kind: FileKind,
-    pub children: Option<Vec<FileNode>>,
-    pub extension: Option<String>,
-}
 ```
 
-Always use `#[serde(rename_all = "camelCase")]` for JSON serialization to match TypeScript conventions.
+After changing exported models, run:
 
-After changing any model type, regenerate bindings:
 ```bash
 npm run generate:bindings
 ```
 
-### 7. Structured Logging
+Commit regenerated files under `src/bindings/`.
 
-Use `tracing` macros, never `println!` or `eprintln!`. Match the log level to the audience:
+### Errors and Logging
 
-```rust
-tracing::error!("LSP process crashed: {}", err);   // must be investigated
-tracing::warn!("File watcher missed event");         // degraded behavior
-tracing::info!("LSP initialized: {:?}", server);    // lifecycle milestones
-tracing::debug!("LSP request [{}] {}", id, method); // developer debugging
-```
-
-Configure at runtime via `RUST_LOG=keynobi_lib=debug`.
+- Use `thiserror` for structured service errors where it improves clarity.
+- Do not use `unwrap()` in production Rust.
+- Use `tracing` macros for logs.
+- GUI log filtering uses `KEYNOBI_LOG`; headless MCP uses `RUST_LOG`.
 
 ---
 
-## Frontend Patterns (SolidJS)
+## Frontend Patterns
 
-### 1. Store Structure
+### Stores
 
-Every logical domain has one store file: `{domain}.store.ts`. The store exports the reactive state object and named action functions. Components never mutate the store directly.
+Each logical domain has a `{domain}.store.ts` file that exports:
 
-```typescript
-// stores/editor.store.ts
+- The reactive state object.
+- Named action functions.
+- Reset helpers for tests when state is mutable across tests.
 
-const [editorState, setEditorState] = createStore<EditorStoreState>({ ... });
+Components read stores but do not mutate them directly. Use `produce` for array splices and nested updates; use direct path setters for scalar updates.
 
-export { editorState }; // read-only reactive state
-export function setActiveFile(path: string | null) { ... } // named action
-export function markDirty(path: string) { ... }            // named action
-```
+Do not destructure Solid stores. Access properties through the store object so fine-grained reactivity remains intact.
 
-Use `produce` from `solid-js/store` for mutations that involve array splicing or nested object deletion — regular `setEditorState("key", value)` for scalar updates.
+### Services
 
-### 2. Component Architecture
+Frontend services coordinate user-visible flows across IPC calls, events, stores, and dialogs. Examples: build/run/deploy, project open, logcat start/stop.
 
-- **`components/common/`** — No domain logic. Pure UI primitives that can be used anywhere.
-- **`components/layout/`** — Shell structure. No business logic; connects stores to UI.
-- **`components/{domain}/`** — Domain-specific panels. Read from stores, delegate mutations to service functions.
+Services may dynamically import UI pieces to avoid cycles, but reusable UI state still belongs in stores.
 
-Components do not call Tauri `invoke` directly. IPC calls belong in `lib/tauri-api.ts` or `services/`.
+### Components
 
-### 3. Registering Keybindings and Actions Together
+- `components/ui/` contains reusable primitives with CSS Modules and `var(--*)` theme tokens.
+- `components/layout/` contains shell layout.
+- `components/{domain}/` contains domain-specific UI.
+- `components/common/` is for legacy or broadly shared non-design-system components; prefer `components/ui/` for new primitives.
 
-Every keyboard shortcut that should appear in the command palette must be registered via `registerKeyAndAction()` in `App.tsx`, not with bare `registerKeybinding()`.
+Components should delegate side effects to services or store actions. Components may use Tauri plugin APIs directly only for UI-specific operations such as dialogs or window controls.
 
-```typescript
-// CORRECT — registers in both the keybinding system and the action registry
-registerKeyAndAction({
-  id: "file.save",
-  key: "s",
-  metaKey: true,
-  label: "Save Active File",
-  category: "File",
-  action: async () => { /* ... */ },
-});
+### SolidJS Reactivity
 
-// WRONG — only registers the keyboard shortcut, never appears in Cmd+Shift+P
-registerKeybinding({ key: "s", metaKey: true, action: () => { /* ... */ } });
-```
+- Use `createMemo` for derived values used in render paths or multiple places.
+- Call signals/memos in JSX: `{label()}`, not `{label}`.
+- Register `onCleanup` for timers, subscriptions, and listeners.
+- Guard async flows where stale responses can arrive out of order.
 
-### 4. Reactive Computations — Use `createMemo`
+### Design System
 
-Values derived from reactive state that are used in multiple places (or in render paths) must be wrapped in `createMemo` to avoid redundant recomputation.
+Use shared UI primitives from `@/components/ui`.
 
-```typescript
-// CORRECT
-const buildLabel = createMemo(() => getBuildStatusLabel());
-const summary = createMemo(() => healthSummary());
-
-// WRONG — called multiple times per render, recomputes on every access
-const label = getBuildStatusLabel(); // inside JSX expression
-```
-
-### 5. SolidJS Reactivity Rules
-
-- **Never destructure stores**: `const { status } = buildState` breaks reactivity. Always access as `buildState.status`.
-- **Signals in JSX must be called**: `{buildLabel()}` not `{buildLabel}`.
-- **`onCleanup` for timers**: Any `setTimeout` set in a component must be cleared in `onCleanup`.
-
-```typescript
-// CORRECT
-let timer: ReturnType<typeof setTimeout> | undefined;
-onCleanup(() => { if (timer) clearTimeout(timer); });
-timer = setTimeout(() => { /* ... */ }, 300);
-```
-
-### 6. TypeScript Types — Import from `@/bindings`
-
-Types that originate from Rust models must be imported from `@/bindings`, not redefined locally.
-
-```typescript
-// CORRECT
-import type { BuildError, Device, SystemHealthReport } from "@/bindings";
-
-// WRONG — creates a parallel definition that can drift from the Rust model
-interface BuildError { message: string; file: string; /* ... */ }
-```
-
-For store types that need additional computed fields beyond the binding shape, extend the binding type:
-
-```typescript
-import type { Diagnostic } from "@/bindings";
-interface DiagnosticWithCount extends Diagnostic { count: number; }
-```
-
-### 7. Design system (`src/components/ui/`)
-
-Reusable atoms and layout pieces live under `src/components/ui/` with **CSS Modules** and **`var(--*)` tokens** from `src/styles/theme.css`. Import from `@/components/ui` via the barrel file.
-
-- **`Button` vs `IconButton`**: Use `Button` for labeled actions (primary/secondary/ghost/danger). Use **`IconButton`** for compact toolbar controls (fixed square hit target, `title` for tooltip, optional `active` / `size="sm" | "md"`).
-- **`Dropdown` / `MenuItem`**: Set `destructive: true` on items that remove data so they get error-colored styling.
-- **Colors**: Prefer semantic tokens (`var(--success)`, `var(--error)`, `var(--info)`, `var(--warning)`, `var(--text-muted)`) instead of hardcoded hex in app components. For translucent tints, use `color-mix(in srgb, var(--token) N%, transparent)` where needed.
-- **Roadmap**: Prefer existing **`Panel`**, **`Tabs`**, and **`Toolbar`** when replacing duplicated headers or tab rows. For icon-only controls, **`Tooltip`** is preferred over bare `title` for accessibility (migrate incrementally).
+- `Button` for labeled actions.
+- `IconButton` for compact toolbar controls.
+- `Dropdown` / `MenuItem` for option menus; mark destructive items with `destructive: true`.
+- `Tooltip` for icon-only controls when practical.
+- Semantic CSS tokens over hardcoded colors.
+- `Panel`, `Tabs`, `Toolbar`, and form controls before inventing local variants.
 
 ---
 
-## IPC / Tauri Bridge Patterns
+## IPC and Events
 
-### 1. Typed IPC Wrappers
+### Typed IPC
 
-All `invoke` calls live in `src/lib/tauri-api.ts`. Components and services import from there, never call `invoke` directly.
+All `invoke` calls belong in `src/lib/tauri-api.ts`. Components and services import typed wrappers from there.
 
 ```typescript
-// lib/tauri-api.ts
-export async function readFile(path: string): Promise<string> {
-    return invoke<string>("read_file", { path });
+export async function getBuildStatus(): Promise<BuildStatus> {
+  return invoke<BuildStatus>("get_build_status");
 }
-
-// component.tsx — CORRECT
-import { readFile } from "@/lib/tauri-api";
-const content = await readFile(path);
-
-// component.tsx — WRONG
-import { invoke } from "@tauri-apps/api/core";
-const content = await invoke<string>("read_file", { path }); // bypasses typed wrapper
 ```
 
-### 2. Tauri Events vs Commands
+### Commands, Events, and Channels
 
-- **Commands** (`invoke`): Request-response. Use for operations where the frontend needs the result before proceeding.
-- **Events** (`emit`/`listen`): Fire-and-forget notifications from Rust to frontend. Use for status updates, file change notifications, LSP progress events.
+- Commands are request/response.
+- Events are lifecycle notifications.
+- Channels are for high-frequency streams such as build output.
 
-```rust
-// Rust — emit for status changes the frontend should react to
-let _ = app.emit("lsp:status", LspStatus { state: LspStatusState::Ready, message: None });
+Always call event `unlisten()` in cleanup.
 
-// Frontend — listen for the event in the relevant store or component
-const unlisten = await listen("lsp:status", (event) => {
-    setLspStatus(event.payload.state, event.payload.message);
-});
-```
+---
 
-Always call `unlisten()` in `onCleanup` to prevent listener leaks.
+## Actions and Keybindings
 
-### 3. Tauri Plugin APIs in Components
+Every keyboard shortcut that should appear in the command palette must be registered with `registerKeyAndAction()` in `App.tsx`.
 
-Tauri plugin APIs (`@tauri-apps/plugin-dialog`, `@tauri-apps/plugin-fs`, `@tauri-apps/api/window`) may be used directly in components when the operation is UI-specific and does not need a typed wrapper. Examples: file save dialog in `LogcatPanel`, window controls in `TitleBar`. These are distinct from `invoke` calls which must always go through `tauri-api.ts`.
+Use `registerAction()` for command-palette actions without shortcuts.
+
+Do not use bare `registerKeybinding()` for app commands unless the shortcut is intentionally hidden from the command palette.
 
 ---
 
 ## Testing Patterns
 
-### Co-location
+### Vitest
 
-Test files live next to the code they test: `editor.store.test.ts` beside `editor.store.ts`, `treesitter.rs` tests inside the `#[cfg(test)]` module at the bottom of the file.
+- Tests live next to the code they cover.
+- Mock Tauri APIs through `src/test/setup.ts` and `src/test/mock-backend/`.
+- Use factories from `src/test/factories/` for IPC-shaped data.
+- Reset mutable stores in `beforeEach`.
+- Test behavior and state transitions, not internal implementation details.
 
-### Frontend Tests (Vitest)
+### Playwright
 
-- Mock all Tauri APIs in `src/test/setup.ts` — tests run in jsdom without a real Tauri runtime.
-- Reuse typed model factories from `src/test/factories/*.ts` when tests need IPC-shaped data (`Device`, `BuildRecord`, `ProcessedEntry`, `AppSettings`). Factories should import types from `@/bindings` and accept `Partial<T>` overrides.
-- Use a `resetState()` helper in `beforeEach` to restore stores to defaults.
-- Test behavior, not implementation: assert on exported state and the effects of actions.
+- E2E tests live under `e2e/`.
+- Web mode uses `vite-plugin-tauri-mock.ts`.
+- Tests may call `window.__e2e__.invoke(...)` and `window.__e2e__.triggerEvent(...)` for IPC contract checks.
+- Per-test startup settings go in `window.__keynobi_e2e_settings_overrides` before `page.goto("/")`.
 
-### Playwright E2E (web mode)
+### Rust
 
-- Keep E2E tests under `e2e/` and share setup via `e2e/fixtures/app.ts`.
-- In `--mode e2e`, Tauri APIs are intercepted by `vite-plugin-tauri-mock.ts`; tests can call `window.__e2e__.invoke(...)` and `window.__e2e__.triggerEvent(...)` for IPC contract checks.
-- For per-test startup overrides (for example onboarding), set `window.__keynobi_e2e_settings_overrides` in `page.addInitScript(...)` before `page.goto("/")` so mock backend defaults are applied before app boot.
-- Mock backend handlers must fail unknown commands and preserve contract semantics that the UI depends on, including backend-side filtering for simple logcat filters.
+- Unit tests live in `#[cfg(test)]` modules near the service code.
+- Use `tempfile::TempDir` for filesystem fixtures.
+- Command tests should focus on validation and boundary behavior.
 
-### Design system and UI refactors (verification gate)
+### Verification Gate
 
-Before merging PRs that touch `src/components/ui/`, shared panel styling, or broad token/color refactors, run all of:
+For design-system work, shared panel styling, broad UI refactors, or token/color changes, run:
 
 ```bash
 npm test && npm run typescript:check && npm run lint
 ```
 
-This is the project’s standard gate for catching broken imports, type errors, and regressions without relying on a separate coverage threshold.
-
-```typescript
-beforeEach(() => { resetUIState(); });
-
-it("closes the active tab and activates the next one", () => {
-    addOpenFile({ path: "/a.kt", ... });
-    addOpenFile({ path: "/b.kt", ... });
-    setActiveFile("/a.kt");
-    removeOpenFile("/a.kt");
-    expect(editorState.activeFilePath).toBe("/b.kt");
-});
-```
-
-### Rust Tests
-
-- Unit tests go inside `#[cfg(test)]` modules at the bottom of each service file.
-- Use `tempfile::TempDir` for tests that need real files on disk.
-- Tests for `#[tauri::command]` functions focus on path validation logic, not Tauri integration.
-
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    #[test]
-    fn excludes_build_directory() {
-        let dir = TempDir::new().unwrap();
-        // ... setup ...
-        assert!(!tree.contains("build/"));
-    }
-}
-```
-
-### Benchmarks
-
-Performance-critical services have Criterion benchmarks in `src-tauri/benches/`. Run with `cargo bench`. Results are captured by `npm run perf:collect` into `perf-metrics/`.
+For Rust changes, match the relevant CI commands in `CONTRIBUTING.md`.
 
 ---
 
-## File Naming Conventions
+## Naming
 
 | Scope | Pattern | Example |
 |-------|---------|---------|
-| Rust modules | `snake_case.rs` | `fs_manager.rs`, `lsp_client.rs` |
-| TypeScript modules | `kebab-case.ts` | `file-utils.ts`, `fuzzy-match.ts` |
-| Store files | `{domain}.store.ts` | `build.store.ts`, `device.store.ts` |
+| Rust modules | `snake_case.rs` | `fs_manager.rs` |
+| TypeScript modules | `kebab-case.ts` | `file-utils.ts` |
+| Stores | `{domain}.store.ts` | `build.store.ts` |
 | Store tests | `{domain}.store.test.ts` | `build.store.test.ts` |
-| Components | `PascalCase.tsx` | `FileTree.tsx`, `SearchPanel.tsx` |
-| Component tests | `{name}.test.ts(x)` | `filetree.test.ts` |
+| Components | `PascalCase.tsx` | `DevicePanel.tsx` |
+| Component tests | `{name}.test.tsx` | `DevicePanel.test.tsx` |
 | Services | `{domain}.service.ts` | `project.service.ts` |
-| Bindings | Auto-generated — do not create manually | `FileNode.ts`, `Diagnostic.ts` |
-
----
-
-## Build / Device / Logcat / MCP Patterns
-
-Domain-specific implementation details are documented in `DOMAIN_PATTERNS.md`. This section covers only the reusable patterns that apply across all domains.
-
-### Channel Streaming
-
-For high-throughput line-by-line streaming from Rust to frontend, use Tauri Channels (not events). The channel reference is passed as a command parameter:
-
-```rust
-#[tauri::command]
-pub async fn run_gradle_task(
-    task: String,
-    on_line: Channel<BuildLine>,
-    ...
-) -> Result<u32, String> {
-    let _ = on_line.send(line);
-}
-```
-
-```typescript
-const channel = new Channel<BuildLine>();
-channel.onmessage = (line) => addBuildLine(line);
-await invoke<number>("run_gradle_task", { task, onLine: channel });
-```
-
-Use **events** (`emit`/`listen`) for fire-and-forget lifecycle notifications. Use **channels** for high-frequency streaming data.
-
-### Service Coordination
-
-Frontend services (`build.service.ts`, `project.service.ts`) coordinate multiple IPC calls into user-visible actions. They own the orchestration logic: spawn a backend task, listen for its completion event, then update stores. Services may dynamically import UI components (e.g. device picker dialog) to avoid circular dependencies.
-
-### MCP Tools
-
-MCP tools use the `rmcp` crate with `#[tool_router]` / `#[tool]` macros. Key rules:
-- Validate all string inputs before acting (task names, package names, device serials, paths)
-- Lock state, clone, drop before I/O — same as Tauri commands
-- Use `CallToolResult::structured(json!({...}))` for data the AI will reason about
-- Use `CallToolResult::error(...)` for execution failures (not protocol errors)
-- `AndroidMcpServer` works in both GUI mode (shared Tauri state) and headless mode (`--mcp` CLI flag)
-
-See `DOMAIN_PATTERNS.md` for detailed MCP tool definitions, resource/prompt patterns, and lifecycle events.
+| Generated bindings | Do not create manually | `BuildStatus.ts` |

--- a/docs/DOMAIN_PATTERNS.md
+++ b/docs/DOMAIN_PATTERNS.md
@@ -1,265 +1,173 @@
 # Domain Patterns
 
-Domain-specific implementation details. These supplement the foundational rules in `CODE_PATTERN.md` with per-domain context needed when working in a specific area.
+Domain-specific rules for Keynobi. These supplement `CODE_PATTERN.md`; keep this file focused on invariants that are not obvious from local code.
+
+Update this file when a domain workflow, boundary, or safety rule changes.
 
 ---
 
-## Table of Contents
+## Build
 
-1. [Build System](#build-system)
-2. [Device Management](#device-management)
-3. [Logcat Pipeline](#logcat-pipeline)
-4. [UI hierarchy (layout viewer)](#ui-hierarchy-layout-viewer)
-5. [MCP Server](#mcp-server)
+### Backend State
 
----
+`BuildState` owns build status, in-flight process IDs, bounded history, accumulated errors, and the bounded raw build log. Keep process lifecycle state in the build domain; do not spread Gradle process ownership into UI code.
 
-## Build System
+Key caps:
 
-### Build State
+- Build history: `MAX_HISTORY`.
+- Raw build output retained for MCP/history: `MAX_BUILD_LOG`.
+- Persisted build logs: rotated by build history and age/size policy.
 
-Build state follows the per-concern Mutex pattern. `BuildState` holds only the in-flight process ID, current status, errors, and bounded history. No Tauri types in `build_runner.rs`.
+### Frontend Flow
 
-```rust
-pub struct BuildState(pub Mutex<BuildStateInner>);
-pub struct BuildStateInner {
-    pub current_build: Option<ProcessId>,
-    pub status: BuildStatus,
-    pub history: VecDeque<BuildRecord>,   // bounded: MAX_HISTORY = 10
-    pub current_errors: Vec<BuildError>,
-    next_id: u32,
-}
+`build.service.ts` owns build orchestration:
+
+```text
+runBuild()
+  -> runGradleTask
+  -> wait for build:complete
+  -> finalizeBuild
 ```
 
-### Build Service Flow
+`runAndDeploy()` builds first, then installs and launches against the resolved online device. Always clear `deployPhase` in `finally`.
 
-`build.service.ts` coordinates multiple IPC calls into a user-visible action:
+### Invariants
 
-```
-runBuild() → runGradleTask (IPC, returns immediately after spawn)
-           → await build:complete event (one-shot Promise resolved by listener)
-           → finalizeBuild (with correct success/duration from event)
-
-runAndDeploy() → resolveDevice (pick dialog if no online device selected)
-              → setDeployPhase("building") → runBuild
-              → setDeployPhase("installing") → findApkPath → installApkOnDevice
-              → setDeployPhase("launching") → launchAppOnDevice (using applicationId)
-              → setDeployPhase(null)
-```
-
-**Key invariants:**
-- `runBuild()` only resolves after `build:complete` fires — `buildState.phase` is always correct when it returns.
-- `_resolveBuildComplete` is a module-level one-shot resolver. It is set before `runGradleTask` and cleared by the `listenBuildComplete` handler.
-- If `cancelBuild()` is called mid-build, `_resolveBuildComplete` is nulled so the awaiting `buildComplete` promise is abandoned without hanging.
-- Build errors accumulate in `accumulatedErrors` and are passed to `finalizeBuild` for backend persistence.
-
-**Device resolution:** `resolveDevice()` checks if `deviceState.selectedSerial` is online; if not, it dynamically imports and shows `DevicePickerDialog`. The dialog is lazy-imported to avoid circular dependency between build service and device UI.
-
-**DeployPhase:** `buildState.deployPhase` drives the status bar during the install/launch steps after a successful build. Always cleared in the `finally` block.
+- Build output streams through a Tauri Channel.
+- Build lifecycle completion uses events.
+- `runBuild()` resolves only after completion/cancellation state is known.
+- Cancellation must clear pending build-completion waiters and process IDs.
+- Parsed build errors are persisted through `finalizeBuild`.
 
 ---
 
 ## Device Management
 
-### Device State
+### Backend State
 
-Same per-concern Mutex pattern:
+`DeviceState` owns connected devices, selected serial, and the polling guard. Device polling runs as a detached task and emits `device:list_changed` when the visible list changes.
 
-```rust
-pub struct DeviceState(pub Mutex<DeviceStateInner>);
-pub struct DeviceStateInner {
-    pub devices: Vec<Device>,
-    pub selected_serial: Option<String>,
-    pub polling: bool,            // guards against double-starting the poll task
-}
-```
+### AVDs
 
-Device polling runs as a detached `tokio::spawn` task. When the device list changes, it emits `device:list_changed` via `AppHandle::emit`. The frontend listens and calls `setDevices()` in the store.
+AVD lifecycle commands go through Android SDK tools and return the refreshed AVD list when practical so the frontend updates in one round-trip.
 
-### AVD Management
+### Frontend Modes
 
-AVD lifecycle (create/delete/wipe) goes through `avdmanager` CLI, resolved from `$ANDROID_HOME/cmdline-tools/`. Commands return the refreshed AVD list (`Vec<AvdInfo>`) so the frontend can update in one round-trip.
+`DevicePanel` supports two contexts:
 
-### DevicePanel Mode Pattern
+- `mode="panel"`: full device management surface.
+- `mode="popover"`: compact status-bar picker with a manage-devices path.
 
-`DevicePanel` accepts a `mode` prop for its two usage contexts:
-- `mode="panel"` (default): full-width tab content with toolbar, two sections, AVD lifecycle actions
-- `mode="popover"`: compact 280px dropdown for the StatusBar pill, with "Manage Devices" footer link
+Device-picking flows must validate that `selectedSerial` is still online before using it.
 
 ---
 
-## Logcat Pipeline
+## Logcat
 
-### Architecture
+### Pipeline
 
-The logcat data flow is a four-stage pipeline:
+Logcat is a backend-first streaming pipeline:
 
-```
+```text
 adb logcat
-  → Ingester (parse raw lines → RawLogLine, zero mutex)
-  → Pipeline+Batcher task (every 100ms: run processors, lock state once, emit filtered)
-  → StreamManager (filter entries before IPC emit)
-  → Frontend (render pre-filtered entries; frontend-only filtering for age/regex/negate)
+  -> raw line ingestion
+  -> processor chain
+  -> bounded LogStore
+  -> backend filter
+  -> batched IPC emit
+  -> frontend render/filter refinements
 ```
 
-### Processor Chain (`services/log_pipeline.rs`)
+Backend processing owns package resolution, crash detection, JSON detection, category classification, stats, and ring-buffer storage.
 
-Processors implement the `LogProcessor` trait and run sequentially per entry:
+### Filtering
 
-```rust
-pub trait LogProcessor: Send + Sync {
-    fn process(&self, entry: &mut ProcessedEntry, ctx: &mut PipelineContext);
-}
-```
+Handle high-volume and simple filters in Rust before crossing IPC. Frontend-only filters are limited to cases that require browser state or JS-only semantics, such as age filters, negation, and regex.
 
-Built-in processors (in order):
-1. **PackageResolver** — attaches `package` from PID→package map
-2. **CrashAnalyzer** — detects FATAL/ANR/native, assigns `crash_group_id`
-3. **JsonExtractor** — detects valid JSON in message, stores raw string in `json_body`
-4. **CategoryClassifier** — O(1) tag→category lookup
+### Frontend Boundaries
 
-`PipelineContext` is owned by the pipeline task (no mutex) and carries cross-entry state (pid_to_package, crash group tracking). It is synced into `LogcatStateInner.known_packages` once per 100ms tick.
+Keep `LogcatPanel.tsx` as composition/orchestration. Domain logic lives in focused helpers:
 
-### LogStore (`services/log_store.rs`)
+- Query parsing: `lib/logcat-query.ts`.
+- Backend filter conversion: `lib/logcat-filter-spec.ts`.
+- Autocomplete data: `lib/logcat-suggestions.ts`.
+- UI entry storage and UI cap: `stores/logcat.store.ts`.
+- Async request ordering: `services/logcat.service.ts`.
+- Query interaction: `QueryBar.tsx`, `QueryBarParts.tsx`, `querybar-styles.ts`.
+- Suggestion runtime: `logcat-suggestion-runtime.ts`.
+- Presentational pieces: `LogcatToolbar.tsx`, `SavedFilterMenu.tsx`, `LogcatRows.tsx`, `LogcatFilterControls.tsx`, `LogcatJsonDetailPanel.tsx`.
 
-Bounded ring buffer with secondary indexes for O(1) crash/JSON lookups:
+Presentational components should not call Tauri IPC except for narrow row actions, such as opening a stack frame in Android Studio.
 
-```rust
-pub struct LogStore {
-    entries: VecDeque<ProcessedEntry>,  // 50K ring buffer
-    crash_ids: VecDeque<u64>,           // IDs of crash entries
-    json_ids: VecDeque<u64>,            // IDs of JSON entries
-    pub stats: LogStats,                // running counters (O(1) per entry)
-}
-```
+### IPC Type
 
-### Backend / Frontend Filter Split
-
-`StreamState` holds the active `LogcatFilter`. The batcher calls `filter_batch()` before emitting — only matching entries cross the IPC bridge.
-
-The frontend `filteredEntries` memo only applies tokens the backend cannot handle:
-- `age:N` — time-based, needs `Date.now()`
-- `-tag:X` / `-message:X` — negation
-- `tag~:X` / `message~:X` — regex
-
-Everything else (level, simple tag/text/package, only_crashes) is handled in Rust. This reduces the JS O(n) scan to a much smaller pre-filtered set.
-
-### ProcessedEntry (IPC type)
-
-`json_body` is `Option<String>` (not `Value`) to avoid double-serialisation. Frontend parses when user expands the JSON viewer panel.
+`ProcessedEntry.json_body` is `Option<String>`, not a JSON value. The frontend parses it only when the user opens JSON details.
 
 ---
 
-## UI hierarchy (layout viewer)
+## Layout Viewer and UI Automation
 
-Black-box capture of the focused window via **UI Automator** (`uiautomator dump`), parsed into a bounded tree for the **Layout** tab and MCP.
+### Capture
 
-### Rust services
+The layout viewer and MCP UI automation share the same UI Automator capture path. Keep capture logic centralized in `services/ui_hierarchy.rs` / `services/ui_automation.rs` so GUI and MCP behavior stay consistent.
 
-- **`services/ui_hierarchy.rs`** — `capture_ui_hierarchy_snapshot` is the single pipeline for the Layout tab, MCP, and UI automation: log `dumpsys activity activities`, `probe_foreground_activity` (first **512 KiB** for a resumed-activity line), `probe_layout_context` (parallel **12s** cap) for capped excerpts of `dumpsys window windows` (**12 KiB**), `dumpsys display` (**8 KiB**), `wm size`, `wm density`, then `dump_hierarchy_xml`. **`dump_hierarchy_xml`** tries `exec-out uiautomator dump --compressed /dev/tty`, then plain `exec-out`, then `shell uiautomator dump` with and without `--compressed` + `exec-out cat` of `window_dump.xml` paths. Raw XML is capped at **4 MiB**; dump attempts use a **25s** timeout. `strip_ui_automator_noise` trims junk around the XML. `build_snapshot` attaches `UiLayoutContext` + `command_log` (every adb line). See `ui_hierarchy_parse::tests::parses_minified_single_line_xml` for **`--compressed`**-style whitespace.
-- **`services/ui_hierarchy_parse.rs`** — `roxmltree` → `UiNode` tree with caps: **8000** nodes, depth **64**, attribute strings **2048** chars. Parses **`selected`** (e.g. bottom nav). `compute_screen_hash` (SHA-256) fingerprints interactive-relevant fields. `extract_interactive_rows` produces flat rows for MCP (`interactive_only`).
-- **`services/ui_automation.rs`** — MCP UI control: `capture_ui_snapshot` (same dump path as Layout), DFS **`find_ui_elements`** with `treePath` aligned to the layout viewer (`0`, `0.1`, …), **`find_ui_parent_from_snapshot`** / **`normalize_tree_path`** / **`get_node_at_path`** for one-step parent traversal, match cap **100**, string fields truncated for JSON; **`encode_adb_input_text`** for `adb shell input text`; allowlisted **`send_ui_key`** keyevents; `adb_input_tap` / `adb_input_swipe` with coordinate bounds **0..=16384**; **`grant_runtime_permission`** validates `android.permission.*` + package. Unit-tested with hierarchy fixtures (no device).
-- **Fixtures** — `services/fixtures/ui_hierarchy_*.xml` for unit tests (classic View + Compose-shaped XML).
+### Bounds and Caps
 
-### IPC
+The hierarchy parser must keep explicit caps for:
 
-- **Command** — `dump_ui_hierarchy` in `commands/ui_hierarchy.rs`; `device_serial: Option<String>` (omit → use `DeviceState.selected_serial`). Reuses `commands::device::validate_device_serial`.
-- **Types** — `models/ui_hierarchy.rs`: `UiNode` (includes **`selected`**), `UiLayoutContext` (window/display/wm excerpts), `UiHierarchySnapshot` (`ts-rs` → `src/bindings/`; includes `layoutContext`, `command_log`). `UiInteractiveRow` is MCP-only (schemars, no TS).
+- Raw XML size.
+- Node count.
+- Tree depth.
+- Attribute string length.
+- Interactive row count.
+- UI automation match count.
+- Tap/swipe coordinate bounds.
 
-### Frontend
+### Paths
 
-- **`lib/ui-hierarchy-display.ts`** — `collapseBoringChains` (synthetic `android.view.KeynobiCollapsedWrappers` rows), `defaultExpandDepthForNodeCount`, search path helpers (`pathOverridesToRevealPath` expands through the match; **`pathOverridesToRevealAncestorPath`** opens only prefixes so a row is visible without expanding its subtree), **`parentLayoutPath`** (direct parent index path for **Find parent**), `formatRowSnippet` / `isMergedTapTargetHeuristic`, package inference for toolbar, and **wireframe** helpers (`parseBoundsRect`, `flattenNodesWithBounds`, `inferScreenSizeFromRects`, `pickNodePathAtDevicePoint`, `prepareWireframeDrawList`, cap **`WIREFRAME_RECT_CAP`**). Vitest covers collapse, paths, parent path vs tree, and wireframe parsing/hit-test.
-- **`LayoutWireframe.tsx`** — SVG wireframe beside the tree; click uses SVG CTM inverse + `pickNodePathAtDevicePoint` (smallest-area win). Paths match the tree (`data-layout-path` + `scrollIntoView` on selection).
-- **`layout-detail-get-node.ts`** — `layoutDetailGetNode(selectedNode)` builds `NodeDetailPanel`’s `getNode` callback. Do not pass Solid `Show`’s render-prop `n` into props (proxy / not callable at runtime). Vitest: `layout-detail-get-node.test.ts`.
-- **`layoutViewer.store.ts`** + **`LayoutViewerPanel.tsx`** — refresh; **Hide boilerplate**, interactive-only, filter with prev/next match, **wireframe | tree | detail** layout, dominant package line; on **selection** (wireframe or tree), merge ancestor path overrides, force **`globalExpand`** back to `auto` if needed, then deferred `scrollIntoView`; footer shows `commandLog` from the latest snapshot.
-- **Tab / shortcut** — `MainTab` includes `"layout"`; **Cmd+4** (`view.layoutPanel`).
+Tree paths use the same index convention across the layout viewer and MCP tools. If UI presentation collapses boilerplate nodes, preserve enough mapping to reveal or act on the real underlying node.
 
-### MCP
+### Screen Hash
 
-- **`get_ui_hierarchy`** — `GetUiHierarchyParams`: optional `device_serial` (resolved like `restart_app`), `interactive_only`, `max_interactive_rows` (default **80**, max **500**). Full mode returns `UiHierarchySnapshot` JSON; interactive mode returns `{ rows, screenHash, commandLog, … }` without the full tree.
-- **`find_ui_elements`** — `FindUiElementsParams` (in `ui_automation.rs`, re-used by the tool router): optional `device_serial`, text/id/class/package filters, optional `clickable_only` / `editable_only` / `enabled_only`, `max_results` (default **50**, max **100**). Requires at least one primary filter (not flags alone). Returns `matches`, `screenHash`, `commandLog`, etc.
-- **`list_clickable_elements`** — `ListClickableElementsParams`: optional `device_serial`, `enabled_only`, `max_results` (default/max **100**). Returns every clickable node in `UiElementMatch` shape without requiring a primary search filter.
-- **`find_ui_parent`** — `FindUiParentParams`: optional `device_serial`, required non-empty `treePath` (same convention as the Layout tab), optional `expect_screen_hash`. Returns `parent` (`UiElementMatch` shape), `parentTreePath`, and snapshot metadata. Empty `treePath` is rejected (display root has no parent).
-- **`ui_tap_element`** — `UiTapElementParams`: optional `device_serial`, required `treePath`, optional `expect_screen_hash`. Fresh-dumps, resolves the current center from the tree, then taps. Prefer over raw `ui_tap` when a `treePath` is available.
-- **`ui_fill_input`** — `UiFillInputParams`: optional `device_serial`, required ASCII `text`, preferred `treePath` target or fallback `x`/`y`, optional `expect_screen_hash`, `clear_before` (default **true**). Always taps the target first before clearing/typing.
-- **`hide_soft_keyboard`** — `HideSoftKeyboardParams`: optional `device_serial`, optional `force`. Checks `dumpsys input_method` and sends Back only when the soft keyboard appears visible; `force=true` sends Back when visibility is unknown.
-- **`ui_wait_for_idle`** — `UiWaitForIdleParams`: optional `device_serial`, `stable_polls` (default **2**), `poll_interval_ms` (default **300**, min **200**), `timeout_ms` (default **5000**, max **30000**). Polls hierarchy `screenHash` until stable.
-- **`ui_scroll_until_element`** — `UiScrollUntilElementParams`: search filters like `find_ui_elements`, optional explicit swipe coordinates, `max_swipes` (default **8**, max **25**). Infers a vertical scroll from hierarchy bounds when coordinates are omitted.
-- **`ui_assert_element`** — `UiAssertElementParams`: search filters plus optional expected state flags (`clickable`, `editable`, `enabled`, `focused`, `checked`, `selected`) or `should_exist=false`. Returns MCP error when the assertion fails.
-- **`open_deep_link`** — `OpenDeepLinkParams`: optional `device_serial`, required URI, optional package. Validates URI scheme/control chars, then runs `am start -a android.intent.action.VIEW -d <uri>` with optional `-p <package>`.
-- **`open_app_settings`** — `OpenAppSettingsParams`: optional `device_serial`, required package, optional `panel` (`appInfo`, `permissions`, `notifications`). Opens Android app settings via `am start`.
-- **`set_device_orientation`** — `SetDeviceOrientationParams`: optional `device_serial`, `orientation` (`portrait`, `landscape`, `reversePortrait`, `reverseLandscape`, `auto`). Uses `settings put system accelerometer_rotation` and `user_rotation`.
-- **`set_network_state`** — `SetNetworkStateParams`: optional `device_serial`, optional `wifi`, `mobile_data`, `airplane_mode`. Best-effort; returns every adb command outcome because Android/emulator versions differ.
-- **`ui_tap`**, **`ui_type_text`**, **`ui_swipe`**, **`send_ui_key`**, **`grant_runtime_permission`**, **`revoke_runtime_permission`** — parameter structs in `ui_automation.rs`; optional `device_serial`; `ui_tap` / `ui_type_text` support optional `expect_screen_hash` against a fresh dump.
+Use `screenHash` to protect automation from stale UI state. Tools that act on UI coordinates or tree paths should support `expect_screen_hash` when stale-screen safety matters.
 
 ---
 
-## MCP Server
+## MCP
 
-### Defining a New Tool
+### Tool Definitions
 
-1. Add a parameter struct (if the tool takes arguments):
+MCP tools live in `services/mcp_server.rs` and are declared with `rmcp` `#[tool_router]` / `#[tool]` macros. Do not describe MCP tools as generated from the frontend action registry.
 
-```rust
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
-pub struct MyToolParams {
-    #[schemars(description = "What this parameter does")]
-    pub my_param: String,
-    pub optional_param: Option<usize>,
-}
-```
+### Validation
 
-2. Add the method to `AndroidMcpServer`'s `#[tool_router]` impl block:
+Validate every external string before acting:
 
-```rust
-#[tool(description = "One-line description for the AI agent.")]
-async fn my_tool(
-    &self,
-    Parameters(p): Parameters<MyToolParams>,
-) -> Result<CallToolResult, McpError> {
-    validate_my_input(&p.my_param)?;
-    let value = { self.build_state.inner.lock().await.some_field.clone() };
-    Ok(CallToolResult::success(vec![Content::text(format!("Result: {value}"))]))
-}
-```
+- Gradle task names.
+- Package names.
+- Device serials.
+- APK paths.
+- Deep links.
+- Runtime permissions.
+- UI key names.
+- UI automation coordinates and tree paths.
 
-3. For execution errors (not protocol errors), use `CallToolResult::error()`.
+Execution failures should usually return `CallToolResult::error(...)`. Protocol or schema failures should return `McpError`.
 
-### Input Validation
+### Output Shape
 
-All MCP tools that accept strings must validate inputs before acting:
-- Gradle task names: `validate_gradle_task(task)?` — alphanumeric + `:.-_`
-- Package names: `validate_package_name(pkg)?` — `com.example.app` format
-- Device serials: `validate_device_serial(serial)?` — alphanumeric + `-:._`
-- APK paths: `self.validate_apk_path(path).await?` — must be within project build outputs
-- UI automation: coordinates bounded in `ui_automation`; runtime permissions via `validate_runtime_permission` (`android.permission.*`); keyevents via allowlist in `resolve_ui_key_code`
+Prefer compact structured output:
 
-### Headless vs GUI Mode
+- Use `CallToolResult::structured(json!(...))` for machine-readable results.
+- Use `CallToolResult::success(...)` for human-readable text.
+- Keep payloads bounded and omit noisy command logs unless the tool is explicitly for diagnostics.
 
-- **GUI mode**: `AndroidMcpServer::from_app_handle(&app)` — reads shared state from Tauri
-- **Headless mode**: `AndroidMcpServer::new_headless(build, device, logcat, fs, pm)` — owns fresh state
-- The `--mcp` CLI flag triggers headless mode in `main.rs`. `--project <path>` sets the project root.
+### Modes
 
-### State Access
+- GUI mode uses shared Tauri state from `AndroidMcpServer::from_app_handle`.
+- Headless mode uses `AndroidMcpServer::new_headless` and initializes state from `--project`, last active project, or current directory.
+- Headless MCP logs to stderr; stdout is reserved for MCP JSON-RPC.
 
-The state structs use `Arc<Mutex<>>` internally, so `AndroidMcpServer` is `Clone` (all fields are cheap Arc copies).
+### Activity
 
-### Structured Outputs
-
-- `CallToolResult::structured(json!({...}))` — data the AI will reason about (devices, errors, logcat)
-- `CallToolResult::success(vec![Content::text(...)])` — human-readable text
-- `Content::image(base64, "image/png")` — screenshots
-
-### Resources and Prompts
-
-- Resources: implement `list_resources` and `read_resource` in `impl ServerHandler`. Use `android://` URIs.
-- Prompts: use `#[prompt_router]` and `#[prompt]` on a separate impl block before `#[tool_handler] #[prompt_handler] impl ServerHandler`.
-
-### Lifecycle Events (GUI Mode)
-
-Emit Tauri events from `on_initialized` and the `start_mcp_server` task:
-- `mcp:started` — when the server task starts
-- `mcp:client_connected` — from `on_initialized` with `{ clientName, connectedAt }`
-- `mcp:stopped` — when the server task exits
-
-Frontend subscribes via `initMcpListeners()` in `src/stores/mcp.store.ts`.
+GUI MCP lifecycle and tool activity should update the MCP activity store through the existing activity logging path. Keep activity entries bounded.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -1,601 +1,319 @@
-# Keynobi — User Manual
+# Keynobi User Guide
 
-> A focused Android development companion for build logs, logcat, and device management.  
-> Works alongside Android Studio and Claude Code.
+Keynobi is a macOS companion app for Android development. It sits next to Android Studio and gives you one place for Gradle builds, logcat, devices, app health, UI hierarchy inspection, and Claude Code MCP workflows.
 
-The distributed app and installer are named **Keynobi**.
-
----
-
-## Table of Contents
-
-1. [Getting Started](#1-getting-started)
-2. [Layout Overview](#2-layout-overview)
-3. [Build Panel](#3-build-panel)
-4. [Logcat Panel](#4-logcat-panel)
-4a. [Layout Panel](#4a-layout-panel)
-5. [Devices Sidebar](#5-devices-sidebar)
-6. [Status Bar](#6-status-bar)
-7. [Settings](#7-settings)
-8. [Health Center](#8-health-center)
-9. [Keyboard Shortcuts](#9-keyboard-shortcuts)
-10. [Claude Code Integration](#10-claude-code-integration)
-11. [Theme and colors](#11-theme-and-colors)
+Use this guide as a quick reference. Most commands are also available from the Command Palette with `Cmd+Shift+P`.
 
 ---
 
-## 1. Getting Started
+## Contents
+
+1. [Quick Start](#quick-start)
+2. [Window Overview](#window-overview)
+3. [Projects](#projects)
+4. [Builds](#builds)
+5. [Logcat](#logcat)
+6. [Layout Viewer](#layout-viewer)
+7. [Devices](#devices)
+8. [Settings and Health](#settings-and-health)
+9. [Claude Code MCP](#claude-code-mcp)
+10. [Keyboard Shortcuts](#keyboard-shortcuts)
+11. [Troubleshooting](#troubleshooting)
+
+---
+
+## Quick Start
 
 ### Requirements
-- macOS (Apple Silicon or Intel)
-- Android SDK with platform-tools (for ADB)
-- Java 11+ (for Gradle builds)
-- Android project with a `gradlew` wrapper
 
-### First Launch
+- macOS, Apple Silicon or Intel.
+- Android SDK with platform-tools.
+- Java 11 or newer.
+- Android project with a `gradlew` wrapper.
 
-1. Launch **Keynobi**. A **Setup** wizard runs once: it can auto-detect your **Android SDK** and **Java** home (or you can enter paths manually), asks whether to enable **anonymous crash reporting** (off by default), and offers optional defaults (MCP auto-start, logcat auto-start). You can **Skip setup** and finish later in **Settings** (Cmd+,).
-2. If you enable crash reporting, it takes effect after the **next app restart** (the setting is saved immediately). Reports are limited to **app-side** diagnostics (e.g. crash type and sanitized stack information) so we can fix stability issues. They do **not** include your project paths, source code, Gradle or log output, or device identifiers.
-3. Add a project: press **Cmd+O** or click **Add Project…** at the bottom of the left **Projects** sidebar, then choose your Android project folder.
-4. The app detects your Gradle root, saves the project to the registry, and initializes build variants.
-5. If you skipped the wizard or need to change paths later, open **Settings** (Cmd+,) and configure:
-   - **Android SDK Path** — path to `$ANDROID_HOME` (e.g. `~/Library/Android/sdk`)
-   - **Java Home** — path to JDK (e.g. `/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home`)
+### First launch
 
-To open the setup wizard again, use the Command Palette (**Cmd+Shift+P** → “Open Setup Wizard”) or **Cmd+Shift+W**.
+1. Open **Keynobi**.
+2. Complete the setup wizard, or skip it and finish later in **Settings**.
+3. Set your **Android SDK Path** and **Java Home** if auto-detect does not find them.
+4. Press `Cmd+O` or click **Add Project** and choose your Android project folder.
+5. Select a device or start an emulator.
+6. Press `Cmd+R` to build, install, and launch.
 
-### Subsequent Launches
+Keynobi restores the last active project on later launches.
 
-The app automatically restores the last-active project. No need to re-open the folder each time.
+### Crash reporting
 
----
-
-## 2. Layout Overview
-
-The window has a **title bar** (draggable; shows the app name and current project, plus a **Build** button that always opens the Build panel), a **tab bar** with **Logcat**, **Layout**, and **Build**, **sidebars** on the left and right, and a **status bar** at the bottom.
-
-```
-┌────────────────────────────────────────────────────────────────────────────┐
-│  Title bar (app — project)                                    [ Build ]     │
-├───┬──[ Logcat ]──[ Layout ]──[ Build ]───────────────────────────────────┬───┤
-│ P │                                                                      │ D │
-│ r │  Active tab content (Logcat, Layout, or Build)                         │ e │
-│ o │                                                                      │ v │
-│ j │                                                                      │ i │
-│ e │                                                                      │ c │
-│ c │                                                                      │ e │
-│ t │                                                                      │ s │
-│ s │                                                                      │   │
-├───┴──────────────────────────────────────────────────────────────────────┴───┤
-│  Status bar: Settings · project · Health · Build · MCP · variant · memory…  │
-└────────────────────────────────────────────────────────────────────────────┘
-```
-
-- **Build** tab — Gradle build output and error list
-- **Logcat** tab — Android device log streaming
-- **Layout** tab — UI Automator / accessibility hierarchy for the focused screen (native Views and Jetpack Compose)
-- **Projects** sidebar (left) — project registry, open/switch projects (**Cmd+B** toggles collapse)
-- **Devices** sidebar (right) — connected devices and emulators (**Cmd+3** toggles visibility)
+Anonymous crash reporting is off by default. If enabled, it takes full effect after restart and sends only app-side diagnostics such as sanitized crash summaries. It does not send source code, project files, Gradle output, logcat, MCP traffic, personal identifiers, or device identifiers.
 
 ---
 
-## 2a. Projects sidebar
+## Window Overview
 
-Use the **Projects** sidebar on the left to work with saved projects. The title bar only shows the current project name; it does not open a menu.
+Keynobi has three main tabs:
 
-```
-┌────────────────────┐
-│ PROJECTS        ‹› │  ← collapse/expand
-│ ┌────────────────┐ │
-│ │ MyApp  gradlew │ │  ← active row highlighted
-│ │ ~/code/...     │ │
-│ └────────────────┘ │
-│   OtherProject …  │
-│ ─────────────────  │
-│  ⊕ Add Project…    │  ← same as Cmd+O
-└────────────────────┘
-```
+- **Build**: Gradle output, build history, and structured errors.
+- **Logcat**: live Android logs with filtering and crash detection.
+- **Layout**: UI Automator accessibility tree and wireframe for the selected device.
 
-### Actions
-- **Click a project row** — switch the active project (cancels a running build for the previous project; **does not stop logcat**)
-- **Pencil** (on hover) — rename the project in the list (does not rename the folder on disk)
-- **×** (on hover, non-active projects only) — remove from the list (**does not** delete the project from disk)
-- **Add Project…** — browse for a new folder (same as **Cmd+O**)
-- **Sidebar header control** — collapse or expand the sidebar; **Cmd+B** toggles the same
+Sidebars and status:
+
+- **Projects sidebar** on the left: saved Android projects.
+- **Devices sidebar** on the right: physical devices and emulators.
+- **Status bar** at the bottom: settings, project, health, build status, MCP, updates, variant, memory, and log folder size.
+
+---
+
+## Projects
+
+Use the **Projects** sidebar to add, switch, rename, or remove saved projects.
+
+- `Cmd+O`: add or open a project folder.
+- `Cmd+B`: collapse or expand the Projects sidebar.
+- Click a project row to switch projects.
+- Rename changes only the label in Keynobi; it does not rename the folder.
+- Remove deletes the saved entry only; it does not delete files on disk.
 
 ### Project App Info
 
-Access via **Command Palette → "Project App Info"** to open a lightweight editor for:
-- **Version Name** (e.g. `1.0.0`) — edits `versionName` in `app/build.gradle(.kts)`
-- **Version Code** (integer) — edits `versionCode` in `app/build.gradle(.kts)`
-- **Application ID** — read-only display of `applicationId`
+Open **Project App Info** from the Command Palette to edit:
 
-Changes are written directly to the Gradle file using a regex replace (safe for standard DSL; does not reformat the file).
+- `versionName`
+- `versionCode`
 
----
-
-## 3. Build Panel
-
-The Build panel streams Gradle output in real time.
-
-### Running a Build
-
-- **Cmd+R** — Build and deploy (assemble → install → launch app)
-- **Cmd+Shift+R** — Build only (no deploy)
-- Click **Run** in the Build panel toolbar
-- The active device and build variant are used automatically
-
-### Build Panel Views
-
-- **Log tab** — Raw streaming Gradle output with ANSI colors
-- **Problems tab** — Structured list of errors and warnings with file paths
-
-The log toolbar includes **↓** to turn follow-tail (auto-scroll to the latest line) on or off. Whether follow-tail starts enabled when you open the app is set under **Settings → Advanced → Auto-scroll build log to end** (on by default).
-
-### Build Variants
-
-- Click the variant pill in the status bar (e.g. `debug`) to open the variant picker
-- **Cmd+Shift+V** — Open variant picker from keyboard
-- Variants are auto-discovered from `app/build.gradle.kts`
-
-### Clean
-
-Use the command palette (Cmd+Shift+P) → **Clean Project** to run `./gradlew clean`.
+The app also shows `applicationId` as read-only. Edits are written to `app/build.gradle` or `app/build.gradle.kts`.
 
 ---
 
-## 4. Logcat Panel
+## Builds
 
-The Logcat panel streams Android device log output in real time through a multi-stage processing pipeline that enriches entries before display.
+The Build tab streams Gradle output and highlights structured errors.
 
-### Starting Logcat
+Common actions:
 
-1. Connect an Android device or start an emulator (see [Devices Sidebar](#5-devices-sidebar))
-2. Click **Start** in the Logcat toolbar, or the app will auto-connect to the selected device
-3. Log entries appear immediately as they arrive, enriched with package resolution and category detection
+- `Cmd+R`: build, install, and launch the app.
+- `Cmd+Shift+R`: build only.
+- `Cmd+Shift+V`: choose the active build variant.
+- **Clean Project** from Command Palette: run `./gradlew clean`.
+- **Cancel Build** from Command Palette: stop the running Gradle task.
 
-### Log Levels
+Build output has two views:
 
-Entries are color-coded by log level:
+- **Log**: raw Gradle output with ANSI colors.
+- **Problems**: parsed errors and warnings.
 
-| Level | Color | Meaning |
-|-------|-------|---------|
-| V (Verbose) | Gray | Most verbose, all messages |
-| D (Debug) | Blue | Debug messages |
-| I (Info) | Green | Informational |
-| W (Warning) | Yellow | Potential issues |
-| E (Error) | Red | Error conditions |
-| F (Fatal) | Purple | Fatal errors / crashes |
+The active device and active variant are used automatically. Click the variant pill in the status bar to change variants.
 
-### Filtering
+---
 
-The query bar supports a rich filter syntax. Simple filters (level, tag, text, package) are applied in the Rust backend before entries cross the IPC bridge — this keeps the JS thread responsive even at 1000+ lines/sec.
+## Logcat
 
-| Syntax | Example | Description |
-|--------|---------|-------------|
-| `level:X` | `level:error` | Minimum log level |
-| `tag:X` | `tag:OkHttp` | Tag substring |
-| `tag~:X` | `tag~:Ok.*Http` | Tag regex |
-| `message:X` | `message:null` | Message substring |
-| `package:X` | `package:com.example` | Package name |
-| `package:mine` | `package:mine` | Filter to the current app |
-| `age:N` | `age:5m` | Only last N seconds/minutes/hours |
-| `is:crash` | `is:crash` | Crash entries only |
-| `is:stacktrace` | `is:stacktrace` | Stack trace lines only |
-| `-tag:system` | `-tag:system` | Negate — exclude entries matching |
-| bare text | `login` | Search tag + message + package |
-| `A && B` | `level:error && tag:MyApp` | **AND** — explicit AND connector (same as space) |
-| `A \| B` | `level:error tag:MyApp \| is:crash` | **OR** — entries matching either group |
-
-Multiple tokens within a group are AND-ed together (space or `&&`). Use `|` to separate OR groups — an entry is shown if it satisfies **any** group. For example:
-
-```
-level:error && tag:MyApp | is:crash
-```
-
-Shows all error-or-above logs from `MyApp` **or** any crash entry from any process.
-
-**Building compound filters:**
-- Click **+ AND** to append `&&` to the active group (makes the AND relationship explicit).
-- Press **Enter** after typing a condition to commit it as a filter pill. If an autocomplete suggestion is highlighted, Enter accepts that suggestion first.
-- Click **+ OR** to start a new OR group with ` | `.
-- You can mix both: `tag:App && level:warn | is:crash | package:mine && age:5m`.
-- The query bar shows an **N OR** badge when multiple OR groups are active.
-- Autocomplete works independently within each group — suggestions are scoped to wherever the cursor is.
-
-### Saved Filters
-
-Use the **☰ Filters** button to manage filters:
-
-- **Quick Filters** — built-in one-click presets (My App, Crashes, Errors+, Last 5 min, and more).
-- **Saved** — your saved filters, shown with a `N / 50` count. Up to 50 filters can be saved.
-  - Click a filter name to apply it.
-  - Click **✎** to rename a filter inline (press Enter to confirm, Esc to cancel).
-  - Click **✕** to delete a filter.
-- **+ Save current filter** — saves the active query under a name you choose. If a filter with the same name already exists, it is overwritten.
-
-Your last active query is automatically restored the next time you open the Logcat panel.
-
-> **Migration**: filters saved under the old "Presets" system are automatically migrated to the new Saved Filters format on first use.
-
-### Package Filter Dropdown
-
-The second toolbar row contains a **package filter dropdown** (labelled "All packages" by default). Click it to open a searchable list of all package names that have produced log output in the current session.
-
-- **All packages** — removes the package filter and shows everything
-- **My App** — shortcut for `package:mine` (resolves to the project's `applicationId`)
-- **Individual packages** — any package name seen so far, sorted alphabetically
-- Use the search box inside the dropdown to narrow the list when many packages are present
-
-Selecting a package inserts a `package:` token into the query bar, which triggers backend-side filtering (entries from other packages are not forwarded across IPC). The dropdown reflects whatever package token is currently in the query, and editing the query bar directly keeps the dropdown in sync.
-
-### JSON Viewer
-
-When a log entry's message contains valid JSON, a `{}` badge appears on the row. Click the badge to open the **JSON Detail Panel** at the bottom of the log, which shows the JSON formatted and syntax-highlighted. Click **Copy** to copy the raw JSON, or **✕** to close the panel.
-
-### Keyboard navigation in the log list
-
-With the **Logcat** tab active (and focus not in the query bar, a text field, or the command palette), use **↑** and **↓** to move the selection between log lines. Process start/stop separator rows are skipped. The focused line shows a **thick accent bar** on the left (the same bar marks the row shown in the **Entry Detail** panel); Shift+click ranges use a lighter tint on all included rows, with the bar on the anchor row only. The list scrolls to keep the focused row in view. **Esc** closes the detail panel. Plain **click** still toggles the detail panel for the same row. While a line is selected (mouse or keyboard) or the JSON detail panel is open, new log lines do not auto-scroll the list; use **↓** in the toolbar to return to the end and resume follow-tail.
+The Logcat tab streams logs from the selected Android device.
 
 ### Controls
 
-- **Start / Stop** — Begin or end logcat streaming
-- **Pause / Resume** — Pause new entries (no data is lost, buffer continues)
-- **↓** (first toolbar row) — Jump to the latest entry and resume follow-tail. Clears row selection, JSON detail, and entry detail so new lines can auto-scroll again.
-- **Clear** — Clear the display buffer and the in-memory ring buffer
-- **Age pills** — Quick-select time window (30s, 1m, 5m, 15m, 1h, All)
-- **☰ Filters** — Open the saved filters dropdown (Quick Filters + your saved filters)
-- **↓ Export** — Save the currently filtered entries to a `.log` file
-- **⎘ N rows** — Copy multiple selected rows (Shift+click to select a range)
-- **Line count** (right side of the first toolbar row) — With a filter active, shows **`shown / ring`** (for example `50 / 1,000`): lines currently listed after all filters, then the **total lines stored in the app’s logcat ring buffer** (includes lines hidden by the stream filter and not sent to the list). With no query, a single total is shown when it matches the ring. Hover the count for details.
+- **Start / Stop**: begin or end streaming.
+- **Pause / Resume**: pause display updates without losing buffered data.
+- **Jump to end**: resume follow-tail and clear row/detail selection.
+- **Clear**: clear displayed entries and the in-memory buffer.
+- **Export**: save filtered entries to a `.log` file.
+- **Filters**: use quick filters or saved filters.
+- **Package dropdown**: show all packages, only your app, or a package seen in this session.
 
-### Ring Buffer
+### Filters
 
-The logcat ring buffer size is configurable under **Settings → Logcat → Ring buffer size** (default **50,000** entries, up to **100,000**). The oldest entries are evicted when the buffer is full. All entries since starting are kept until you click Clear. The **listed** lines in the panel are capped separately by **Max lines in Logcat** (default 20k) and cannot exceed the ring size.
+Use the query bar for targeted searches:
 
-### Crash Detection
+| Query | Meaning |
+|-------|---------|
+| `level:error` | error and fatal logs |
+| `tag:OkHttp` | tag contains `OkHttp` |
+| `message:timeout` | message contains `timeout` |
+| `package:mine` | current app package |
+| `package:com.example` | specific package |
+| `age:5m` | last five minutes |
+| `is:crash` | crash entries only |
+| `-tag:system` | exclude matching tag |
+| `level:warn tag:MyApp` | AND search |
+| `level:error | is:crash` | OR search |
 
-When a `FATAL EXCEPTION`, `AndroidRuntime` crash, ANR, or native signal crash is detected:
-- The entry is highlighted in red with a red left border
-- All consecutive lines in the same stack trace share a `crash_group_id` and get the same red indicator
-- The crash counter in the toolbar (⚡ N) increments
-- Use **↑ / ↓** beside the crash counter to navigate between crashes
-- ANR entries are highlighted in yellow with an **ANR** badge
+Press **Enter** to commit a typed condition as a filter pill. Use **+ AND** and **+ OR** for compound filters. Saved filters are capped at 50.
 
-### Entry Categories
+### Reading logs
 
-The pipeline automatically classifies entries by tag into categories (visible in filtering):
-- **Network** — OkHttp, Retrofit, Volley
-- **Lifecycle** — ActivityManager, Fragment, Application
-- **Performance** — Choreographer, SurfaceFlinger, OpenGLRenderer
-- **GC** — art, dalvikvm
-- **Database** — SQLiteDatabase, Room
+- Crash entries are highlighted and grouped.
+- ANRs get an ANR badge.
+- JSON messages show a `{}` badge; open it to view formatted JSON.
+- Arrow keys move the selected row when focus is not in the query bar.
+- Selecting a row pauses follow-tail until you jump back to the end.
 
----
-
-## 4a. Layout Panel
-
-The **Layout** tab shows the **accessibility / UI Automator** tree for whatever is on screen on the **selected device** — the same surface **UI Automator**, **TalkBack**, and MCP automation see. **Jetpack Compose** is primary: composables draw a **semantics** tree that merges into this view (not the full composable call tree). **Android Views / XML** appear as usual when not using Compose.
-
-### How to use
-
-1. Select an **online** device in the **Devices** sidebar (right).
-2. Open the **Layout** tab (**Cmd+4**).
-3. Click **Refresh**. Keynobi runs official **platform-tools** commands: `dumpsys activity activities`, capped excerpts from **`dumpsys window windows`**, **`dumpsys display`**, **`wm size`**, **`wm density`**, then **`uiautomator dump`** (tries **`--compressed`** first when the device supports it, then plain dump and file fallbacks). The XML is parsed into a tree.
-
-### Toolbar
-
-- **Refresh** — Capture the current hierarchy (snapshot; not live video).
-- **Interactive only** — Hide branches that are not clickable/scrollable/editable and do not carry text or content description (similar to automation “actionable” lists). Parent rows may show a short **inherited** snippet from a descendant so clickable Compose groups stay readable.
-- **Hide boilerplate** — Collapse long chains of single-child, same-bounds, empty wrappers (sibling-safe: parallel subtrees like status bar vs content stay separate).
-- **Filter** — Narrow the tree by substring in class, resource id, text, content description, or package. **Prev / Next** steps through matches and expands the path to each hit.
-- **Expand all / Collapse all** — Control disclosure state. Default expansion depth scales with tree size (deeper on smaller dumps).
-
-### Tree and detail
-
-- The **left column** is a **wireframe** (SVG) in **device pixel** coordinates: every node with valid bounds is drawn as a rectangle, using the same filtered tree as the list (interactive only, hide boilerplate, search). **Click a region** to select that node: the **tree expands only along the path** from the root to that row (ancestors open; the node’s own subtree stays collapsed unless you expand it or shallow auto-expand applies), then **scrolls** the row into view, highlights it, and updates the **detail** panel. Overlapping rects prefer the **smallest** containing hit (so nested controls win). Very large trees may show only the first **2000** rects (a short notice appears); refine filters to reduce count.
-- Rows show **class**, a **resource-id** chip (when present), **text** and **content-desc** previews, bounds with **width×height**, and badges such as **minified** (short obfuscated class names), **merged target** (typical Compose tap parent), **selected** (e.g. tab), and **Compose** where applicable. The dominant **package** for the dump is shown under the toolbar; it is omitted on rows when it matches, to reduce noise.
-- Click a row to select it; the **right-hand detail** panel lists every field (full class, id, text, descriptions, flags) and offers **Copy bounds**, **Copy id**, **Copy summary**, and **Find parent** (selects the **direct parent** of the current row in the displayed tree—the node one level up; disabled on the display root). Accessibility flags in dumps are not always accurate (for example, some `HorizontalScrollView` nodes report `scrollable=false`); use them as hints.
-
-### Metadata
-
-Below the tree, Keynobi shows capture time, a **screen hash** (for comparing whether the screen changed), interactive node count, parser **warnings**, and a best-effort **foreground activity** line from `dumpsys activity activities` when available. The same refresh still records capped window/display/`wm` excerpts on the snapshot (for MCP and other tooling); they are **not** shown in this panel.
-
-At the **bottom of the Layout panel**, after a successful refresh, Keynobi lists **ADB commands (this capture)** — every `adb -s …` line run for that refresh so you can paste them into a terminal.
-
-### Deeper inspection (debuggable apps, Compose-first)
-
-The Layout tab is the right default for **automation-aligned** trees. It does **not** replace Android Studio’s **full composable / modifier** view.
-
-- **Semantics and stable ids** — Follow [Semantics in Compose](https://developer.android.com/develop/ui/compose/accessibility/semantics): `Modifier.testTag`, `testTagsAsResourceId` (for `resource-id` in dumps), `contentDescription`, and custom `Modifier.semantics` where needed. See also [Inspect and debug (Compose accessibility)](https://developer.android.com/develop/ui/compose/accessibility/inspect-debug).
-- **Layout Inspector (Android Studio)** — For **debuggable** builds, use [Layout Inspector](https://developer.android.com/studio/debug/layout-inspector) for composable parameters, semantics properties (e.g. hidden from accessibility), and recompositions. Studio can enable **view attribute inspection** via the global setting below.
-- **View attribute inspection (optional, terminal)** — On a device or emulator: `adb shell settings put global debug_view_attributes 1` (and `0` or `delete` to turn off). This is primarily for **Layout Inspector** and richer **View** metadata on **debuggable** processes; impact on `uiautomator dump` XML varies by OS and app—treat any extra fields as a bonus, not a guarantee.
-- **Semantics text via tests (terminal)** — Run instrumented UI tests from your project, for example `./gradlew :app:connectedDebugAndroidTest`, and use `ComposeTestRule.onRoot().printToLog("tag")` (or similar) so the **semantics tree** is printed to **logcat**—official AndroidX testing, useful when the XML snapshot is not enough.
-
-**Reference:** the `uiautomator` shell command is part of the platform ([AOSP `cmds/uiautomator`](https://github.com/aosp-mirror/platform_frameworks_base/tree/master/cmds/uiautomator)); **adb** only transports it ([adb module](https://android.googlesource.com/platform/packages/modules/adb/+/refs/heads/main)). For a broad menu of other official-style `adb` / `dumpsys` / `logcat` ideas (validate on your API level), see the community gist [Adb useful commands](https://gist.github.com/Pulimet/5013acf2cd5b28e55036c82c91bd56d8).
-
-### Limitations
-
-- **Snapshot only** — the UI may change between refreshes; rapid polling can occasionally fail or return empty dumps.
-- **Compose vs composables** — You see **merged semantics** as exposed to accessibility, not every composable or internal modifier chain. Shallow trees are normal when children merge.
-- **`FLAG_SECURE`** — can hide or obscure content from accessibility dumps.
+Logcat keeps a bounded ring buffer. Configure the ring size and max visible lines under **Settings -> Logcat**.
 
 ---
 
-## 5. Devices Sidebar
+## Layout Viewer
 
-The **Devices** sidebar on the right lists connected physical devices and available emulators. **Cmd+3** toggles this sidebar open and closed.
+The Layout tab captures the current UI hierarchy from the selected device using UI Automator. It shows the same accessibility surface used by TalkBack and automation tools, including Jetpack Compose semantics.
 
-### Physical Devices
+Basic flow:
 
-- Devices connected via USB appear automatically (polled every 2 seconds)
-- The device serial, model name, API level, and connection state are shown
-- Click a device row to select it as the active deployment target
+1. Select an online device.
+2. Open **Layout** with `Cmd+4`.
+3. Click **Refresh**.
+4. Click a wireframe region or tree row to inspect details.
 
-### Emulators (AVDs)
+Useful controls:
 
-- Available AVDs from `~/.android/avd/` are listed
-- **Launch** — Start an emulator from its AVD name
-- **Stop** — Terminate a running emulator
-- Emulators appear in both the AVD list and the physical device list once running
+- **Interactive only**: focus on actionable nodes.
+- **Hide boilerplate**: collapse wrapper chains.
+- **Filter**: search class, resource id, text, content description, or package.
+- **Prev / Next**: move between matches.
+- **Expand all / Collapse all**: control tree disclosure.
+- **Find parent**: jump from the selected row to its direct parent.
 
-### Device Selection
+The panel also shows capture time, screen hash, interactive node count, parser warnings, foreground activity when available, and the ADB commands used for the capture.
 
-The selected device is used for installs and launches from the Build panel. When no suitable device is available, the app may prompt you to pick one. Device choice is not shown as a separate pill on the status bar—use the Devices sidebar (or the picker when prompted).
+Notes:
 
----
-
-## 6. Status Bar
-
-The status bar at the bottom shows (left to right on the main strip, then indicators on the right):
-
-| Item | Description |
-|------|-------------|
-| ⚙ | Settings gear — click to open settings |
-| Project name | Name of the open Android project (or app name when none is open) |
-| Health | App health indicator — click to open Health Center |
-| Build status | Current or last build — click to switch to the Build tab |
-| MCP | MCP integration — click to open the MCP activity panel (setup, copy command, activity log) |
-| Update | New Keynobi version indicator — click to open the GitHub release download page |
-| Variant pill | Active build variant (when a project is open) — click to change |
-| App memory | Approximate app memory use (right side) |
-| Log folder size | Log folder size vs configured cap (right side); tooltip shows rotation when applicable |
-
-### Update Notification
-
-On startup, Keynobi checks the latest GitHub release at `thiagodmont/keynobi`. When a newer version is available, a modal offers **Download** or **Later**. **Download** opens the GitHub release page. **Later** dismisses that release's modal permanently, but the status bar still shows the update indicator so you can open the release page later.
+- The Layout tab is a snapshot, not a live video.
+- Compose output is the merged semantics tree, not every composable or modifier.
+- `FLAG_SECURE` screens may hide or obscure content.
+- For full Compose internals, use Android Studio Layout Inspector on debuggable builds.
 
 ---
 
-## 7. Settings
+## Devices
 
-Open Settings with **Cmd+,** or the gear icon in the status bar.
+The Devices sidebar lists physical devices and emulators. Toggle it with `Cmd+3`.
 
-### Android SDK
+Physical devices show serial, model, API level, and connection state. Click a row to make it the active deploy target.
 
-Set the path to your Android SDK installation. This is required for:
-- ADB device communication
-- Emulator launching
-- Health checks
+Emulators can be launched and stopped from the sidebar. Running emulators also appear in the connected-device list once ADB sees them.
 
-Use **Auto-detect** to find the SDK from your shell environment.
-
-### Java / JDK
-
-Set the path to your JDK installation. Required for Gradle builds.
-
-Use **Auto-detect** to find Java from your shell environment.
-
-### Logcat
-
-- **Auto-start on connect** — Start logcat streaming when a device connects (on by default).
-- **Auto-scroll Logcat to end** — When on (default), the Logcat tab opens with follow-tail enabled so new lines scroll into view. Follow-tail pauses automatically while a log line is selected, while the JSON detail panel is open, or when you scroll away from the bottom; use the **↓** control in the Logcat toolbar to jump to the end and resume. You can still pause follow-tail from that toolbar at any time.
-- **Ring buffer size** — How many lines the app stores in the in-memory capture ring before the oldest are dropped (default **50,000**, range **1,000**–**100,000**). Changing it applies immediately after settings save.
-- **Max lines in Logcat** — How many lines the Logcat tab keeps in the UI list and requests when loading from the capture buffer (default **20,000**). It cannot exceed the ring buffer size.
-
-### Advanced (Build)
-
-Under **Settings → Advanced**, the **Build** section includes **Auto-scroll build log to end** (on by default), which sets the initial follow-tail state for the Build log tab. The log toolbar **↓** still toggles follow-tail for the current session.
-
-### Build Settings (persisted automatically)
-
-- **Last-used variant** — restored on next launch
-- **Last-used device serial** — restored on next launch
-
-### Telemetry (crash reporting)
-
-Under **Privacy**, **Anonymous crash reporting** is **off** by default. When enabled, the app may send **minimal, non-identifying** crash reports from the **native** layer and the **UI** (for example, panic and UI error summaries with paths stripped) to help fix bugs. It does **not** send your Android project files, Gradle log content, logcat, MCP traffic, or personal identifiers. Changing the toggle applies fully after **restart** (same as in the setup wizard).
+If no suitable device is selected during a run, Keynobi may ask you to choose one.
 
 ---
 
-## 8. Health Center
+## Settings and Health
 
-Open the Health Center with **Cmd+Shift+H** or by clicking the Health indicator in the status bar.
+Open Settings with `Cmd+,` or the gear icon.
 
-The Health Center checks:
+Important settings:
 
-| Check | What it verifies |
-|-------|-----------------|
-| Android SDK | Path exists and contains `platforms/` or `platform-tools/` |
-| ADB | Found in `$ANDROID_HOME/platform-tools/` or PATH |
-| Emulator | Found in `$ANDROID_HOME/emulator/` |
-| Java / JDK | `java -version` exits successfully |
-| Gradle Wrapper | `gradlew` exists at the project root |
-| Disk Space | Free space in `~/.keynobi/` |
-| App Directory | `~/.keynobi/` is writable |
+- **Android SDK Path**: required for ADB, emulator support, and health checks.
+- **Java Home**: required for Gradle builds.
+- **Logcat auto-start** and **follow-tail** behavior.
+- **Logcat ring buffer size** and visible line cap.
+- **Build log follow-tail** behavior.
+- **Anonymous crash reporting**.
 
-Click **Refresh** to re-run all checks.
+Open Health Center with `Cmd+Shift+H` or the Health status item.
 
----
+Health checks include:
 
-## 9. Keyboard Shortcuts
-
-| Shortcut | Action |
-|----------|--------|
-| **Cmd+O** | Open / add Android project folder |
-| **Cmd+R** | Run App (build → install → launch) |
-| **Cmd+Shift+R** | Build Only (no deploy) |
-| **Cmd+Shift+V** | Select Build Variant |
-| **Cmd+1** | Open Build tab |
-| **Cmd+2** | Open Logcat tab |
-| **Cmd+4** | Open Layout tab |
-| **Cmd+3** | Toggle Device Sidebar |
-| **Cmd+B** | Toggle Project Sidebar |
-| **Cmd+,** | Open Settings |
-| **Cmd+Shift+W** | Open Setup Wizard |
-| **Cmd+Shift+H** | Open Health Center |
-| **Cmd+Shift+M** | Open MCP Activity Panel |
-| **Cmd+Shift+P** | Command Palette |
-
-**Command Palette actions** (Cmd+Shift+P, then type):
-- `Open Setup Wizard` — environment paths, privacy, and workflow defaults
-- `Project App Info` — open the version name/code editor
-- `Open Folder` — browse for a new project
-- `Cancel Build` — stop the current Gradle run
-- `Clean Project` — run `./gradlew clean`
-- `Manage Virtual Devices` — toggle the Device Sidebar
-- `Copy MCP Setup Command` — copy the `claude mcp add …` line (uses this app’s real binary path)
+- Android SDK
+- ADB
+- Emulator
+- Java / JDK
+- Gradle wrapper
+- Disk space
+- App data directory
+- MCP setup command
 
 ---
 
-## 10. Claude Code Integration
+## Claude Code MCP
 
-Keynobi exposes an **MCP server** that Claude Code can connect to. This lets Claude Code:
-- Trigger builds and read structured errors
-- Read logcat output and crash logs
-- Manage devices, install APKs, and launch apps
-- List and switch build variants
-- Run health checks and query project info
+Keynobi includes an MCP server so Claude Code can use real app state instead of guessing.
 
-### Setup
+Claude can:
 
-**Option A — Headless mode (recommended for Claude Code)**
+- Run Gradle tasks and read structured build errors.
+- Read logcat and crash logs.
+- Inspect devices and app runtime state.
+- Install, launch, stop, and restart apps.
+- Inspect the UI hierarchy and perform UI automation.
+- Run health checks and query project information.
 
-The app binary can run as a headless MCP server with no GUI window. Register it once with Claude Code using the **exact path** to the installed binary (the Health Center shows the command with your real path). A typical install location looks like:
+### Recommended setup
+
+Use the command copied from **Health Center** or **Copy MCP Setup Command** in the Command Palette. It includes the correct local app path.
+
+Typical command:
 
 ```bash
 claude mcp add --transport stdio keynobi -- "/Applications/Keynobi.app/Contents/MacOS/keynobi" --mcp
 ```
 
-Always prefer the command copied from **Health Center** (Cmd+Shift+H) or **Copy MCP Setup Command** in the command palette—paths vary by machine and install location.
-
-The MCP server uses whichever Android project is currently open in Keynobi. No extra configuration is needed — open your project in the app and the MCP session will see it.
-
-To override and point at a specific project regardless of what the app has open, append `--project`:
+To bind MCP to a specific Android project:
 
 ```bash
 claude mcp add --transport stdio keynobi -- "/Applications/Keynobi.app/Contents/MacOS/keynobi" --mcp --project /path/to/MyAndroidProject
 ```
 
-**Option B — GUI mode**
-
-1. Open Keynobi and load your project
-2. Use **Cmd+Shift+M** or click the **MCP** pill in the status bar to open the MCP panel
-3. Run **Copy MCP Setup Command** from the command palette (Cmd+Shift+P) and paste the line in your terminal to register with Claude Code, or copy the same command from **Health Center** (Cmd+Shift+H)
-4. The MCP pill updates to reflect server/client state (see [MCP Status Indicator](#mcp-status-indicator) below)
-
-### Available MCP Tools
-
-| Tool | Description |
-|------|-------------|
-| `run_gradle_task` | Run a Gradle task (e.g. `assembleDebug`), returns result + structured errors |
-| `get_build_status` | Current build status (idle, running, success, failed, cancelled) |
-| `get_build_errors` | Structured compiler errors and warnings from the last build (JSON) |
-| `get_build_log` | Raw Gradle output lines (last N lines, capped) |
-| `cancel_build` | Cancel the running Gradle build |
-| `list_build_variants` | List variants and active variant (JSON) |
-| `set_active_variant` | Set the active build variant (persists in settings) |
-| `find_apk_path` | Output APK path for a variant after a build |
-| `get_build_config` | Parse `build.gradle(.kts)` for SDK levels, `applicationId`, build types, flavors (no Gradle run) |
-| `run_tests` | Run unit tests (`testDebug`), connected tests, or a custom test task |
-| `get_crash_stack_trace` | Parsed crash from logcat buffer (frames, caused-by); needs logcat streaming |
-| `restart_app` | Force-stop or clear data, relaunch, wait for display |
-| `get_app_runtime_state` | Processes, threads, RSS for an app package |
-| `start_logcat` | Start logcat streaming (required in headless mode before reads) |
-| `stop_logcat` | Stop the logcat stream |
-| `get_logcat_entries` | Recent logcat entries with filters (JSON) |
-| `get_crash_logs` | FATAL EXCEPTION, ANR, and native crash entries (JSON) |
-| `clear_logcat` | Clear the in-memory logcat buffer |
-| `get_logcat_stats` | Logcat statistics (counts by level, crashes, packages) |
-| `list_devices` | Connected ADB devices (JSON) |
-| `get_ui_hierarchy` | Focused window UI tree from UI Automator (full JSON, or `interactive_only` for compact rows) |
-| `find_ui_elements` | Fresh dump + search by text, content-desc, resource-id, class, or package; returns `treePath`, bounds, `centerX`/`centerY`, flags, and `screenHash` (needs at least one primary filter) |
-| `list_clickable_elements` | Fresh dump + all clickable tap targets; returns `treePath`, bounds, centers, flags, and `screenHash` |
-| `find_ui_parent` | Given a non-empty `treePath` from `find_ui_elements` or the Layout tab, returns the **direct parent** node (same match shape: `treePath`, bounds, centers, flags) plus `screenHash`; optional `expect_screen_hash` like `ui_tap` |
-| `ui_tap` | Tap device pixel coordinates (use centers from `find_ui_elements`); optional `expect_screen_hash` to refuse if the UI changed |
-| `ui_tap_element` | Tap by `treePath`; fresh-dumps the hierarchy and resolves the current center before tapping |
-| `ui_fill_input` | Focus an editable input by `treePath` or coordinates, clear it by default, then type ASCII text |
-| `ui_type_text` | Low-level `adb shell input text` after optional tap to focus; ASCII-oriented (no emoji); optional `expect_screen_hash` |
-| `hide_soft_keyboard` | Hide the Android soft keyboard; checks visibility first so Back is not sent when the keyboard is already hidden |
-| `ui_swipe` | Swipe or long-press (`duration_ms`, same start/end) in device pixels |
-| `ui_scroll_until_element` | Swipe repeatedly until an element matching text/id/content-desc/class/package appears |
-| `ui_wait_for_idle` | Poll `screenHash` until the focused UI stops changing |
-| `ui_assert_element` | Assert element presence or state (`enabled`, `clickable`, `focused`, `checked`, `selected`, etc.) |
-| `send_ui_key` | Allowlisted keyevent (Back, Home, Enter, Delete, Tab, D-pad, Menu, AppSwitch, …) |
-| `open_deep_link` | Open a URI with Android intent resolution, optionally constrained to an app package |
-| `open_app_settings` | Open Android settings for an app package (`appInfo`, `permissions`, or `notifications`) |
-| `set_device_orientation` | Set portrait/landscape/reverse orientation or return to auto-rotate |
-| `set_network_state` | Best-effort Wi-Fi, mobile data, and airplane-mode toggles with per-command results |
-| `grant_runtime_permission` | `pm grant` for `android.permission.*` on a package |
-| `revoke_runtime_permission` | `pm revoke` for `android.permission.*` on a package |
-| `screenshot` | Capture a screenshot (inline image) |
-| `get_device_info` | SDK level, model, screen, battery |
-| `dump_app_info` | App version, install path, activities |
-| `get_memory_info` | Memory breakdown (PSS, heap, native, graphics) |
-| `install_apk` | Install an APK (path-validated) |
-| `launch_app` | Launch an app (`am start`) |
-| `stop_app` | Force-stop an app |
-| `list_avds` | List AVDs (JSON) |
-| `launch_avd` | Start an emulator |
-| `stop_avd` | Stop a running emulator |
-| `get_project_info` | Project name, path, Gradle root |
-| `run_health_check` | Java, SDK, ADB, Gradle wrapper, disk, app dir (JSON) |
-
-### MCP Prompts
-
-Three built-in prompts wire multiple tools together:
-
-| Prompt | Description |
-|--------|-------------|
-| `diagnose-crash` | Fetches crash logs, memory, and app info for root-cause analysis |
-| `full-deploy` | Builds, finds APK, installs, and launches in one workflow |
-| `build-and-fix` | Runs build and explains each error with suggested fixes |
-
-### MCP Resources
-
-The server exposes project files as readable resources:
-
-- `android://manifest` — AndroidManifest.xml
-- `android://app-build-gradle` — app/build.gradle.kts
-- `android://build-gradle` — root build.gradle.kts
-- `android://gradle-settings` — settings.gradle.kts
-- `android://project-info` — project name and path
-
-### Workflow Example
-
-1. Ask Claude Code: *"Build the app and show me any errors"*
-2. Claude calls `get_project_info()` to verify the project is open
-3. Claude calls `run_gradle_task("assembleDebug")`
-4. Claude calls `get_build_errors()` and explains the issues
-5. You fix in your editor
-6. Ask Claude: *"Run it on the connected emulator"*
-7. Claude calls `list_devices()` to pick a device, then `install_apk()` and `launch_app()`
-
-For **UI automation**, use `find_ui_elements` to locate controls, then `ui_tap` on the returned centers. Use **`find_ui_parent`** with a match’s `treePath` to walk up one level in the same tree as the Layout viewer (repeat to reach an ancestor container). Pass `screenHash` from the find result into `expect_screen_hash` on tap/type when you need to avoid acting on a stale screen. `ui_type_text` is limited by what `adb input text` supports (mostly ASCII).
-
-### MCP Status Indicator
-
-The status bar shows an **MCP** pill:
-- **Dim** when idle (no server process or client activity detected)
-- **Info (blue)** when an MCP server process is alive (stdio transport)
-- **Warning (amber)** when the GUI believes a server run is in progress
-- **Success (green)** when a client (e.g. Claude Code) is connected — the pill may show the client name
-- **Click** opens the MCP activity panel (setup, copied command reminder, activity log)
-
-The **Health Center** (Cmd+Shift+H) shows MCP integration status and the exact `claude mcp add` command with your real binary path.
+Exact tools, prompts, and resources are discoverable from the MCP client. In Keynobi, the MCP Activity panel shows setup status and recent tool activity.
 
 ---
 
-## 11. Theme and colors
+## Keyboard Shortcuts
 
-The app uses **CSS variables** in `src/styles/theme.css` (backgrounds, text, borders, and **semantic** colors: success, error, warning, info). Build status, device connection state, log levels, logcat chips, and status-bar indicators draw from these tokens so the UI stays consistent. Toolbar icon buttons use the shared **IconButton** control; destructive actions in menus use a dedicated **destructive** style where applicable.
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+Shift+P` | Command Palette |
+| `Cmd+Shift+W` | Setup Wizard |
+| `Cmd+,` | Settings |
+| `Cmd+O` | Open / add project folder |
+| `Cmd+R` | Run App: build, install, launch |
+| `Cmd+Shift+R` | Build only |
+| `Cmd+Shift+V` | Select build variant |
+| `Cmd+1` | Build tab |
+| `Cmd+2` | Logcat tab |
+| `Cmd+3` | Toggle Devices sidebar |
+| `Cmd+4` | Layout tab |
+| `Cmd+B` | Toggle Projects sidebar |
+| `Cmd+Shift+H` | Health Center |
+| `Cmd+Shift+M` | MCP Activity panel |
+
+Useful Command Palette actions:
+
+- Open Setup Wizard
+- Project App Info
+- Open Folder
+- Cancel Build
+- Clean Project
+- Manage Virtual Devices
+- Copy MCP Setup Command
+
+---
+
+## Troubleshooting
+
+### No devices appear
+
+- Confirm `adb devices` works in a terminal.
+- Check Android SDK Path in Settings.
+- For USB devices, confirm USB debugging is enabled and trusted.
+
+### Build fails immediately
+
+- Open Health Center and check Java, SDK, Gradle wrapper, and disk space.
+- Confirm the selected project has a `gradlew` wrapper.
+- Try **Clean Project** from the Command Palette.
+
+### Logcat is empty
+
+- Select an online device.
+- Press **Start** in the Logcat toolbar.
+- Clear restrictive filters such as package, age, or crash-only.
+
+### Layout capture fails
+
+- Confirm the device is online and unlocked.
+- Open the screen you want to inspect, then click **Refresh**.
+- Some secure screens or OS states may return partial or empty dumps.
+
+### MCP cannot connect
+
+- Copy the setup command from Health Center again.
+- Confirm the app path in the command exists.
+- If using `--project`, confirm the folder exists and contains the Android project.

--- a/src-tauri/src/commands/logcat.rs
+++ b/src-tauri/src/commands/logcat.rs
@@ -71,7 +71,7 @@ pub async fn get_logcat_entries(
     logcat_state: State<'_, LogcatState>,
 ) -> Result<Vec<ProcessedEntry>, String> {
     let filter = LogcatFilter::new(
-        min_level.as_deref().map(parse_level),
+        min_level.as_deref().map(logcat::parse_level_str),
         tag,
         text,
         package,
@@ -140,21 +140,6 @@ pub async fn get_logcat_stats(logcat_state: State<'_, LogcatState>) -> Result<Lo
     let cap = state.store.capacity().max(1) as f32;
     stats.buffer_usage_pct = (len as f32 / cap) * 100.0;
     Ok(stats)
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-fn parse_level(s: &str) -> crate::models::logcat::LogcatLevel {
-    use crate::models::logcat::LogcatLevel;
-    match s.to_uppercase().as_str() {
-        "V" | "VERBOSE" => LogcatLevel::Verbose,
-        "D" | "DEBUG" => LogcatLevel::Debug,
-        "I" | "INFO" => LogcatLevel::Info,
-        "W" | "WARN" | "WARNING" => LogcatLevel::Warn,
-        "E" | "ERROR" => LogcatLevel::Error,
-        "F" | "FATAL" | "A" | "ASSERT" => LogcatLevel::Fatal,
-        _ => LogcatLevel::Verbose,
-    }
 }
 
 pub fn new_logcat_state() -> LogcatState {

--- a/src-tauri/src/services/log_pipeline.rs
+++ b/src-tauri/src/services/log_pipeline.rs
@@ -167,7 +167,7 @@ impl LogPipeline {
     /// Callers provide the target buffer so it can be pre-allocated or reused.
     pub fn run_batch_into(
         &self,
-        rx: &mut tokio::sync::mpsc::UnboundedReceiver<RawLogLine>,
+        rx: &mut tokio::sync::mpsc::Receiver<RawLogLine>,
         ctx: &mut PipelineContext,
         out: &mut Vec<ProcessedEntry>,
     ) {

--- a/src-tauri/src/services/logcat.rs
+++ b/src-tauri/src/services/logcat.rs
@@ -1,10 +1,11 @@
 use crate::models::logcat::{LogcatFilterSpec, LogcatLevel, ProcessedEntry};
-use crate::services::log_pipeline::{parse_logcat_line, LogPipeline, PipelineContext};
+use crate::services::log_pipeline::{parse_logcat_line, LogPipeline, PipelineContext, RawLogLine};
 use crate::services::log_store::LogStore;
 use crate::services::log_stream::StreamState;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tauri::Emitter;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, warn};
@@ -204,6 +205,12 @@ pub fn find_adb_binary(sdk_path: Option<&str>) -> PathBuf {
 /// JSON payload so the JS thread is never blocked deserializing a huge message.
 pub const MAX_BATCH_SIZE: usize = 500;
 
+/// Maximum raw lines waiting between the reader and processing tasks.
+///
+/// This keeps a bursty logcat stream from growing memory without bound if the
+/// processing task or frontend event emission temporarily falls behind.
+pub const RAW_LOG_LINE_CHANNEL_CAPACITY: usize = 10_000;
+
 /// How long to wait before reconnecting after an unexpected ADB disconnect.
 /// Short in tests so the reconnect loop runs fast without sleeping 1.5 s.
 #[cfg(not(test))]
@@ -265,6 +272,44 @@ pub fn parse_ps_output(text: &str) -> HashMap<i32, String> {
     map
 }
 
+fn store_and_filter_processed_entries(
+    state: &mut LogcatStateInner,
+    ctx: &mut PipelineContext,
+    processed: Vec<ProcessedEntry>,
+) -> Vec<ProcessedEntry> {
+    if !ctx.new_packages.is_empty() {
+        for pkg in ctx.new_packages.drain(..) {
+            state.known_packages.insert(pkg);
+        }
+        state.store.stats.packages_seen = state.known_packages.len();
+    }
+
+    let filter = state.stream_state.clone_filter();
+    let mut to_emit: Vec<ProcessedEntry> = Vec::with_capacity(processed.len().min(MAX_BATCH_SIZE));
+
+    for entry in processed {
+        let passes = filter.as_ref().is_none_or(|f| f.matches(&entry));
+        if passes {
+            to_emit.push(entry.clone());
+        }
+        state.store.push(entry);
+    }
+
+    to_emit
+}
+
+fn emit_entry_batches(app_handle: Option<&tauri::AppHandle>, entries: &[ProcessedEntry]) {
+    let Some(handle) = app_handle else {
+        return;
+    };
+
+    for chunk in entries.chunks(MAX_BATCH_SIZE) {
+        if let Err(e) = handle.emit("logcat:entries", chunk) {
+            warn!("Failed to emit logcat batch: {}", e);
+        }
+    }
+}
+
 /// Spawn an `adb logcat` process, parse lines through the processing pipeline,
 /// store them in the LogStore, and stream filtered batches to the frontend.
 ///
@@ -295,8 +340,6 @@ pub async fn start_logcat_stream(
     logcat_state: LogcatState,
     app_handle: Option<tauri::AppHandle>,
 ) {
-    use tauri::Emitter;
-
     'reconnect: loop {
         // Check whether a graceful stop was requested before (re)connecting.
         {
@@ -343,7 +386,7 @@ pub async fn start_logcat_stream(
         };
 
         // Channel: reader → pipeline+batcher
-        let (tx, mut rx) = mpsc::unbounded_channel::<crate::services::log_pipeline::RawLogLine>();
+        let (tx, mut rx) = mpsc::channel::<RawLogLine>(RAW_LOG_LINE_CHANNEL_CAPACITY);
 
         // ── Reader task ──────────────────────────────────────────────────────────
         // Parses raw lines only — zero state access, zero mutex.
@@ -354,7 +397,10 @@ pub async fn start_logcat_stream(
                 match reader.next_line().await {
                     Ok(Some(line)) => {
                         if let Some(raw) = parse_logcat_line(&line) {
-                            let _ = tx.send(raw);
+                            if tx.send(raw).await.is_err() {
+                                debug!("logcat pipeline receiver closed");
+                                break;
+                            }
                         }
                     }
                     Ok(None) => {
@@ -430,40 +476,12 @@ pub async fn start_logcat_stream(
                     // instead of 100 %.
                     let to_emit = {
                         let mut state = logcat_state.lock().await;
-
-                        // Sync newly discovered packages into state (drain buffer).
-                        if !ctx.new_packages.is_empty() {
-                            for pkg in ctx.new_packages.drain(..) {
-                                state.known_packages.insert(pkg);
-                            }
-                            state.store.stats.packages_seen = state.known_packages.len();
-                        }
-
-                        let filter = state.stream_state.clone_filter();
-                        let mut to_emit: Vec<ProcessedEntry> =
-                            Vec::with_capacity(processed.len().min(MAX_BATCH_SIZE));
-
-                        for entry in processed {
-                            // Clone only if this entry will be emitted.
-                            let passes = filter.as_ref().is_none_or(|f| f.matches(&entry));
-                            if passes {
-                                to_emit.push(entry.clone());
-                            }
-                            state.store.push(entry); // move into store — zero clone
-                        }
-
-                        to_emit
+                        store_and_filter_processed_entries(&mut state, &mut ctx, processed)
                         // Lock dropped here.
                     };
 
                     // Emit the filtered entries in chunks of MAX_BATCH_SIZE.
-                    for chunk in to_emit.chunks(MAX_BATCH_SIZE) {
-                        if let Some(ref handle) = app_handle {
-                            if let Err(e) = handle.emit("logcat:entries", chunk) {
-                                warn!("Failed to emit logcat batch: {}", e);
-                            }
-                        }
-                    }
+                    emit_entry_batches(app_handle.as_ref(), &to_emit);
                 }
 
                 // Exit once the channel is closed (reader task finished).
@@ -474,30 +492,9 @@ pub async fn start_logcat_stream(
                     if !remaining.is_empty() {
                         let to_emit = {
                             let mut state = logcat_state.lock().await;
-                            if !ctx.new_packages.is_empty() {
-                                for pkg in ctx.new_packages.drain(..) {
-                                    state.known_packages.insert(pkg);
-                                }
-                                state.store.stats.packages_seen = state.known_packages.len();
-                            }
-                            let filter = state.stream_state.clone_filter();
-                            let mut to_emit = Vec::with_capacity(remaining.len());
-                            for entry in remaining {
-                                let passes = filter.as_ref().is_none_or(|f| f.matches(&entry));
-                                if passes {
-                                    to_emit.push(entry.clone());
-                                }
-                                state.store.push(entry);
-                            }
-                            to_emit
+                            store_and_filter_processed_entries(&mut state, &mut ctx, remaining)
                         };
-                        for chunk in to_emit.chunks(MAX_BATCH_SIZE) {
-                            if let Some(ref handle) = app_handle {
-                                if let Err(e) = handle.emit("logcat:entries", chunk) {
-                                    warn!("Failed to emit final logcat batch: {}", e);
-                                }
-                            }
-                        }
+                        emit_entry_batches(app_handle.as_ref(), &to_emit);
                     }
                     break;
                 }
@@ -779,6 +776,54 @@ PID NAME
             None,
             false,
         )));
+    }
+
+    #[test]
+    fn store_and_filter_processed_entries_stores_all_and_emits_matches() {
+        let mut state = LogcatStateInner::new();
+        state.stream_state.set_filter(Some(LogcatFilter::new(
+            Some(LogcatLevel::Error),
+            None,
+            None,
+            None,
+            false,
+        )));
+
+        let mut ctx = PipelineContext::new();
+        ctx.new_packages.push("com.example.app".into());
+
+        let emitted = store_and_filter_processed_entries(
+            &mut state,
+            &mut ctx,
+            vec![
+                entry(
+                    1,
+                    LogcatLevel::Info,
+                    "MainActivity",
+                    "startup",
+                    Some("com.example.app"),
+                    false,
+                ),
+                entry(
+                    2,
+                    LogcatLevel::Error,
+                    "MainActivity",
+                    "crash",
+                    Some("com.example.app"),
+                    false,
+                ),
+            ],
+        );
+
+        assert_eq!(state.store.len(), 2, "all entries should be stored");
+        assert_eq!(emitted.len(), 1, "only matching entries should be emitted");
+        assert_eq!(emitted[0].id, 2);
+        assert!(
+            ctx.new_packages.is_empty(),
+            "new packages should be drained"
+        );
+        assert!(state.known_packages.contains("com.example.app"));
+        assert_eq!(state.store.stats.packages_seen, 1);
     }
 
     // ── Ring buffer stress tests ──────────────────────────────────────────────

--- a/src-tauri/src/services/logcat.rs
+++ b/src-tauri/src/services/logcat.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::Emitter;
 use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, error, warn};
 
@@ -315,7 +316,7 @@ fn emit_entry_batches(app_handle: Option<&tauri::AppHandle>, entries: &[Processe
 ///
 /// Architecture (two tasks):
 ///
-///   ┌─────────────────────┐     mpsc::unbounded     ┌───────────────────────────┐
+///   ┌─────────────────────┐      bounded mpsc       ┌───────────────────────────┐
 ///   │  reader task        │ ──── RawLogLine ────────► │  pipeline + batcher task  │
 ///   │  (parse lines only) │                          │  (enrich → store → emit)  │
 ///   └─────────────────────┘                          └───────────────────────────┘
@@ -397,9 +398,17 @@ pub async fn start_logcat_stream(
                 match reader.next_line().await {
                     Ok(Some(line)) => {
                         if let Some(raw) = parse_logcat_line(&line) {
-                            if tx.send(raw).await.is_err() {
-                                debug!("logcat pipeline receiver closed");
-                                break;
+                            match tx.try_send(raw) {
+                                Ok(()) => {}
+                                Err(TrySendError::Full(_)) => {
+                                    debug!(
+                                        "dropping logcat line because processing channel is full"
+                                    );
+                                }
+                                Err(TrySendError::Closed(_)) => {
+                                    debug!("logcat pipeline receiver closed");
+                                    break;
+                                }
                             }
                         }
                     }

--- a/src-tauri/src/services/ui_automation.rs
+++ b/src-tauri/src/services/ui_automation.rs
@@ -1730,12 +1730,17 @@ pub async fn adb_hide_soft_keyboard(
     force: bool,
 ) -> Result<HideSoftKeyboardOutcome, String> {
     let visibility_dump_result = run_adb_shell(adb, serial, &["dumpsys", "input_method"]).await;
-    let visible = visibility_dump_result.as_ref().ok().and_then(|dump| parse_soft_keyboard_visible(dump));
+    let visible = visibility_dump_result
+        .as_ref()
+        .ok()
+        .and_then(|dump| parse_soft_keyboard_visible(dump));
 
     // If force=true or we can see the keyboard is visible, send Back to hide it
     if force || visible == Some(true) {
         // Even if we couldn't get visibility dump, still try to hide if force=true
-        let back_sent = adb_keyevent(adb, serial, resolve_ui_key_code("Back")?).await.is_ok();
+        let back_sent = adb_keyevent(adb, serial, resolve_ui_key_code("Back")?)
+            .await
+            .is_ok();
         return Ok(HideSoftKeyboardOutcome {
             keyboard_visible: visible,
             back_sent,

--- a/src/components/logcat/LogcatFilterControls.tsx
+++ b/src/components/logcat/LogcatFilterControls.tsx
@@ -1,0 +1,118 @@
+import { For, Show, type JSX } from "solid-js";
+import { QueryBar } from "@/components/logcat/QueryBar";
+import { PackageDropdown } from "@/components/logcat/PackageDropdown";
+import { btnStyle } from "./logcat-styles";
+
+export const LOGCAT_AGE_PILLS = [
+  { label: "30s", value: "30s" },
+  { label: "1m", value: "1m" },
+  { label: "5m", value: "5m" },
+  { label: "15m", value: "15m" },
+  { label: "1h", value: "1h" },
+  { label: "All", value: null },
+] as const;
+
+export type LogcatAgePillValue = (typeof LOGCAT_AGE_PILLS)[number]["value"];
+
+export function LogcatFilterControls(props: {
+  query: string;
+  knownTags: string[];
+  knownPackages: string[];
+  hasAgeFilter: boolean;
+  activeAge: string | null;
+  activePackage: string | null;
+  isFiltered: boolean;
+  onQueryChange: (query: string) => void;
+  onAgeSelect: (value: LogcatAgePillValue) => void;
+  onPackageSelect: (pkg: string | null) => void;
+  onClear: () => void;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        display: "flex",
+        "flex-wrap": "wrap",
+        "align-items": "flex-start",
+        gap: "6px",
+        padding: "5px 10px",
+        background: "var(--bg-secondary)",
+        "border-bottom": "1px solid var(--border)",
+        "flex-shrink": "0",
+      }}
+    >
+      <QueryBar
+        value={props.query}
+        onChange={props.onQueryChange}
+        knownTags={props.knownTags}
+        knownPackages={props.knownPackages}
+      />
+
+      <div style={{ display: "flex", "align-items": "center", gap: "4px", "flex-shrink": "0" }}>
+        <span
+          style={{
+            "font-size": "10px",
+            color: "var(--text-muted)",
+            "margin-right": "2px",
+            "flex-shrink": "0",
+          }}
+        >
+          Age:
+        </span>
+        <For each={LOGCAT_AGE_PILLS}>
+          {(pill) => {
+            const isActive = () =>
+              pill.value === null ? !props.hasAgeFilter : props.activeAge === pill.value;
+            return (
+              <button
+                onClick={() => props.onAgeSelect(pill.value)}
+                style={{
+                  padding: "1px 7px",
+                  "font-size": "10px",
+                  background: isActive() ? "var(--accent)" : "var(--bg-primary)",
+                  color: isActive() ? "#fff" : "var(--text-muted)",
+                  border: `1px solid ${isActive() ? "var(--accent)" : "var(--border)"}`,
+                  "border-radius": "10px",
+                  cursor: "pointer",
+                  "flex-shrink": "0",
+                  transition: "all 0.1s",
+                }}
+              >
+                {pill.label}
+              </button>
+            );
+          }}
+        </For>
+
+        <div
+          style={{
+            width: "1px",
+            height: "14px",
+            background: "var(--border)",
+            "flex-shrink": "0",
+            "margin-left": "2px",
+          }}
+        />
+
+        <PackageDropdown
+          packages={props.knownPackages}
+          selected={props.activePackage}
+          onSelect={props.onPackageSelect}
+        />
+
+        <Show when={props.isFiltered}>
+          <button
+            onClick={() => props.onClear()}
+            title="Clear all filters"
+            style={{
+              ...btnStyle("var(--text-muted)"),
+              "font-size": "10px",
+              padding: "1px 7px",
+            }}
+          >
+            ✕ Clear
+          </button>
+        </Show>
+      </div>
+    </div>
+  );
+}

--- a/src/components/logcat/LogcatJsonDetailPanel.tsx
+++ b/src/components/logcat/LogcatJsonDetailPanel.tsx
@@ -1,0 +1,115 @@
+import { createSignal, type JSX } from "solid-js";
+import type { LogcatEntry } from "@/lib/tauri-api";
+
+export function JsonDetailPanel(props: { entry: LogcatEntry; onClose: () => void }): JSX.Element {
+  const [copied, setCopied] = createSignal(false);
+
+  const formattedJson = () => {
+    try {
+      const raw = props.entry.jsonBody;
+      if (!raw) return null;
+      return JSON.stringify(JSON.parse(raw), null, 2);
+    } catch {
+      return props.entry.jsonBody;
+    }
+  };
+
+  async function copyJson() {
+    const json = formattedJson();
+    if (!json) return;
+    try {
+      await navigator.clipboard.writeText(json);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* Clipboard copy is best-effort; the button state remains unchanged. */
+    }
+  }
+
+  return (
+    <div
+      style={{
+        "flex-shrink": "0",
+        "max-height": "220px",
+        display: "flex",
+        "flex-direction": "column",
+        background: "var(--bg-secondary)",
+        "border-top": "1px solid var(--border)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "6px",
+          padding: "3px 10px",
+          background: "var(--bg-tertiary)",
+          "border-bottom": "1px solid var(--border)",
+          "flex-shrink": "0",
+        }}
+      >
+        <span style={{ "font-size": "10px", color: "var(--info)", "font-weight": "600" }}>
+          JSON
+        </span>
+        <span
+          style={{
+            "font-size": "10px",
+            color: "var(--text-muted)",
+            flex: "1",
+            overflow: "hidden",
+            "text-overflow": "ellipsis",
+            "white-space": "nowrap",
+          }}
+        >
+          {props.entry.tag}: {props.entry.timestamp}
+        </span>
+        <button
+          onClick={copyJson}
+          title="Copy JSON"
+          style={{
+            background: "none",
+            border: "1px solid var(--border)",
+            color: copied() ? "var(--success)" : "var(--text-muted)",
+            "border-radius": "3px",
+            cursor: "pointer",
+            "font-size": "10px",
+            padding: "1px 6px",
+          }}
+        >
+          {copied() ? "Copied!" : "Copy"}
+        </button>
+        <button
+          onClick={() => props.onClose()}
+          title="Close JSON viewer"
+          style={{
+            background: "none",
+            border: "none",
+            color: "var(--text-muted)",
+            cursor: "pointer",
+            "font-size": "12px",
+            padding: "0 4px",
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      <pre
+        style={{
+          flex: "1",
+          overflow: "auto",
+          margin: "0",
+          padding: "8px 12px",
+          "font-family": "var(--font-mono)",
+          "font-size": "11px",
+          "line-height": "1.5",
+          color: "var(--text-primary)",
+          "white-space": "pre",
+          background: "transparent",
+        }}
+      >
+        {formattedJson() ?? "(invalid JSON)"}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/logcat/LogcatPanel.filter-spec.test.ts
+++ b/src/components/logcat/LogcatPanel.filter-spec.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { parseFilterGroups, parseQuery, setMinePackage } from "@/lib/logcat-query";
-import { groupsToFilterSpec, hasAnyFrontendOnlyLogic, tokensToFilterSpec } from "./LogcatPanel";
+import {
+  groupsToFilterSpec,
+  hasAnyFrontendOnlyLogic,
+  tokensToFilterSpec,
+} from "@/lib/logcat-filter-spec";
 
 describe("LogcatPanel backend filter spec conversion", () => {
   beforeEach(() => {

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -6,9 +6,7 @@ import {
   onMount,
   onCleanup,
   Show,
-  For,
 } from "solid-js";
-import { createStore, produce } from "solid-js/store";
 import {
   startLogcat,
   stopLogcat,
@@ -23,7 +21,6 @@ import {
   listenDeviceListChanged,
   formatError,
   type LogcatEntry,
-  type LogcatFilterSpec,
 } from "@/lib/tauri-api";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { save } from "@tauri-apps/plugin-dialog";
@@ -31,55 +28,49 @@ import { selectedDevice } from "@/stores/device.store";
 import { settingsState } from "@/stores/settings.store";
 import { showToast } from "@/components/ui";
 import { VirtualList, type VirtualListHandle, isPaletteOpen } from "@/components/ui";
-import { QueryBar } from "@/components/logcat/QueryBar";
-import { Icon } from "@/components/ui";
 import {
+  parseAge,
   parseFilterGroups,
   matchesFilterGroups,
-  getFrontendOnlyTokens,
   setAgeInQuery,
   setPackageInQuery,
   getPackageFromQuery,
-  getMinePackage,
   setMinePackage,
-  parseStackFrame,
-  isProjectFrame,
-  type QueryToken,
   type FilterGroup,
 } from "@/lib/logcat-query";
 import { projectState } from "@/stores/project.store";
 import { buildState } from "@/stores/build.store";
-import { PackageDropdown } from "@/components/logcat/PackageDropdown";
 import { LogEntryDetailPanel } from "./LogEntryDetailPanel";
-import { LEVEL_CONFIG } from "./logcat-levels";
-import {
-  loadFilterStorage,
-  addSavedFilter,
-  deleteSavedFilter,
-  renameSavedFilter,
-  getLastActiveQuery,
-  setLastActiveQuery,
-  MAX_SAVED_FILTERS,
-  type SavedFilter,
-} from "@/lib/logcat-filter-storage";
-import { openInStudio } from "@/lib/tauri-api";
-import { healthState } from "@/stores/health.store";
+import { getLastActiveQuery, setLastActiveQuery } from "@/lib/logcat-filter-storage";
 import { uiState } from "@/stores/ui.store";
 import { clampSelectionIndices, nextSelectableIndex } from "./logcat-selection-nav";
-import { rowFocusMarked, rowInSelectionRange } from "./logcat-row-selection";
 import { formatLogcatToolbarCount } from "./logcat-toolbar-count";
 import { clampLogcatMaxUiLines, clampLogcatRingMaxEntries } from "@/lib/logcat-ui-lines";
 import { effectiveLogcatFollowTail } from "@/lib/logcat-follow-tail";
-
-// ── EntryFlags (mirrors Rust EntryFlags consts) ────────────────────────────────
-const ENTRY_FLAGS = {
-  CRASH: 1 << 0,
-  ANR: 1 << 1,
-  JSON_BODY: 1 << 2,
-  NATIVE_CRASH: 1 << 3,
-} as const;
-
-// ── Store ─────────────────────────────────────────────────────────────────────
+import {
+  emptyLogcatFilterSpec,
+  groupsToFilterSpec,
+  hasAnyFrontendOnlyLogic,
+} from "@/lib/logcat-filter-spec";
+import {
+  appendLogcatEntries,
+  clearLogcatEntries,
+  logcatState,
+  replaceLogcatEntries,
+  setLogcatRingBufferTotal,
+  setLogcatStreaming,
+} from "@/stores/logcat.store";
+import { createLatestOnlyGuard } from "@/services/logcat.service";
+import { JsonDetailPanel } from "./LogcatJsonDetailPanel";
+import { LogcatVirtualRow, ROW_HEIGHT, SeparatorRow } from "./LogcatRows";
+import { SavedFilterMenu } from "./SavedFilterMenu";
+import {
+  LogcatFilterControls,
+  LOGCAT_AGE_PILLS,
+  type LogcatAgePillValue,
+} from "./LogcatFilterControls";
+import { LogcatToolbar } from "./LogcatToolbar";
+import { createLogcatSuggestionRuntime } from "./logcat-suggestion-runtime";
 
 function maxUiLinesCap(): number {
   return clampLogcatMaxUiLines(
@@ -88,209 +79,7 @@ function maxUiLinesCap(): number {
   );
 }
 
-let evictionPending = false;
-let lastEvictionTime = 0;
-const EVICTION_INTERVAL_MS = 1_000;
-
-interface LogcatStore {
-  entries: LogcatEntry[];
-  streaming: boolean;
-}
-
-const [logcatStore, setLogcatStore] = createStore<LogcatStore>({
-  entries: [],
-  streaming: false,
-});
-
-// ── Incremental autocomplete data ─────────────────────────────────────────────
-
-const _pkgSet = new Set<string>();
-const _tagFreqMap = new Map<string, number>();
-
-const [knownPackages, setKnownPackages] = createSignal<string[]>([]);
-const [knownTags, setKnownTags] = createSignal<string[]>([]);
-let _suggestTimer: ReturnType<typeof setTimeout> | null = null;
-
-function ingestForSuggestions(entries: LogcatEntry[]) {
-  for (const e of entries) {
-    if (e.package) _pkgSet.add(e.package);
-    if (!e.kind || e.kind === "normal") {
-      _tagFreqMap.set(e.tag, (_tagFreqMap.get(e.tag) ?? 0) + 1);
-    }
-  }
-}
-
-function flushSuggestions(immediate = false) {
-  if (_suggestTimer !== null && !immediate) return;
-  if (_suggestTimer) clearTimeout(_suggestTimer);
-  _suggestTimer = setTimeout(
-    () => {
-      _suggestTimer = null;
-      setKnownPackages(Array.from(_pkgSet).sort());
-      setKnownTags(
-        Array.from(_tagFreqMap.entries())
-          .sort((a, b) => b[1] - a[1])
-          .slice(0, 50)
-          .map(([tag]) => tag)
-      );
-    },
-    immediate ? 0 : 3_000
-  );
-}
-
-function clearSuggestions() {
-  _pkgSet.clear();
-  _tagFreqMap.clear();
-  setKnownPackages([]);
-  setKnownTags([]);
-  if (_suggestTimer !== null) {
-    clearTimeout(_suggestTimer);
-    _suggestTimer = null;
-  }
-}
-
-// ── Query → backend FilterSpec conversion ─────────────────────────────────────
-
-/**
- * Extract the subset of query tokens that can be applied by the Rust backend.
- * Only simple (non-regex, non-negated) tokens are converted.
- * Complex tokens (regex, negate, age) remain for frontend-side filtering.
- */
-export function tokensToFilterSpec(tokens: QueryToken[]): LogcatFilterSpec {
-  const spec: LogcatFilterSpec = {
-    minLevel: null,
-    tag: null,
-    text: null,
-    package: null,
-    onlyCrashes: false,
-  };
-
-  for (const token of tokens) {
-    // Skip negated tokens — backend has no negation support
-    if ("negate" in token && token.negate) continue;
-
-    switch (token.type) {
-      case "level":
-        if (!spec.minLevel) spec.minLevel = token.value;
-        break;
-      case "tag":
-        // Skip regex tokens — backend does substring only
-        if (!token.regex && !spec.tag) spec.tag = token.value;
-        break;
-      case "message":
-        if (!token.regex && !spec.text) spec.text = token.value;
-        break;
-      case "package": {
-        if (!spec.package) {
-          // Resolve "mine" to the actual package name
-          const pkg = token.value === "mine" ? (getMinePackage() ?? null) : token.value;
-          if (pkg) spec.package = pkg;
-        }
-        break;
-      }
-      case "is":
-        if (token.value === "crash") spec.onlyCrashes = true;
-        break;
-      case "freetext":
-        // Only use the first freetext token for backend (rest handled in JS)
-        if (!spec.text) spec.text = token.value;
-        break;
-    }
-  }
-
-  return spec;
-}
-
-/**
- * Compute the most-permissive union `LogcatFilterSpec` across all OR groups.
- *
- * For multi-group queries, the backend cannot know which group will match a
- * given entry, so we send the least-restrictive spec that still pre-filters
- * obvious non-matches (e.g. if every group requires `level:error` or higher,
- * we can still push that to the backend). All precise OR logic is done on the
- * frontend via `matchesFilterGroups`.
- */
-export function groupsToFilterSpec(groups: FilterGroup[]): LogcatFilterSpec {
-  if (groups.length === 0)
-    return { minLevel: null, tag: null, text: null, package: null, onlyCrashes: false };
-  if (groups.length === 1) return tokensToFilterSpec(groups[0]);
-
-  const LEVEL_PRIORITY_MAP: Record<string, number> = {
-    verbose: 0,
-    debug: 1,
-    info: 2,
-    warn: 3,
-    error: 4,
-    fatal: 5,
-  };
-
-  // Collect per-group specs
-  const specs = groups.map((g) => tokensToFilterSpec(g));
-
-  // minLevel: use the minimum across groups (most permissive)
-  const levels = specs.map((s) => (s.minLevel ? (LEVEL_PRIORITY_MAP[s.minLevel] ?? 0) : 0));
-  const minLevelPriority = Math.min(...levels);
-  const minLevel =
-    minLevelPriority === 0
-      ? null
-      : (Object.entries(LEVEL_PRIORITY_MAP).find(([, v]) => v === minLevelPriority)?.[0] ?? null);
-
-  // tag: only push to backend if every group filters the same tag; otherwise omit
-  const tags = specs.map((s) => s.tag);
-  const tag = tags.every((t) => t !== null && t === tags[0]) ? tags[0] : null;
-
-  // text: same rule as tag
-  const texts = specs.map((s) => s.text);
-  const text = texts.every((t) => t !== null && t === texts[0]) ? texts[0] : null;
-
-  // package: same rule
-  const pkgs = specs.map((s) => s.package);
-  const packageFilter = pkgs.every((p) => p !== null && p === pkgs[0]) ? pkgs[0] : null;
-
-  // onlyCrashes: only if ALL groups require it
-  const onlyCrashes = specs.every((s) => s.onlyCrashes);
-
-  return { minLevel, tag, text, package: packageFilter, onlyCrashes };
-}
-
-/**
- * When OR groups are present, the frontend must apply full OR logic.
- * Returns true if any group contains frontend-only tokens (overflow, age,
- * negation, regex, is:stacktrace), or if there are multiple OR groups.
- */
-export function hasAnyFrontendOnlyLogic(groups: FilterGroup[]): boolean {
-  if (groups.length > 1) return true;
-  return getFrontendOnlyTokens(groups[0] ?? []).length > 0;
-}
-
-// ── Saved filters (via logcat-filter-storage) ────────────────────────────────
-
-interface LogcatPreset {
-  name: string;
-  query: string;
-  builtin?: true;
-}
-
-const BUILTIN_PRESETS: LogcatPreset[] = [
-  { name: "My App", query: "package:mine", builtin: true },
-  { name: "Crashes", query: "is:crash", builtin: true },
-  { name: "Errors+", query: "level:error", builtin: true },
-  { name: "Last 5 min", query: "age:5m", builtin: true },
-  { name: "My App OR Crashes", query: "package:mine | is:crash", builtin: true },
-];
-
 // ── LogcatPanel ───────────────────────────────────────────────────────────────
-
-const ROW_HEIGHT = 20;
-
-const AGE_PILLS = [
-  { label: "30s", value: "30s" },
-  { label: "1m", value: "1m" },
-  { label: "5m", value: "5m" },
-  { label: "15m", value: "15m" },
-  { label: "1h", value: "1h" },
-  { label: "All", value: null },
-] as const;
 
 function isLogcatTypingTarget(target: unknown): boolean {
   if (!target || !(target instanceof HTMLElement)) return false;
@@ -335,29 +124,11 @@ export function LogcatPanel(): JSX.Element {
     })
   );
 
-  // Preset / saved filter UI
-  const [presetsOpen, setPresetsOpen] = createSignal(false);
-  const [savedFilters, setSavedFilters] = createSignal<SavedFilter[]>(loadFilterStorage().filters);
-  const [savingPreset, setSavingPreset] = createSignal(false);
-  const [presetNameDraft, setPresetNameDraft] = createSignal("");
-  // Per-filter inline rename state: maps filter id → draft name string
-  const [renamingId, setRenamingId] = createSignal<string | null>(null);
-  const [renameDraft, setRenameDraft] = createSignal("");
-
   // Now signal for age filter reactivity (updates every 5s when age token exists)
   const [now, setNow] = createSignal(Date.now());
 
-  // Currently active backend filter spec (for sync between filter changes and new entries)
-  const [_activeBackendSpec, setActiveBackendSpec] = createSignal<LogcatFilterSpec>({
-    minLevel: null,
-    tag: null,
-    text: null,
-    package: null,
-    onlyCrashes: false,
-  });
-
-  /** Rust `LogStore::len()` from `get_logcat_stats`; null if IPC failed. */
-  const [ringBufferTotal, setRingBufferTotal] = createSignal<number | null>(null);
+  const filterSyncGuard = createLatestOnlyGuard();
+  const suggestions = createLogcatSuggestionRuntime();
 
   let unlistenEntries: (() => void) | undefined;
   let unlistenCleared: (() => void) | undefined;
@@ -375,7 +146,7 @@ export function LogcatPanel(): JSX.Element {
 
   // ── filteredEntries ───────────────────────────────────────────────────────────
   //
-  // The backend has already filtered `logcatStore.entries` to match the simple
+  // The backend has already filtered `logcatState.entries` to match the simple
   // parts of the query (level, tag, text, package, only_crashes).
   //
   // This memo handles:
@@ -390,7 +161,7 @@ export function LogcatPanel(): JSX.Element {
   const filteredEntries = createMemo(
     () => {
       const groups = parsedGroups();
-      const entries = logcatStore.entries;
+      const entries = logcatState.entries;
       if (!needsFrontendFilter()) return entries;
       const currentNow = hasAgeFilter() ? now() : Date.now();
       return entries.filter((e) => matchesFilterGroups(e, groups, currentNow));
@@ -408,14 +179,12 @@ export function LogcatPanel(): JSX.Element {
   //
   // `filteredEntries` may further shrink the set (age/regex tokens), so we
   // rebuild fully only when frontend-only tokens are active.
-  const [crashIndicesFull, setCrashIndicesFull] = createSignal<number[]>([]);
-
   // When frontend tokens are active filteredEntries may differ from the store,
   // so we fall back to scanning filteredEntries() (the set is already small).
   const crashIndices = createMemo(() => {
     if (!needsFrontendFilter()) {
       // Fast path: no frontend filtering, use the incremental index.
-      return crashIndicesFull();
+      return logcatState.crashIndicesFull;
     }
     // Slow path: frontend tokens active, rescan the (small) filtered set.
     const indices: number[] = [];
@@ -430,7 +199,7 @@ export function LogcatPanel(): JSX.Element {
       | { type: "age"; seconds: number }
       | undefined;
     if (!t) return null;
-    for (const p of AGE_PILLS) {
+    for (const p of LOGCAT_AGE_PILLS) {
       if (p.value && parseAge(p.value) === t.seconds) return p.value;
     }
     return null;
@@ -443,28 +212,12 @@ export function LogcatPanel(): JSX.Element {
     updateQuery(q.trimEnd() ? q.trimEnd() + " " : "");
   }
 
-  function parseAge(v: string): number {
-    const m = v.match(/^(\d+)(s|m|h)$/i);
-    if (!m) return 0;
-    const n = parseInt(m[1]);
-    switch (m[2].toLowerCase()) {
-      case "s":
-        return n;
-      case "m":
-        return n * 60;
-      case "h":
-        return n * 3600;
-      default:
-        return 0;
-    }
-  }
-
   async function refreshLogcatRingStats(): Promise<void> {
     try {
       const s = await getLogcatStats();
-      setRingBufferTotal(Number(s.bufferEntryCount));
+      setLogcatRingBufferTotal(Number(s.bufferEntryCount));
     } catch {
-      setRingBufferTotal(null);
+      setLogcatRingBufferTotal(null);
     }
   }
 
@@ -480,8 +233,8 @@ export function LogcatPanel(): JSX.Element {
   // For multi-group queries the union spec is sent so the backend pre-filters
   // broadly; precise OR matching is done client-side in `filteredEntries`.
   async function syncBackendFilter(groups: FilterGroup[]) {
+    const syncToken = filterSyncGuard.begin();
     const spec = groupsToFilterSpec(groups);
-    setActiveBackendSpec(spec);
 
     try {
       await setLogcatFilter(spec);
@@ -495,18 +248,14 @@ export function LogcatPanel(): JSX.Element {
         package: spec.package ?? undefined,
         onlyCrashes: spec.onlyCrashes,
       });
-      setLogcatStore("entries", entries);
-      // Rebuild incremental crash index from the new backfill.
-      setCrashIndicesFull(
-        entries.reduce<number[]>((acc, e, i) => {
-          if (e.isCrash) acc.push(i);
-          return acc;
-        }, [])
-      );
-      ingestForSuggestions(entries);
-      flushSuggestions(true);
-    } catch {
-      /* ignore — don't break the UI if IPC fails */
+      if (!filterSyncGuard.isLatest(syncToken)) return;
+      replaceLogcatEntries(entries);
+      suggestions.ingest(entries);
+      suggestions.flush(true);
+    } catch (err) {
+      if (filterSyncGuard.isLatest(syncToken)) {
+        showToast(`Failed to sync logcat filter: ${formatError(err)}`, "error");
+      }
     }
     await refreshLogcatRingStats();
   }
@@ -576,23 +325,13 @@ export function LogcatPanel(): JSX.Element {
     const cap = maxUiLinesCap();
     if (prevLogcatMaxUi !== undefined) {
       if (cap < prevLogcatMaxUi) {
-        const len = logcatStore.entries.length;
+        const len = logcatState.entries.length;
         const excess = len - cap;
         if (excess > 0) {
-          setLogcatStore(
-            produce((s) => {
-              s.entries.splice(0, excess);
-            })
-          );
+          replaceLogcatEntries(cap === 0 ? [] : logcatState.entries.slice(-cap));
           if (!followTailForList()) {
             setScrollCompensate((c) => c + excess * ROW_HEIGHT);
           }
-          setCrashIndicesFull(
-            logcatStore.entries.reduce<number[]>((acc, e, i) => {
-              if (e.isCrash) acc.push(i);
-              return acc;
-            }, [])
-          );
         }
       } else if (cap > prevLogcatMaxUi) {
         void syncBackendFilter(parseFilterGroups(debouncedQuery()));
@@ -621,8 +360,9 @@ export function LogcatPanel(): JSX.Element {
     const restoredSpec = restoredGroups ? groupsToFilterSpec(restoredGroups) : null;
 
     if (restoredSpec && savedQuery) {
-      setActiveBackendSpec(restoredSpec);
-      await setLogcatFilter(restoredSpec).catch(() => {});
+      await setLogcatFilter(restoredSpec).catch((err) => {
+        showToast(`Failed to restore logcat filter: ${formatError(err)}`, "error");
+      });
     }
 
     try {
@@ -635,99 +375,50 @@ export function LogcatPanel(): JSX.Element {
         package: restoredSpec?.package ?? undefined,
         onlyCrashes: restoredSpec?.onlyCrashes ?? false,
       });
-      setLogcatStore("entries", entries);
-      setCrashIndicesFull(
-        entries.reduce<number[]>((acc, e, i) => {
-          if (e.isCrash) acc.push(i);
-          return acc;
-        }, [])
-      );
-      ingestForSuggestions(entries);
-      flushSuggestions(true);
-    } catch {
-      /* ignore */
+      replaceLogcatEntries(entries);
+      suggestions.ingest(entries);
+      suggestions.flush(true);
+    } catch (err) {
+      showToast(`Failed to load logcat entries: ${formatError(err)}`, "error");
     }
 
     try {
       const streaming = await getLogcatStatus();
-      setLogcatStore("streaming", streaming);
-    } catch {
-      /* ignore */
+      setLogcatStreaming(streaming);
+    } catch (err) {
+      showToast(`Failed to read logcat status: ${formatError(err)}`, "error");
     }
 
     // eslint-disable-next-line solid/reactivity
     unlistenEntries = await listenLogcatEntries((newEntries) => {
       if (paused()) return;
-      const n = Date.now();
-      const shouldEvict = logcatStore.entries.length + newEntries.length > maxUiLinesCap();
-      if (shouldEvict && n - lastEvictionTime > EVICTION_INTERVAL_MS) {
-        evictionPending = true;
-        lastEvictionTime = n;
-      }
-
-      // Update incremental crash index before touching the store so we know
-      // the offset at which new entries will be appended.
-      const baseLen = logcatStore.entries.length;
-      const newCrashOffsets: number[] = [];
-      newEntries.forEach((e, i) => {
-        if (e.isCrash) newCrashOffsets.push(baseLen + i);
-      });
-
-      let didEvict = false;
-      let dropped = 0;
-      setLogcatStore(
-        produce((s) => {
-          for (const e of newEntries) s.entries.push(e);
-          if (evictionPending && s.entries.length > maxUiLinesCap()) {
-            dropped = s.entries.length - maxUiLinesCap();
-            s.entries.splice(0, dropped);
-            evictionPending = false;
-            didEvict = true;
-          }
-        })
-      );
-
-      if (didEvict && !followTailForList()) {
+      const dropped = appendLogcatEntries(newEntries, maxUiLinesCap());
+      if (dropped > 0 && !followTailForList()) {
         setScrollCompensate((c) => c + dropped * ROW_HEIGHT);
       }
 
-      if (didEvict) {
-        // After eviction all pre-computed offsets are stale — rebuild fully.
-        setCrashIndicesFull(
-          logcatStore.entries.reduce<number[]>((acc, e, i) => {
-            if (e.isCrash) acc.push(i);
-            return acc;
-          }, [])
-        );
-      } else if (newCrashOffsets.length > 0) {
-        // No eviction — safe to append the incremental offsets.
-        setCrashIndicesFull((prev) => [...prev, ...newCrashOffsets]);
-      }
-
-      ingestForSuggestions(newEntries);
-      flushSuggestions();
+      suggestions.ingest(newEntries);
+      suggestions.flush();
     });
 
     unlistenCleared = await listenLogcatCleared(() => {
-      setLogcatStore("entries", []);
-      setCrashIndicesFull([]);
-      clearSuggestions();
+      clearLogcatEntries();
+      suggestions.clear();
       setAutoScroll(true);
       virtualListRef?.scrollToBottom();
       void refreshLogcatRingStats();
     });
 
     // Auto-start on device connect
-    // eslint-disable-next-line solid/reactivity
     unlistenDevices = await listenDeviceListChanged((devices) => {
-      if (logcatStore.streaming) return;
+      if (logcatState.streaming) return;
       const hasAutoStart = settingsState.logcat?.autoStart !== false;
       if (!hasAutoStart) return;
       const online = devices.find((d) => d.connectionState === "online");
       if (online) {
         startLogcat(online.serial)
-          .then(() => setLogcatStore("streaming", true))
-          .catch(() => {});
+          .then(() => setLogcatStreaming(true))
+          .catch((err) => showToast(`Failed to auto-start logcat: ${formatError(err)}`, "error"));
       }
     });
 
@@ -737,7 +428,7 @@ export function LogcatPanel(): JSX.Element {
     // consistent; this listener is purely for future indicator use.
 
     unlistenReconnecting = await listenLogcatReconnecting(() => {
-      setLogcatStore("streaming", true);
+      setLogcatStreaming(true);
     });
 
     nowTimer = setInterval(() => setNow(Date.now()), 5_000);
@@ -751,7 +442,7 @@ export function LogcatPanel(): JSX.Element {
 
   // Keep ring-buffer denominator fresh while streaming (cheap IPC; throttled).
   createEffect(() => {
-    if (!logcatStore.streaming || uiState.activeTab !== "logcat") return;
+    if (!logcatState.streaming || uiState.activeTab !== "logcat") return;
     void refreshLogcatRingStats();
     const id = window.setInterval(() => {
       void refreshLogcatRingStats();
@@ -766,14 +457,9 @@ export function LogcatPanel(): JSX.Element {
     unlistenReconnecting?.();
     clearInterval(nowTimer);
     clearTimeout(_queryDebounce);
+    filterSyncGuard.invalidate();
     // Clear backend filter on unmount so it doesn't persist
-    setLogcatFilter({
-      minLevel: null,
-      tag: null,
-      text: null,
-      package: null,
-      onlyCrashes: false,
-    }).catch(() => {});
+    setLogcatFilter(emptyLogcatFilterSpec()).catch(() => {});
   });
 
   // ── Controls ──────────────────────────────────────────────────────────────────
@@ -782,7 +468,7 @@ export function LogcatPanel(): JSX.Element {
     try {
       const device = selectedDevice();
       await startLogcat(device?.serial ?? undefined);
-      setLogcatStore("streaming", true);
+      setLogcatStreaming(true);
       void refreshLogcatRingStats();
     } catch (e) {
       showToast(`Failed to start logcat: ${formatError(e)}`, "error");
@@ -792,7 +478,7 @@ export function LogcatPanel(): JSX.Element {
   async function handleStop() {
     try {
       await stopLogcat();
-      setLogcatStore("streaming", false);
+      setLogcatStreaming(false);
       void refreshLogcatRingStats();
     } catch (e) {
       showToast(`Failed to stop logcat: ${formatError(e)}`, "error");
@@ -817,7 +503,7 @@ export function LogcatPanel(): JSX.Element {
       await clearLogcat(); // emits logcat:cleared → entries cleared + scroll to bottom
       const device = selectedDevice();
       await startLogcat(device?.serial ?? undefined);
-      setLogcatStore("streaming", true);
+      setLogcatStreaming(true);
     } catch (e) {
       showToast(`Failed to restart logcat: ${formatError(e)}`, "error");
     } finally {
@@ -910,57 +596,9 @@ export function LogcatPanel(): JSX.Element {
     }
   }
 
-  // ── Presets / saved filters ───────────────────────────────────────────────────
-
-  function applyPreset(q: string) {
-    // Trailing space commits all tokens as pills immediately (QueryBar's convention:
-    // a value ending in whitespace means the last token is committed, not a draft).
-    updateQuery(q.trimEnd() + " ");
-    setPresetsOpen(false);
-  }
-
-  function saveCurrentFilter() {
-    const name = presetNameDraft().trim();
-    if (!name) return;
-    try {
-      const saved = addSavedFilter(name, query());
-      setSavedFilters(loadFilterStorage().filters);
-      setSavingPreset(false);
-      setPresetNameDraft("");
-      showToast(`Saved filter "${saved.name}"`, "success");
-    } catch (e) {
-      showToast(String(e), "error");
-    }
-  }
-
-  function deleteSavedFilterItem(id: string) {
-    deleteSavedFilter(id);
-    setSavedFilters(loadFilterStorage().filters);
-  }
-
-  function startRename(filter: SavedFilter) {
-    setRenamingId(filter.id);
-    setRenameDraft(filter.name);
-  }
-
-  function commitRename() {
-    const id = renamingId();
-    if (id) {
-      renameSavedFilter(id, renameDraft());
-      setSavedFilters(loadFilterStorage().filters);
-    }
-    setRenamingId(null);
-    setRenameDraft("");
-  }
-
-  function cancelRename() {
-    setRenamingId(null);
-    setRenameDraft("");
-  }
-
   // ── Age pills ─────────────────────────────────────────────────────────────────
 
-  function handleAgePill(value: string | null) {
+  function handleAgePill(value: LogcatAgePillValue) {
     const q = setAgeInQuery(query(), value);
     updateQuery(q.trimEnd() ? q.trimEnd() + " " : "");
   }
@@ -1022,6 +660,15 @@ export function LogcatPanel(): JSX.Element {
     setAutoScroll(false);
   }
 
+  function handleScrollToEnd() {
+    setSelectionAnchor(null);
+    setSelectionEnd(null);
+    setSelectedJsonEntry(null);
+    setSelectedDetailEntry(null);
+    setAutoScroll(true);
+    virtualListRef?.scrollToBottom();
+  }
+
   // ── UI helpers ────────────────────────────────────────────────────────────────
 
   const isFiltered = () => query().trim() !== "";
@@ -1029,7 +676,7 @@ export function LogcatPanel(): JSX.Element {
     formatLogcatToolbarCount({
       queryActive: isFiltered(),
       visible: filteredEntries().length,
-      ringTotal: ringBufferTotal(),
+      ringTotal: logcatState.ringBufferTotal,
     })
   );
   const crashes = () => crashIndices().length;
@@ -1051,556 +698,46 @@ export function LogcatPanel(): JSX.Element {
         background: "var(--bg-primary)",
       }}
     >
-      {/* ── Toolbar row 1: controls + query ──────────────────────────────── */}
-      <div
-        style={{
-          display: "flex",
-          "align-items": "flex-start",
-          gap: "6px",
-          padding: "5px 10px",
-          background: "var(--bg-secondary)",
-          "border-bottom": "1px solid var(--border)",
-          "flex-shrink": "0",
-          "flex-wrap": "wrap",
-        }}
-      >
-        {/* Start/Stop */}
-        <Show
-          when={logcatStore.streaming}
-          fallback={
-            <button onClick={handleStart} title="Start Logcat" style={btnStyle("var(--success)")}>
-              <Icon name="play" size={13} /> Start
-            </button>
-          }
-        >
-          <button onClick={handleStop} title="Stop Logcat" style={btnStyle("var(--error)")}>
-            <Icon name="stop" size={13} /> Stop
-          </button>
-        </Show>
+      <LogcatToolbar
+        streaming={logcatState.streaming}
+        paused={paused()}
+        restarting={restarting()}
+        crashes={crashes()}
+        selectedCount={selCount()}
+        autoScroll={autoScroll()}
+        toolbarCount={toolbarCount()}
+        onStart={handleStart}
+        onStop={handleStop}
+        onTogglePaused={() => setPaused((v) => !v)}
+        onRestart={handleRestart}
+        onClear={handleClear}
+        onJumpToLastCrash={jumpToLastCrash}
+        onJumpToPreviousCrash={() => jumpToCrash(-1)}
+        onJumpToNextCrash={() => jumpToCrash(1)}
+        onCopySelectedRows={copySelectedRows}
+        onScrollToEnd={handleScrollToEnd}
+        onExport={handleExport}
+        renderSavedFilterMenu={() => (
+          <SavedFilterMenu query={query()} isFiltered={isFiltered()} onApplyQuery={updateQuery} />
+        )}
+      />
 
-        {/* Pause/Resume */}
-        <button
-          onClick={() => setPaused((v) => !v)}
-          title={paused() ? "Resume" : "Pause new entries"}
-          style={btnStyle(paused() ? "var(--warning)" : "var(--text-muted)")}
-        >
-          {paused() ? "▶" : "⏸"}
-        </button>
-
-        {/* Restart */}
-        <button
-          onClick={handleRestart}
-          title="Stop, clear and restart logcat"
-          disabled={restarting()}
-          style={btnStyle("var(--text-muted)")}
-        >
-          ↺ Restart
-        </button>
-
-        {/* Clear */}
-        <button
-          onClick={handleClear}
-          title="Clear logcat buffer"
-          style={btnStyle("var(--text-muted)")}
-        >
-          <Icon name="trash" size={12} />
-        </button>
-
-        <div
-          style={{ width: "1px", height: "18px", background: "var(--border)", "flex-shrink": "0" }}
-        />
-
-        {/* Crash nav */}
-        <Show when={crashes() > 0}>
-          <div style={{ display: "flex", "align-items": "center", gap: "2px", "flex-shrink": "0" }}>
-            <button
-              onClick={jumpToLastCrash}
-              title={`${crashes()} crash${crashes() !== 1 ? "es" : ""} — click to jump`}
-              style={{
-                ...btnStyle("var(--error)"),
-                gap: "3px",
-                animation: "lsp-dot-pulse 3s ease-in-out infinite",
-              }}
-            >
-              ⚡ {crashes()}
-            </button>
-            <button
-              onClick={() => jumpToCrash(-1)}
-              title="Previous crash"
-              style={btnStyle("var(--text-muted)")}
-            >
-              ↑
-            </button>
-            <button
-              onClick={() => jumpToCrash(1)}
-              title="Next crash"
-              style={btnStyle("var(--text-muted)")}
-            >
-              ↓
-            </button>
-          </div>
-        </Show>
-
-        {/* Multi-select copy */}
-        <Show when={selCount() > 1}>
-          <button
-            onClick={copySelectedRows}
-            title={`Copy ${selCount()} selected rows`}
-            style={btnStyle("var(--accent)")}
-          >
-            ⎘ {selCount()} rows
-          </button>
-        </Show>
-
-        {/* Presets */}
-        <div style={{ position: "relative", "flex-shrink": "0" }}>
-          <button
-            onClick={() => {
-              setPresetsOpen((v) => !v);
-              setSavingPreset(false);
-              setRenamingId(null);
-            }}
-            title="Filter presets"
-            style={btnStyle("var(--text-muted)")}
-          >
-            ☰ Filters
-          </button>
-          <Show when={presetsOpen()}>
-            <div
-              style={{
-                position: "absolute",
-                top: "calc(100% + 3px)",
-                right: "0",
-                "min-width": "260px",
-                "max-width": "340px",
-                background: "var(--bg-secondary)",
-                border: "1px solid var(--border)",
-                "border-radius": "4px",
-                "box-shadow": "0 6px 20px rgba(0,0,0,0.45)",
-                "z-index": "700",
-                "font-size": "11px",
-              }}
-            >
-              <div style={{ padding: "6px 0" }}>
-                {/* Quick Filters (built-in) */}
-                <div
-                  style={{
-                    padding: "2px 10px 4px",
-                    "font-size": "10px",
-                    color: "var(--text-muted)",
-                    "text-transform": "uppercase",
-                    "letter-spacing": "0.05em",
-                  }}
-                >
-                  Quick Filters
-                </div>
-                <For each={BUILTIN_PRESETS}>
-                  {(p) => (
-                    <div
-                      onClick={() => applyPreset(p.query)}
-                      style={{
-                        display: "flex",
-                        "align-items": "center",
-                        padding: "5px 10px",
-                        cursor: "pointer",
-                        color: "var(--text-primary)",
-                        "font-family": "var(--font-mono)",
-                      }}
-                      onMouseEnter={(e) => {
-                        (e.currentTarget as HTMLElement).style.background =
-                          "rgba(255,255,255,0.06)";
-                      }}
-                      onMouseLeave={(e) => {
-                        (e.currentTarget as HTMLElement).style.background = "transparent";
-                      }}
-                    >
-                      <span style={{ flex: "1" }}>{p.name}</span>
-                      <span
-                        style={{
-                          color: "var(--text-muted)",
-                          "font-size": "10px",
-                          "max-width": "130px",
-                          overflow: "hidden",
-                          "text-overflow": "ellipsis",
-                          "white-space": "nowrap",
-                        }}
-                      >
-                        {p.query}
-                      </span>
-                    </div>
-                  )}
-                </For>
-
-                {/* Saved Filters */}
-                <div style={{ height: "1px", background: "var(--border)", margin: "4px 0" }} />
-                <div style={{ display: "flex", "align-items": "center", padding: "2px 10px 4px" }}>
-                  <span
-                    style={{
-                      "font-size": "10px",
-                      color: "var(--text-muted)",
-                      "text-transform": "uppercase",
-                      "letter-spacing": "0.05em",
-                      flex: "1",
-                    }}
-                  >
-                    Saved
-                  </span>
-                  <span style={{ "font-size": "10px", color: "var(--text-muted)" }}>
-                    {savedFilters().length} / {MAX_SAVED_FILTERS}
-                  </span>
-                </div>
-
-                <Show when={savedFilters().length === 0}>
-                  <div
-                    style={{
-                      padding: "4px 10px 6px",
-                      "font-size": "10px",
-                      color: "var(--text-muted)",
-                      "font-style": "italic",
-                    }}
-                  >
-                    No saved filters yet
-                  </div>
-                </Show>
-
-                <For each={savedFilters()}>
-                  {(f) => (
-                    <div
-                      style={{
-                        display: "flex",
-                        "align-items": "center",
-                        padding: "4px 10px",
-                        cursor: "pointer",
-                        color: "var(--text-primary)",
-                        gap: "4px",
-                      }}
-                      onMouseEnter={(e) => {
-                        (e.currentTarget as HTMLElement).style.background =
-                          "rgba(255,255,255,0.06)";
-                      }}
-                      onMouseLeave={(e) => {
-                        (e.currentTarget as HTMLElement).style.background = "transparent";
-                      }}
-                    >
-                      <Show
-                        when={renamingId() === f.id}
-                        fallback={
-                          <>
-                            <span
-                              onClick={() => applyPreset(f.query)}
-                              style={{
-                                flex: "1",
-                                overflow: "hidden",
-                                "text-overflow": "ellipsis",
-                                "white-space": "nowrap",
-                              }}
-                              title={f.query}
-                            >
-                              {f.name}
-                            </span>
-                            {/* Rename button */}
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                startRename(f);
-                              }}
-                              style={{
-                                background: "none",
-                                border: "none",
-                                color: "var(--text-muted)",
-                                cursor: "pointer",
-                                padding: "0 3px",
-                                "font-size": "10px",
-                              }}
-                              title="Rename"
-                            >
-                              ✎
-                            </button>
-                            {/* Delete button */}
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                deleteSavedFilterItem(f.id);
-                              }}
-                              style={{
-                                background: "none",
-                                border: "none",
-                                color: "var(--text-muted)",
-                                cursor: "pointer",
-                                padding: "0 3px",
-                                "font-size": "10px",
-                              }}
-                              title="Delete"
-                            >
-                              ✕
-                            </button>
-                          </>
-                        }
-                      >
-                        {/* Inline rename row */}
-                        <input
-                          type="text"
-                          value={renameDraft()}
-                          onInput={(e) => setRenameDraft(e.currentTarget.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") {
-                              e.stopPropagation();
-                              commitRename();
-                            }
-                            if (e.key === "Escape") {
-                              e.stopPropagation();
-                              cancelRename();
-                            }
-                          }}
-                          autofocus
-                          style={{
-                            flex: "1",
-                            background: "var(--bg-primary)",
-                            border: "1px solid var(--accent)",
-                            color: "var(--text-primary)",
-                            "border-radius": "3px",
-                            padding: "2px 5px",
-                            "font-size": "11px",
-                            outline: "none",
-                          }}
-                        />
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            commitRename();
-                          }}
-                          style={btnStyle("var(--accent)")}
-                        >
-                          ✓
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            cancelRename();
-                          }}
-                          style={btnStyle("var(--text-muted)")}
-                        >
-                          ✕
-                        </button>
-                      </Show>
-                    </div>
-                  )}
-                </For>
-
-                {/* Save current filter */}
-                <div style={{ height: "1px", background: "var(--border)", margin: "4px 0" }} />
-                <Show
-                  when={savingPreset()}
-                  fallback={
-                    <div
-                      onClick={() => {
-                        setSavingPreset(true);
-                        setPresetNameDraft("");
-                      }}
-                      style={{
-                        padding: "5px 10px",
-                        cursor: "pointer",
-                        color: isFiltered() ? "var(--accent)" : "var(--text-muted)",
-                      }}
-                      onMouseEnter={(e) => {
-                        (e.currentTarget as HTMLElement).style.background =
-                          "rgba(255,255,255,0.06)";
-                      }}
-                      onMouseLeave={(e) => {
-                        (e.currentTarget as HTMLElement).style.background = "transparent";
-                      }}
-                    >
-                      + Save current filter
-                    </div>
-                  }
-                >
-                  <div style={{ display: "flex", gap: "4px", padding: "4px 8px" }}>
-                    <input
-                      type="text"
-                      placeholder="Filter name…"
-                      value={presetNameDraft()}
-                      onInput={(e) => setPresetNameDraft(e.currentTarget.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") saveCurrentFilter();
-                        if (e.key === "Escape") setSavingPreset(false);
-                      }}
-                      autofocus
-                      style={{
-                        flex: "1",
-                        background: "var(--bg-primary)",
-                        border: "1px solid var(--border)",
-                        color: "var(--text-primary)",
-                        "border-radius": "3px",
-                        padding: "3px 6px",
-                        "font-size": "11px",
-                        outline: "none",
-                      }}
-                    />
-                    <button onClick={saveCurrentFilter} style={btnStyle("var(--accent)")}>
-                      Save
-                    </button>
-                  </div>
-                </Show>
-              </div>
-            </div>
-            <div
-              style={{ position: "fixed", inset: "0", "z-index": "699" }}
-              onClick={() => {
-                setPresetsOpen(false);
-                cancelRename();
-              }}
-            />
-          </Show>
-        </div>
-
-        {/* Scroll to end */}
-        <button
-          onClick={() => {
-            setSelectionAnchor(null);
-            setSelectionEnd(null);
-            setSelectedJsonEntry(null);
-            setSelectedDetailEntry(null);
-            setAutoScroll(true);
-            virtualListRef?.scrollToBottom();
-          }}
-          title="Scroll to end"
-          style={btnStyle(autoScroll() ? "var(--text-muted)" : "var(--accent)")}
-        >
-          ↓
-        </button>
-
-        {/* Export */}
-        <button
-          onClick={handleExport}
-          title="Export filtered log to file"
-          style={btnStyle("var(--text-muted)")}
-        >
-          ↓ Export
-        </button>
-
-        <div style={{ flex: "1" }} />
-
-        {/* Entry count — labeled visible vs buffer (see logcat-toolbar-count.ts) */}
-        <span
-          title={toolbarCount().title}
-          style={{
-            "font-size": "11px",
-            color: "var(--text-muted)",
-            "flex-shrink": "0",
-            cursor: "default",
-          }}
-        >
-          {toolbarCount().text}
-        </span>
-
-        {/* Streaming dot */}
-        <Show when={logcatStore.streaming}>
-          <span
-            style={{
-              width: "6px",
-              height: "6px",
-              "border-radius": "50%",
-              background: "var(--success)",
-              "flex-shrink": "0",
-              animation: "lsp-dot-pulse 2s ease-in-out infinite",
-            }}
-          />
-        </Show>
-      </div>
-
-      {/* ── Unified filter zone ───────────────────────────────────────────── */}
-      <div
-        style={{
-          display: "flex",
-          "flex-wrap": "wrap",
-          "align-items": "flex-start",
-          gap: "6px",
-          padding: "5px 10px",
-          background: "var(--bg-secondary)",
-          "border-bottom": "1px solid var(--border)",
-          "flex-shrink": "0",
-        }}
-      >
-        {/* Query bar — grows to fill available width */}
-        <QueryBar
-          value={query()}
-          onChange={updateQuery}
-          knownTags={knownTags()}
-          knownPackages={knownPackages()}
-        />
-
-        {/* Age + Package sub-row — inline right, wraps below on narrow windows */}
-        <div style={{ display: "flex", "align-items": "center", gap: "4px", "flex-shrink": "0" }}>
-          <span
-            style={{
-              "font-size": "10px",
-              color: "var(--text-muted)",
-              "margin-right": "2px",
-              "flex-shrink": "0",
-            }}
-          >
-            Age:
-          </span>
-          <For each={AGE_PILLS}>
-            {(pill) => {
-              const isActive = () =>
-                pill.value === null ? !hasAgeFilter() : activeAge() === pill.value;
-              return (
-                <button
-                  onClick={() => handleAgePill(pill.value ?? null)}
-                  style={{
-                    padding: "1px 7px",
-                    "font-size": "10px",
-                    background: isActive() ? "var(--accent)" : "var(--bg-primary)",
-                    color: isActive() ? "#fff" : "var(--text-muted)",
-                    border: `1px solid ${isActive() ? "var(--accent)" : "var(--border)"}`,
-                    "border-radius": "10px",
-                    cursor: "pointer",
-                    "flex-shrink": "0",
-                    transition: "all 0.1s",
-                  }}
-                >
-                  {pill.label}
-                </button>
-              );
-            }}
-          </For>
-
-          <div
-            style={{
-              width: "1px",
-              height: "14px",
-              background: "var(--border)",
-              "flex-shrink": "0",
-              "margin-left": "2px",
-            }}
-          />
-
-          {/* Package filter dropdown */}
-          <PackageDropdown
-            packages={knownPackages()}
-            selected={activePackage()}
-            onSelect={handlePackageSelect}
-          />
-
-          <Show when={isFiltered()}>
-            <button
-              onClick={() => updateQuery("")}
-              title="Clear all filters"
-              style={{
-                ...btnStyle("var(--text-muted)"),
-                "font-size": "10px",
-                padding: "1px 7px",
-              }}
-            >
-              ✕ Clear
-            </button>
-          </Show>
-        </div>
-      </div>
+      <LogcatFilterControls
+        query={query()}
+        knownTags={suggestions.knownTags()}
+        knownPackages={suggestions.knownPackages()}
+        hasAgeFilter={hasAgeFilter()}
+        activeAge={activeAge()}
+        activePackage={activePackage()}
+        isFiltered={isFiltered()}
+        onQueryChange={updateQuery}
+        onAgeSelect={handleAgePill}
+        onPackageSelect={handlePackageSelect}
+        onClear={() => updateQuery("")}
+      />
 
       {/* ── Empty state ───────────────────────────────────────────────────── */}
-      <Show when={logcatStore.entries.length === 0}>
+      <Show when={logcatState.entries.length === 0}>
         <div
           style={{
             flex: "1",
@@ -1614,7 +751,7 @@ export function LogcatPanel(): JSX.Element {
           }}
         >
           <Show
-            when={logcatStore.streaming}
+            when={logcatState.streaming}
             fallback={
               <>
                 <span style={{ "font-size": "24px", opacity: "0.3" }}>📋</span>
@@ -1632,7 +769,7 @@ export function LogcatPanel(): JSX.Element {
       </Show>
 
       {/* ── Virtualised log list ──────────────────────────────────────────── */}
-      <Show when={logcatStore.entries.length > 0}>
+      <Show when={logcatState.entries.length > 0}>
         <VirtualList
           items={filteredEntries()}
           rowHeight={ROW_HEIGHT}
@@ -1684,519 +821,4 @@ export function LogcatPanel(): JSX.Element {
       </Show>
     </div>
   );
-}
-
-/**
- * Wraps {@link LogcatRow} so selection/detail signals are read inside `createMemo`.
- * VirtualList's inner `<For>` does not re-invoke `renderRow` when only selection changes;
- * this child re-subscribes so the focus stripe and range tint stay in sync with clicks and keyboard.
- */
-function LogcatVirtualRow(props: {
-  entry: LogcatEntry;
-  index: number;
-  getSelectionRange: () => [number, number] | null;
-  getAnchor: () => number | null;
-  getEnd: () => number | null;
-  getDetailEntry: () => LogcatEntry | null;
-  getJsonEntry: () => LogcatEntry | null;
-  onRowClick: (e: MouseEvent) => void;
-  onJsonClick: (e: MouseEvent) => void;
-}): JSX.Element {
-  const inSelectionRange = createMemo(() =>
-    rowInSelectionRange(props.index, props.getSelectionRange())
-  );
-
-  const focusMarked = createMemo(() =>
-    rowFocusMarked(
-      props.index,
-      props.getAnchor(),
-      props.getEnd(),
-      props.getDetailEntry(),
-      props.entry.id
-    )
-  );
-
-  const jsonSelected = createMemo(() => props.getJsonEntry()?.id === props.entry.id);
-
-  return (
-    <LogcatRow
-      entry={props.entry}
-      inSelectionRange={inSelectionRange()}
-      focusMarked={focusMarked()}
-      jsonSelected={jsonSelected()}
-      onClick={props.onRowClick}
-      onJsonClick={props.onJsonClick}
-    />
-  );
-}
-
-// ── SeparatorRow ──────────────────────────────────────────────────────────────
-
-function SeparatorRow(props: { entry: LogcatEntry }): JSX.Element {
-  const isDied = () => props.entry.kind === "processDied";
-  const pkg = () => props.entry.package ?? props.entry.tag;
-  const label = () => (isDied() ? `⚠  ${pkg()} PROCESS DIED` : `▶  ${pkg()} PROCESS RESTARTED`);
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        "align-items": "center",
-        height: `${ROW_HEIGHT}px`,
-        "min-height": `${ROW_HEIGHT}px`,
-        padding: "0 8px",
-        background: isDied()
-          ? "color-mix(in srgb, var(--error) 10%, transparent)"
-          : "color-mix(in srgb, var(--success) 7%, transparent)",
-        "border-top": `1px solid ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
-        "border-bottom": `1px solid ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
-        overflow: "hidden",
-      }}
-    >
-      <span
-        style={{
-          flex: "1",
-          "border-top": `1px dashed ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
-        }}
-      />
-      <span
-        style={{
-          "font-size": "10px",
-          color: isDied() ? "var(--error)" : "var(--success)",
-          "font-weight": "600",
-          "white-space": "nowrap",
-          padding: "0 10px",
-          "letter-spacing": "0.04em",
-        }}
-      >
-        {label()}
-      </span>
-      <span style={{ "font-size": "10px", color: "var(--text-muted)", "flex-shrink": "0" }}>
-        {props.entry.timestamp}
-      </span>
-      <span
-        style={{
-          flex: "1",
-          "border-top": `1px dashed ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
-        }}
-      />
-    </div>
-  );
-}
-
-// ── StudioJumpButton ──────────────────────────────────────────────────────────
-
-/**
- * A small "↗ Studio" button rendered on hover for crash-group stack frame lines.
- * Parses the message to extract the file and line, then calls `open_in_studio`.
- */
-function StudioJumpButton(props: { message: string }): JSX.Element {
-  const frame = () => {
-    const f = parseStackFrame(props.message);
-    // Only show the button for frames that belong to the project —
-    // hide it for Android / Kotlin / Java framework packages.
-    if (f && !isProjectFrame(f.classPath)) return null;
-    return f;
-  };
-  const studioReady = () => healthState.systemReport?.studioCommandFound === true;
-  const [hovered, setHovered] = createSignal(false);
-  const [opening, setOpening] = createSignal(false);
-
-  const handleOpen = async (e: MouseEvent) => {
-    e.stopPropagation();
-    const f = frame();
-    if (!f) return;
-    if (!studioReady()) {
-      showToast("Install the studio command — see Health Panel for setup instructions", "warning");
-      return;
-    }
-    setOpening(true);
-    try {
-      await openInStudio(f.packagePath, f.filename, f.line);
-    } catch (err: unknown) {
-      showToast(String(err), "error");
-    } finally {
-      setOpening(false);
-    }
-  };
-
-  return (
-    <Show when={frame() !== null}>
-      <button
-        onClick={handleOpen}
-        title={
-          studioReady()
-            ? `Open ${frame()!.filename}:${frame()!.line} in Android Studio`
-            : "Install the studio command to enable jump-to-line (see Health Panel)"
-        }
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
-        style={{
-          "flex-shrink": "0",
-          display: "inline-flex",
-          "align-items": "center",
-          gap: "3px",
-          padding: "1px 6px",
-          "border-radius": "3px",
-          border: `1px solid ${studioReady() ? "color-mix(in srgb, var(--info) 40%, transparent)" : "color-mix(in srgb, var(--text-muted) 30%, transparent)"}`,
-          background: hovered()
-            ? studioReady()
-              ? "color-mix(in srgb, var(--info) 15%, transparent)"
-              : "color-mix(in srgb, var(--text-muted) 10%, transparent)"
-            : "transparent",
-          color: studioReady() ? "var(--info)" : "var(--text-disabled)",
-          cursor: opening() ? "wait" : studioReady() ? "pointer" : "not-allowed",
-          "font-size": "9px",
-          "font-family": "var(--font-ui)",
-          "font-weight": "500",
-          opacity: opening() ? "0.6" : "1",
-          transition: "background 0.1s, opacity 0.1s",
-          "white-space": "nowrap",
-        }}
-      >
-        {opening() ? "⟳" : "↗"} Studio
-      </button>
-    </Show>
-  );
-}
-
-// ── LogcatRow ─────────────────────────────────────────────────────────────────
-
-function LogcatRow(props: {
-  entry: LogcatEntry;
-  /** Row index lies in the Shift+click copy range (or single anchor). */
-  inSelectionRange: boolean;
-  /** Primary line: detail panel entry, or anchor when no detail / multi-range stripe on anchor only. */
-  focusMarked: boolean;
-  jsonSelected: boolean;
-  onClick: (e: MouseEvent) => void;
-  onJsonClick: (e: MouseEvent) => void;
-}): JSX.Element {
-  const cfg = () =>
-    LEVEL_CONFIG[props.entry.level as keyof typeof LEVEL_CONFIG] ?? LEVEL_CONFIG.unknown;
-  const hasJson = () => (props.entry.flags & ENTRY_FLAGS.JSON_BODY) !== 0;
-  const hasAnr = () => (props.entry.flags & ENTRY_FLAGS.ANR) !== 0;
-  // Entries in a crash group but not the header get a subtle left border variation
-  const inCrashGroup = () => props.entry.crashGroupId !== null && !props.entry.isCrash;
-
-  // Left border when not showing the focus accent stripe
-  const semanticBorderColor = () => {
-    if (props.entry.isCrash) return "var(--error)";
-    if (hasAnr()) return "var(--warning)";
-    if (inCrashGroup()) return "color-mix(in srgb, var(--error) 40%, transparent)";
-    return "transparent";
-  };
-
-  const ACCENT_RANGE_BG = "rgba(var(--accent-rgb, 59,130,246),0.14)";
-  const ACCENT_FOCUS_BG = "rgba(var(--accent-rgb, 59,130,246),0.28)";
-
-  function defaultRowBackground(): string {
-    if (props.focusMarked) return ACCENT_FOCUS_BG;
-    if (props.inSelectionRange) return ACCENT_RANGE_BG;
-    if (props.jsonSelected) return "color-mix(in srgb, var(--info) 12%, transparent)";
-    if (props.entry.isCrash) return "color-mix(in srgb, var(--error) 12%, transparent)";
-    if (hasAnr()) return "color-mix(in srgb, var(--warning) 8%, transparent)";
-    return cfg().bg;
-  }
-
-  return (
-    <div
-      onClick={(e) => props.onClick(e)}
-      title="Click to copy · Shift+click to select range"
-      style={{
-        display: "flex",
-        "align-items": "center",
-        gap: "6px",
-        padding: "0 10px",
-        height: `${ROW_HEIGHT}px`,
-        "min-height": `${ROW_HEIGHT}px`,
-        background: defaultRowBackground(),
-        "border-left": props.focusMarked
-          ? "4px solid var(--accent)"
-          : `2px solid ${semanticBorderColor()}`,
-        overflow: "hidden",
-        cursor: "pointer",
-      }}
-      onMouseEnter={(e) => {
-        if (!props.focusMarked && !props.inSelectionRange && !props.jsonSelected) {
-          (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.04)";
-        }
-      }}
-      onMouseLeave={(e) => {
-        if (!props.focusMarked && !props.inSelectionRange && !props.jsonSelected) {
-          (e.currentTarget as HTMLElement).style.background = props.entry.isCrash
-            ? "color-mix(in srgb, var(--error) 12%, transparent)"
-            : hasAnr()
-              ? "color-mix(in srgb, var(--warning) 8%, transparent)"
-              : cfg().bg;
-        } else {
-          (e.currentTarget as HTMLElement).style.background = defaultRowBackground();
-        }
-      }}
-    >
-      {/* Timestamp */}
-      <span
-        style={{
-          color: "var(--text-disabled, #4b5563)",
-          "white-space": "nowrap",
-          "flex-shrink": "0",
-          "font-size": "10px",
-          opacity: "0.7",
-        }}
-      >
-        {props.entry.timestamp}
-      </span>
-
-      {/* Level badge */}
-      <span
-        style={{
-          color: cfg().color,
-          "font-weight": "700",
-          "min-width": "12px",
-          "text-align": "center",
-          "flex-shrink": "0",
-          "font-size": "11px",
-        }}
-      >
-        {cfg().label}
-      </span>
-
-      {/* Package chip */}
-      <Show when={props.entry.package}>
-        <span
-          style={{
-            "font-size": "9px",
-            color: "var(--accent)",
-            "flex-shrink": "0",
-            "max-width": "90px",
-            overflow: "hidden",
-            "text-overflow": "ellipsis",
-            "white-space": "nowrap",
-            opacity: "0.8",
-          }}
-          title={props.entry.package ?? ""}
-        >
-          {props.entry.package}
-        </span>
-      </Show>
-
-      {/* Tag */}
-      <span
-        style={{
-          color: "var(--text-secondary)",
-          "min-width": "80px",
-          "max-width": "120px",
-          overflow: "hidden",
-          "text-overflow": "ellipsis",
-          "white-space": "nowrap",
-          "flex-shrink": "0",
-          "font-size": "10px",
-        }}
-        title={props.entry.tag}
-      >
-        {props.entry.tag}
-      </span>
-
-      {/* JSON badge — clickable to open detail panel */}
-      <Show when={hasJson()}>
-        <span
-          onClick={(e) => props.onJsonClick(e)}
-          title="Click to view formatted JSON"
-          style={{
-            "font-size": "9px",
-            color: props.jsonSelected ? "var(--accent-fg)" : "var(--info)",
-            "flex-shrink": "0",
-            opacity: "1",
-            "font-weight": "600",
-            background: props.jsonSelected
-              ? "color-mix(in srgb, var(--info) 50%, transparent)"
-              : "color-mix(in srgb, var(--info) 10%, transparent)",
-            padding: "0 4px",
-            "border-radius": "2px",
-            cursor: "pointer",
-            border: "1px solid color-mix(in srgb, var(--info) 30%, transparent)",
-          }}
-        >
-          {"{}"}
-        </span>
-      </Show>
-
-      {/* ANR badge */}
-      <Show when={hasAnr()}>
-        <span
-          style={{
-            "font-size": "9px",
-            color: "var(--warning)",
-            "flex-shrink": "0",
-            "font-weight": "600",
-            background: "color-mix(in srgb, var(--warning) 10%, transparent)",
-            padding: "0 3px",
-            "border-radius": "2px",
-          }}
-        >
-          ANR
-        </span>
-      </Show>
-
-      {/* Message */}
-      <span
-        style={{
-          flex: "1",
-          color: props.entry.isCrash
-            ? "var(--error)"
-            : hasAnr()
-              ? "var(--warning)"
-              : props.entry.level.toLowerCase() === "info"
-                ? "var(--text-primary)"
-                : cfg().color,
-          "white-space": "nowrap",
-          overflow: "hidden",
-          "text-overflow": "ellipsis",
-        }}
-        title={props.entry.message}
-      >
-        {props.entry.message}
-      </span>
-
-      {/* Open in Studio button — shown for crash-group stack frame lines */}
-      <Show when={inCrashGroup() || props.entry.isCrash}>
-        <StudioJumpButton message={props.entry.message} />
-      </Show>
-    </div>
-  );
-}
-
-// ── JsonDetailPanel ───────────────────────────────────────────────────────────
-
-function JsonDetailPanel(props: { entry: LogcatEntry; onClose: () => void }): JSX.Element {
-  const [copied, setCopied] = createSignal(false);
-
-  const formattedJson = () => {
-    try {
-      const raw = props.entry.jsonBody;
-      if (!raw) return null;
-      return JSON.stringify(JSON.parse(raw), null, 2);
-    } catch {
-      return props.entry.jsonBody;
-    }
-  };
-
-  async function copyJson() {
-    const json = formattedJson();
-    if (!json) return;
-    try {
-      await navigator.clipboard.writeText(json);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      /* ignore */
-    }
-  }
-
-  return (
-    <div
-      style={{
-        "flex-shrink": "0",
-        "max-height": "220px",
-        display: "flex",
-        "flex-direction": "column",
-        background: "var(--bg-secondary)",
-        "border-top": "1px solid var(--border)",
-      }}
-    >
-      {/* Panel header */}
-      <div
-        style={{
-          display: "flex",
-          "align-items": "center",
-          gap: "6px",
-          padding: "3px 10px",
-          background: "var(--bg-tertiary)",
-          "border-bottom": "1px solid var(--border)",
-          "flex-shrink": "0",
-        }}
-      >
-        <span style={{ "font-size": "10px", color: "var(--info)", "font-weight": "600" }}>
-          JSON
-        </span>
-        <span
-          style={{
-            "font-size": "10px",
-            color: "var(--text-muted)",
-            flex: "1",
-            overflow: "hidden",
-            "text-overflow": "ellipsis",
-            "white-space": "nowrap",
-          }}
-        >
-          {props.entry.tag}: {props.entry.timestamp}
-        </span>
-        <button
-          onClick={copyJson}
-          title="Copy JSON"
-          style={{
-            background: "none",
-            border: "1px solid var(--border)",
-            color: copied() ? "var(--success)" : "var(--text-muted)",
-            "border-radius": "3px",
-            cursor: "pointer",
-            "font-size": "10px",
-            padding: "1px 6px",
-          }}
-        >
-          {copied() ? "Copied!" : "Copy"}
-        </button>
-        <button
-          onClick={() => props.onClose()}
-          title="Close JSON viewer"
-          style={{
-            background: "none",
-            border: "none",
-            color: "var(--text-muted)",
-            cursor: "pointer",
-            "font-size": "12px",
-            padding: "0 4px",
-          }}
-        >
-          ✕
-        </button>
-      </div>
-
-      {/* JSON content */}
-      <pre
-        style={{
-          flex: "1",
-          overflow: "auto",
-          margin: "0",
-          padding: "8px 12px",
-          "font-family": "var(--font-mono)",
-          "font-size": "11px",
-          "line-height": "1.5",
-          color: "var(--text-primary)",
-          "white-space": "pre",
-          background: "transparent",
-        }}
-      >
-        {formattedJson() ?? "(invalid JSON)"}
-      </pre>
-    </div>
-  );
-}
-
-// ── Style helpers ─────────────────────────────────────────────────────────────
-
-function btnStyle(color: string): Record<string, string> {
-  return {
-    display: "flex",
-    "align-items": "center",
-    gap: "4px",
-    padding: "3px 8px",
-    background: "none",
-    border: "1px solid var(--border)",
-    color,
-    "border-radius": "4px",
-    cursor: "pointer",
-    "font-size": "11px",
-    "white-space": "nowrap",
-  };
 }

--- a/src/components/logcat/LogcatRows.tsx
+++ b/src/components/logcat/LogcatRows.tsx
@@ -1,0 +1,368 @@
+import { type JSX, Show, createMemo, createSignal } from "solid-js";
+import type { LogcatEntry } from "@/lib/tauri-api";
+import { showToast } from "@/components/ui";
+import { openInStudio } from "@/lib/tauri-api";
+import { healthState } from "@/stores/health.store";
+import { isProjectFrame, parseStackFrame } from "@/lib/logcat-query";
+import { LEVEL_CONFIG } from "./logcat-levels";
+import { rowFocusMarked, rowInSelectionRange } from "./logcat-row-selection";
+
+export const ROW_HEIGHT = 20;
+
+const ENTRY_FLAGS = {
+  CRASH: 1 << 0,
+  ANR: 1 << 1,
+  JSON_BODY: 1 << 2,
+  NATIVE_CRASH: 1 << 3,
+} as const;
+
+export function LogcatVirtualRow(props: {
+  entry: LogcatEntry;
+  index: number;
+  getSelectionRange: () => [number, number] | null;
+  getAnchor: () => number | null;
+  getEnd: () => number | null;
+  getDetailEntry: () => LogcatEntry | null;
+  getJsonEntry: () => LogcatEntry | null;
+  onRowClick: (e: MouseEvent) => void;
+  onJsonClick: (e: MouseEvent) => void;
+}): JSX.Element {
+  const inSelectionRange = createMemo(() =>
+    rowInSelectionRange(props.index, props.getSelectionRange())
+  );
+
+  const focusMarked = createMemo(() =>
+    rowFocusMarked(
+      props.index,
+      props.getAnchor(),
+      props.getEnd(),
+      props.getDetailEntry(),
+      props.entry.id
+    )
+  );
+
+  const jsonSelected = createMemo(() => props.getJsonEntry()?.id === props.entry.id);
+
+  return (
+    <LogcatRow
+      entry={props.entry}
+      inSelectionRange={inSelectionRange()}
+      focusMarked={focusMarked()}
+      jsonSelected={jsonSelected()}
+      onClick={props.onRowClick}
+      onJsonClick={props.onJsonClick}
+    />
+  );
+}
+
+export function SeparatorRow(props: { entry: LogcatEntry }): JSX.Element {
+  const isDied = () => props.entry.kind === "processDied";
+  const pkg = () => props.entry.package ?? props.entry.tag;
+  const label = () => (isDied() ? `⚠  ${pkg()} PROCESS DIED` : `▶  ${pkg()} PROCESS RESTARTED`);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        "align-items": "center",
+        height: `${ROW_HEIGHT}px`,
+        "min-height": `${ROW_HEIGHT}px`,
+        padding: "0 8px",
+        background: isDied()
+          ? "color-mix(in srgb, var(--error) 10%, transparent)"
+          : "color-mix(in srgb, var(--success) 7%, transparent)",
+        "border-top": `1px solid ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
+        "border-bottom": `1px solid ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
+        overflow: "hidden",
+      }}
+    >
+      <span
+        style={{
+          flex: "1",
+          "border-top": `1px dashed ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
+        }}
+      />
+      <span
+        style={{
+          "font-size": "10px",
+          color: isDied() ? "var(--error)" : "var(--success)",
+          "font-weight": "600",
+          "white-space": "nowrap",
+          padding: "0 10px",
+          "letter-spacing": "0.04em",
+        }}
+      >
+        {label()}
+      </span>
+      <span style={{ "font-size": "10px", color: "var(--text-muted)", "flex-shrink": "0" }}>
+        {props.entry.timestamp}
+      </span>
+      <span
+        style={{
+          flex: "1",
+          "border-top": `1px dashed ${isDied() ? "color-mix(in srgb, var(--error) 30%, transparent)" : "color-mix(in srgb, var(--success) 20%, transparent)"}`,
+        }}
+      />
+    </div>
+  );
+}
+
+function StudioJumpButton(props: { message: string }): JSX.Element {
+  const frame = () => {
+    const f = parseStackFrame(props.message);
+    if (f && !isProjectFrame(f.classPath)) return null;
+    return f;
+  };
+  const studioReady = () => healthState.systemReport?.studioCommandFound === true;
+  const [hovered, setHovered] = createSignal(false);
+  const [opening, setOpening] = createSignal(false);
+
+  const handleOpen = async (e: MouseEvent) => {
+    e.stopPropagation();
+    const f = frame();
+    if (!f) return;
+    if (!studioReady()) {
+      showToast("Install the studio command — see Health Panel for setup instructions", "warning");
+      return;
+    }
+    setOpening(true);
+    try {
+      await openInStudio(f.packagePath, f.filename, f.line);
+    } catch (err: unknown) {
+      showToast(String(err), "error");
+    } finally {
+      setOpening(false);
+    }
+  };
+
+  return (
+    <Show when={frame() !== null}>
+      <button
+        onClick={handleOpen}
+        title={
+          studioReady()
+            ? `Open ${frame()!.filename}:${frame()!.line} in Android Studio`
+            : "Install the studio command to enable jump-to-line (see Health Panel)"
+        }
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        style={{
+          "flex-shrink": "0",
+          display: "inline-flex",
+          "align-items": "center",
+          gap: "3px",
+          padding: "1px 6px",
+          "border-radius": "3px",
+          border: `1px solid ${studioReady() ? "color-mix(in srgb, var(--info) 40%, transparent)" : "color-mix(in srgb, var(--text-muted) 30%, transparent)"}`,
+          background: hovered()
+            ? studioReady()
+              ? "color-mix(in srgb, var(--info) 15%, transparent)"
+              : "color-mix(in srgb, var(--text-muted) 10%, transparent)"
+            : "transparent",
+          color: studioReady() ? "var(--info)" : "var(--text-disabled)",
+          cursor: opening() ? "wait" : studioReady() ? "pointer" : "not-allowed",
+          "font-size": "9px",
+          "font-family": "var(--font-ui)",
+          "font-weight": "500",
+          opacity: opening() ? "0.6" : "1",
+          transition: "background 0.1s, opacity 0.1s",
+          "white-space": "nowrap",
+        }}
+      >
+        {opening() ? "⟳" : "↗"} Studio
+      </button>
+    </Show>
+  );
+}
+
+function LogcatRow(props: {
+  entry: LogcatEntry;
+  inSelectionRange: boolean;
+  focusMarked: boolean;
+  jsonSelected: boolean;
+  onClick: (e: MouseEvent) => void;
+  onJsonClick: (e: MouseEvent) => void;
+}): JSX.Element {
+  const cfg = () =>
+    LEVEL_CONFIG[props.entry.level as keyof typeof LEVEL_CONFIG] ?? LEVEL_CONFIG.unknown;
+  const hasJson = () => (props.entry.flags & ENTRY_FLAGS.JSON_BODY) !== 0;
+  const hasAnr = () => (props.entry.flags & ENTRY_FLAGS.ANR) !== 0;
+  const inCrashGroup = () => props.entry.crashGroupId !== null && !props.entry.isCrash;
+
+  const semanticBorderColor = () => {
+    if (props.entry.isCrash) return "var(--error)";
+    if (hasAnr()) return "var(--warning)";
+    if (inCrashGroup()) return "color-mix(in srgb, var(--error) 40%, transparent)";
+    return "transparent";
+  };
+
+  const ACCENT_RANGE_BG = "rgba(var(--accent-rgb, 59,130,246),0.14)";
+  const ACCENT_FOCUS_BG = "rgba(var(--accent-rgb, 59,130,246),0.28)";
+
+  function defaultRowBackground(): string {
+    if (props.focusMarked) return ACCENT_FOCUS_BG;
+    if (props.inSelectionRange) return ACCENT_RANGE_BG;
+    if (props.jsonSelected) return "color-mix(in srgb, var(--info) 12%, transparent)";
+    if (props.entry.isCrash) return "color-mix(in srgb, var(--error) 12%, transparent)";
+    if (hasAnr()) return "color-mix(in srgb, var(--warning) 8%, transparent)";
+    return cfg().bg;
+  }
+
+  return (
+    <div
+      onClick={(e) => props.onClick(e)}
+      title="Click to copy · Shift+click to select range"
+      style={{
+        display: "flex",
+        "align-items": "center",
+        gap: "6px",
+        padding: "0 10px",
+        height: `${ROW_HEIGHT}px`,
+        "min-height": `${ROW_HEIGHT}px`,
+        background: defaultRowBackground(),
+        "border-left": props.focusMarked
+          ? "4px solid var(--accent)"
+          : `2px solid ${semanticBorderColor()}`,
+        overflow: "hidden",
+        cursor: "pointer",
+      }}
+      onMouseEnter={(e) => {
+        if (!props.focusMarked && !props.inSelectionRange && !props.jsonSelected) {
+          (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.04)";
+        }
+      }}
+      onMouseLeave={(e) => {
+        if (!props.focusMarked && !props.inSelectionRange && !props.jsonSelected) {
+          (e.currentTarget as HTMLElement).style.background = props.entry.isCrash
+            ? "color-mix(in srgb, var(--error) 12%, transparent)"
+            : hasAnr()
+              ? "color-mix(in srgb, var(--warning) 8%, transparent)"
+              : cfg().bg;
+        } else {
+          (e.currentTarget as HTMLElement).style.background = defaultRowBackground();
+        }
+      }}
+    >
+      <span
+        style={{
+          color: "var(--text-disabled, #4b5563)",
+          "white-space": "nowrap",
+          "flex-shrink": "0",
+          "font-size": "10px",
+          opacity: "0.7",
+        }}
+      >
+        {props.entry.timestamp}
+      </span>
+
+      <span
+        style={{
+          color: cfg().color,
+          "font-weight": "700",
+          "min-width": "12px",
+          "text-align": "center",
+          "flex-shrink": "0",
+          "font-size": "11px",
+        }}
+      >
+        {cfg().label}
+      </span>
+
+      <Show when={props.entry.package}>
+        <span
+          style={{
+            "font-size": "9px",
+            color: "var(--accent)",
+            "flex-shrink": "0",
+            "max-width": "90px",
+            overflow: "hidden",
+            "text-overflow": "ellipsis",
+            "white-space": "nowrap",
+            opacity: "0.8",
+          }}
+          title={props.entry.package ?? ""}
+        >
+          {props.entry.package}
+        </span>
+      </Show>
+
+      <span
+        style={{
+          color: "var(--text-secondary)",
+          "min-width": "80px",
+          "max-width": "120px",
+          overflow: "hidden",
+          "text-overflow": "ellipsis",
+          "white-space": "nowrap",
+          "flex-shrink": "0",
+          "font-size": "10px",
+        }}
+        title={props.entry.tag}
+      >
+        {props.entry.tag}
+      </span>
+
+      <Show when={hasJson()}>
+        <span
+          onClick={(e) => props.onJsonClick(e)}
+          title="Click to view formatted JSON"
+          style={{
+            "font-size": "9px",
+            color: props.jsonSelected ? "var(--accent-fg)" : "var(--info)",
+            "flex-shrink": "0",
+            opacity: "1",
+            "font-weight": "600",
+            background: props.jsonSelected
+              ? "color-mix(in srgb, var(--info) 50%, transparent)"
+              : "color-mix(in srgb, var(--info) 10%, transparent)",
+            padding: "0 4px",
+            "border-radius": "2px",
+            cursor: "pointer",
+            border: "1px solid color-mix(in srgb, var(--info) 30%, transparent)",
+          }}
+        >
+          {"{}"}
+        </span>
+      </Show>
+
+      <Show when={hasAnr()}>
+        <span
+          style={{
+            "font-size": "9px",
+            color: "var(--warning)",
+            "flex-shrink": "0",
+            "font-weight": "600",
+            background: "color-mix(in srgb, var(--warning) 10%, transparent)",
+            padding: "0 3px",
+            "border-radius": "2px",
+          }}
+        >
+          ANR
+        </span>
+      </Show>
+
+      <span
+        style={{
+          flex: "1",
+          color: props.entry.isCrash
+            ? "var(--error)"
+            : hasAnr()
+              ? "var(--warning)"
+              : props.entry.level.toLowerCase() === "info"
+                ? "var(--text-primary)"
+                : cfg().color,
+          "white-space": "nowrap",
+          overflow: "hidden",
+          "text-overflow": "ellipsis",
+        }}
+        title={props.entry.message}
+      >
+        {props.entry.message}
+      </span>
+
+      <Show when={inCrashGroup() || props.entry.isCrash}>
+        <StudioJumpButton message={props.entry.message} />
+      </Show>
+    </div>
+  );
+}

--- a/src/components/logcat/LogcatToolbar.test.tsx
+++ b/src/components/logcat/LogcatToolbar.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { LogcatToolbar } from "./LogcatToolbar";
+
+function renderToolbar(overrides: Partial<Parameters<typeof LogcatToolbar>[0]> = {}) {
+  const props: Parameters<typeof LogcatToolbar>[0] = {
+    streaming: true,
+    paused: false,
+    restarting: false,
+    crashes: 0,
+    selectedCount: 0,
+    autoScroll: true,
+    toolbarCount: { text: "0 rows", title: "No rows" },
+    onStart: vi.fn(),
+    onStop: vi.fn(),
+    onTogglePaused: vi.fn(),
+    onRestart: vi.fn(),
+    onClear: vi.fn(),
+    onJumpToLastCrash: vi.fn(),
+    onJumpToPreviousCrash: vi.fn(),
+    onJumpToNextCrash: vi.fn(),
+    onCopySelectedRows: vi.fn(),
+    onScrollToEnd: vi.fn(),
+    onExport: vi.fn(),
+    renderSavedFilterMenu: () => <div data-testid="saved-filter-menu" />,
+    ...overrides,
+  };
+
+  return {
+    ...render(() => <LogcatToolbar {...props} />),
+    props,
+  };
+}
+
+describe("LogcatToolbar", () => {
+  it("shows copy-selected for a single selected row", () => {
+    const onCopySelectedRows = vi.fn();
+    renderToolbar({ selectedCount: 1, onCopySelectedRows });
+
+    const button = screen.getByTitle("Copy selected row");
+    expect(button.textContent).toContain("1 row");
+
+    fireEvent.click(button);
+    expect(onCopySelectedRows).toHaveBeenCalledOnce();
+  });
+
+  it("hides copy-selected when no rows are selected", () => {
+    renderToolbar({ selectedCount: 0 });
+
+    expect(screen.queryByTitle("Copy selected row")).toBeNull();
+  });
+});

--- a/src/components/logcat/LogcatToolbar.tsx
+++ b/src/components/logcat/LogcatToolbar.tsx
@@ -112,13 +112,17 @@ export function LogcatToolbar(props: {
         </div>
       </Show>
 
-      <Show when={props.selectedCount > 1}>
+      <Show when={props.selectedCount > 0}>
         <button
           onClick={() => props.onCopySelectedRows()}
-          title={`Copy ${props.selectedCount} selected rows`}
+          title={
+            props.selectedCount === 1
+              ? "Copy selected row"
+              : `Copy ${props.selectedCount} selected rows`
+          }
           style={btnStyle("var(--accent)")}
         >
-          ⎘ {props.selectedCount} rows
+          ⎘ {props.selectedCount === 1 ? "1 row" : `${props.selectedCount} rows`}
         </button>
       </Show>
 

--- a/src/components/logcat/LogcatToolbar.tsx
+++ b/src/components/logcat/LogcatToolbar.tsx
@@ -1,0 +1,171 @@
+import { Show, type JSX } from "solid-js";
+import { Icon } from "@/components/ui";
+import { btnStyle } from "./logcat-styles";
+
+export function LogcatToolbar(props: {
+  streaming: boolean;
+  paused: boolean;
+  restarting: boolean;
+  crashes: number;
+  selectedCount: number;
+  autoScroll: boolean;
+  toolbarCount: { text: string; title: string };
+  onStart: () => void;
+  onStop: () => void;
+  onTogglePaused: () => void;
+  onRestart: () => void;
+  onClear: () => void;
+  onJumpToLastCrash: () => void;
+  onJumpToPreviousCrash: () => void;
+  onJumpToNextCrash: () => void;
+  onCopySelectedRows: () => void;
+  onScrollToEnd: () => void;
+  onExport: () => void;
+  renderSavedFilterMenu: () => JSX.Element;
+}): JSX.Element {
+  return (
+    <div
+      style={{
+        display: "flex",
+        "align-items": "flex-start",
+        gap: "6px",
+        padding: "5px 10px",
+        background: "var(--bg-secondary)",
+        "border-bottom": "1px solid var(--border)",
+        "flex-shrink": "0",
+        "flex-wrap": "wrap",
+      }}
+    >
+      <Show
+        when={props.streaming}
+        fallback={
+          <button
+            onClick={() => props.onStart()}
+            title="Start Logcat"
+            style={btnStyle("var(--success)")}
+          >
+            <Icon name="play" size={13} /> Start
+          </button>
+        }
+      >
+        <button onClick={() => props.onStop()} title="Stop Logcat" style={btnStyle("var(--error)")}>
+          <Icon name="stop" size={13} /> Stop
+        </button>
+      </Show>
+
+      <button
+        onClick={() => props.onTogglePaused()}
+        title={props.paused ? "Resume" : "Pause new entries"}
+        style={btnStyle(props.paused ? "var(--warning)" : "var(--text-muted)")}
+      >
+        {props.paused ? "▶" : "⏸"}
+      </button>
+
+      <button
+        onClick={() => props.onRestart()}
+        title="Stop, clear and restart logcat"
+        disabled={props.restarting}
+        style={btnStyle("var(--text-muted)")}
+      >
+        ↺ Restart
+      </button>
+
+      <button
+        onClick={() => props.onClear()}
+        title="Clear logcat buffer"
+        style={btnStyle("var(--text-muted)")}
+      >
+        <Icon name="trash" size={12} />
+      </button>
+
+      <div
+        style={{ width: "1px", height: "18px", background: "var(--border)", "flex-shrink": "0" }}
+      />
+
+      <Show when={props.crashes > 0}>
+        <div style={{ display: "flex", "align-items": "center", gap: "2px", "flex-shrink": "0" }}>
+          <button
+            onClick={() => props.onJumpToLastCrash()}
+            title={`${props.crashes} crash${props.crashes !== 1 ? "es" : ""} — click to jump`}
+            style={{
+              ...btnStyle("var(--error)"),
+              gap: "3px",
+              animation: "lsp-dot-pulse 3s ease-in-out infinite",
+            }}
+          >
+            ⚡ {props.crashes}
+          </button>
+          <button
+            onClick={() => props.onJumpToPreviousCrash()}
+            title="Previous crash"
+            style={btnStyle("var(--text-muted)")}
+          >
+            ↑
+          </button>
+          <button
+            onClick={() => props.onJumpToNextCrash()}
+            title="Next crash"
+            style={btnStyle("var(--text-muted)")}
+          >
+            ↓
+          </button>
+        </div>
+      </Show>
+
+      <Show when={props.selectedCount > 1}>
+        <button
+          onClick={() => props.onCopySelectedRows()}
+          title={`Copy ${props.selectedCount} selected rows`}
+          style={btnStyle("var(--accent)")}
+        >
+          ⎘ {props.selectedCount} rows
+        </button>
+      </Show>
+
+      {props.renderSavedFilterMenu()}
+
+      <button
+        onClick={() => props.onScrollToEnd()}
+        title="Scroll to end"
+        style={btnStyle(props.autoScroll ? "var(--text-muted)" : "var(--accent)")}
+      >
+        ↓
+      </button>
+
+      <button
+        onClick={() => props.onExport()}
+        title="Export filtered log to file"
+        style={btnStyle("var(--text-muted)")}
+      >
+        ↓ Export
+      </button>
+
+      <div style={{ flex: "1" }} />
+
+      <span
+        title={props.toolbarCount.title}
+        style={{
+          "font-size": "11px",
+          color: "var(--text-muted)",
+          "flex-shrink": "0",
+          cursor: "default",
+        }}
+      >
+        {props.toolbarCount.text}
+      </span>
+
+      <Show when={props.streaming}>
+        <span
+          style={{
+            width: "6px",
+            height: "6px",
+            "border-radius": "50%",
+            background: "var(--success)",
+            "flex-shrink": "0",
+            animation: "lsp-dot-pulse 2s ease-in-out infinite",
+          }}
+        />
+      </Show>
+    </div>
+  );
+}

--- a/src/components/logcat/PackageDropdown.tsx
+++ b/src/components/logcat/PackageDropdown.tsx
@@ -8,14 +8,14 @@
  * `onSelect(null)` to clear the filter.
  */
 
-import {
-  type JSX,
-  createSignal,
-  createMemo,
-  For,
-  Show,
-} from "solid-js";
+import { type JSX, createSignal, createMemo, For, Show } from "solid-js";
 import { getMinePackage } from "@/lib/logcat-query";
+import {
+  logcatDropdownOverlayStyle,
+  logcatDropdownPanelStyle,
+  logcatDropdownRootStyle,
+  logcatDropdownSeparatorStyle,
+} from "./logcat-dropdown-styles";
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -45,9 +45,7 @@ export function PackageDropdown(props: PackageDropdownProps): JSX.Element {
 
   const filteredPackages = createMemo(() => {
     const q = search().toLowerCase();
-    return q
-      ? props.packages.filter((p) => p.toLowerCase().includes(q))
-      : props.packages;
+    return q ? props.packages.filter((p) => p.toLowerCase().includes(q)) : props.packages;
   });
 
   // Truncate for display in the button (keep last two segments of package name).
@@ -92,7 +90,7 @@ export function PackageDropdown(props: PackageDropdownProps): JSX.Element {
   // ── Render ───────────────────────────────────────────────────────────────────
 
   return (
-    <div style={{ position: "relative", "flex-shrink": "0" }}>
+    <div style={logcatDropdownRootStyle()}>
       {/* Trigger button */}
       <button
         onClick={handleToggle}
@@ -124,19 +122,11 @@ export function PackageDropdown(props: PackageDropdownProps): JSX.Element {
       {/* Dropdown panel */}
       <Show when={open()}>
         <div
-          style={{
-            position: "absolute",
-            top: "calc(100% + 4px)",
-            left: "0",
-            "min-width": "220px",
-            "max-width": "320px",
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "4px",
-            "box-shadow": "0 6px 20px rgba(0,0,0,0.45)",
-            "z-index": "700",
-            "font-size": "11px",
-          }}
+          style={logcatDropdownPanelStyle({
+            align: "left",
+            minWidth: "220px",
+            maxWidth: "320px",
+          })}
         >
           {/* Search input */}
           <div style={{ padding: "6px 8px 4px", "border-bottom": "1px solid var(--border)" }}>
@@ -197,7 +187,7 @@ export function PackageDropdown(props: PackageDropdownProps): JSX.Element {
 
             {/* Separator */}
             <Show when={!search() && props.packages.length > 0}>
-              <div style={{ height: "1px", background: "var(--border)", margin: "4px 0" }} />
+              <div style={logcatDropdownSeparatorStyle()} />
             </Show>
 
             {/* Actual package list */}
@@ -229,10 +219,7 @@ export function PackageDropdown(props: PackageDropdownProps): JSX.Element {
         </div>
 
         {/* Click-outside overlay */}
-        <div
-          style={{ position: "fixed", inset: "0", "z-index": "699" }}
-          onClick={() => setOpen(false)}
-        />
+        <div style={logcatDropdownOverlayStyle()} onClick={() => setOpen(false)} />
       </Show>
     </div>
   );
@@ -259,7 +246,8 @@ function PackageRow(props: {
         color: props.active ? "var(--accent)" : "var(--text-primary)",
       }}
       onMouseEnter={(e) => {
-        if (!props.active) (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.06)";
+        if (!props.active)
+          (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.06)";
       }}
       onMouseLeave={(e) => {
         if (!props.active) (e.currentTarget as HTMLElement).style.background = "transparent";
@@ -285,7 +273,14 @@ function PackageRow(props: {
       </span>
 
       <Show when={props.sublabel}>
-        <span style={{ "font-size": "9px", color: "var(--text-muted)", "flex-shrink": "0", "font-family": "var(--font-mono)" }}>
+        <span
+          style={{
+            "font-size": "9px",
+            color: "var(--text-muted)",
+            "flex-shrink": "0",
+            "font-family": "var(--font-mono)",
+          }}
+        >
           {props.sublabel}
         </span>
       </Show>

--- a/src/components/logcat/QueryBar.tsx
+++ b/src/components/logcat/QueryBar.tsx
@@ -24,11 +24,8 @@
 
 import { type JSX, createSignal, createMemo, For, Show, untrack } from "solid-js";
 import {
-  QUERY_KEYS,
-  LEVEL_NAMES,
-  AGE_SUGGESTIONS,
-  IS_SUGGESTIONS,
   getActiveTokenContext,
+  getQueryBarSuggestions,
   parseQueryBarState,
   balanceMessageDraftQuotes,
   buildQueryBarPillGroups,
@@ -41,6 +38,25 @@ import {
   applyInlineEditCommit,
   commitQueryBarDraft,
 } from "@/lib/logcat-query";
+import {
+  QueryBarAndBadge,
+  QueryBarConnectorButton,
+  QueryBarInlineEditInput,
+  QueryBarOrBadge,
+  QueryBarPill,
+  QueryBarSuggestions,
+} from "./QueryBarParts";
+import {
+  queryBarClearButtonStyle,
+  queryBarConnectorGroupStyle,
+  queryBarContainerStyle,
+  queryBarDraftInputStyle,
+  queryBarGroupBoxStyle,
+  queryBarInputRowStyle,
+  queryBarOrphanInlineEditStyle,
+  queryBarRootStyle,
+  searchIconStyle,
+} from "./querybar-styles";
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -50,59 +66,6 @@ export interface QueryBarProps {
   knownTags: string[];
   knownPackages: string[];
   placeholder?: string;
-}
-
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-const MAX_SUGGESTIONS = 10;
-
-// ── Token styling ─────────────────────────────────────────────────────────────
-
-interface TokenStyle {
-  color: string;
-  bg: string;
-  border: string;
-}
-
-function getTokenStyle(tokenText: string): TokenStyle {
-  const t = tokenText.startsWith("-") ? tokenText.slice(1) : tokenText;
-  if (t.startsWith("level:"))
-    return {
-      color: "var(--warning)",
-      bg: "color-mix(in srgb, var(--warning) 13%, transparent)",
-      border: "color-mix(in srgb, var(--warning) 35%, transparent)",
-    };
-  if (t.startsWith("tag:") || t.startsWith("tag~:"))
-    return {
-      color: "var(--info)",
-      bg: "color-mix(in srgb, var(--info) 13%, transparent)",
-      border: "color-mix(in srgb, var(--info) 35%, transparent)",
-    };
-  if (t.startsWith("message:") || t.startsWith("message~:") || t.startsWith("msg:"))
-    return {
-      color: "var(--success)",
-      bg: "color-mix(in srgb, var(--success) 11%, transparent)",
-      border: "color-mix(in srgb, var(--success) 35%, transparent)",
-    };
-  if (t.startsWith("package:") || t.startsWith("pkg:"))
-    return {
-      color: "var(--accent)",
-      bg: "color-mix(in srgb, var(--accent) 13%, transparent)",
-      border: "color-mix(in srgb, var(--accent) 40%, transparent)",
-    };
-  if (t.startsWith("age:"))
-    return {
-      color: "var(--accent)",
-      bg: "color-mix(in srgb, var(--accent) 13%, transparent)",
-      border: "color-mix(in srgb, var(--accent) 35%, transparent)",
-    };
-  if (t.startsWith("is:"))
-    return {
-      color: "var(--error)",
-      bg: "color-mix(in srgb, var(--error) 13%, transparent)",
-      border: "color-mix(in srgb, var(--error) 35%, transparent)",
-    };
-  return { color: "var(--text-secondary)", bg: "rgba(255,255,255,0.07)", border: "var(--border)" };
 }
 
 // ── Query parsing helpers (local to this component) ───────────────────────────
@@ -160,22 +123,6 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
     return pillGroups().reduce((n, gr) => n + gr.length, 0);
   }
 
-  function inlineSlotStyle(): Record<string, string> {
-    return {
-      flex: "1",
-      "min-width": "120px",
-      "max-width": "420px",
-      background: "var(--bg-primary)",
-      border: "1px solid var(--accent)",
-      color: "var(--text-primary)",
-      "font-size": "11px",
-      "font-family": "var(--font-mono)",
-      "border-radius": "10px",
-      padding: "1px 6px",
-      outline: "none",
-    };
-  }
-
   /** True when the draft lives in a new OR group (last committed part is `|`). */
   const draftInNewGroup = createMemo(() => committedEndsWithOrSeparator(committed()));
 
@@ -195,54 +142,9 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
 
   // ── Suggestions (based on the draft being typed) ──────────────────────────
 
-  const suggestions = createMemo(() => {
-    const ctx = getActiveTokenContext(draft());
-
-    if (ctx.key) {
-      const partial = ctx.partial.toLowerCase();
-      switch (ctx.key.toLowerCase()) {
-        case "level":
-          return LEVEL_NAMES.filter((l) => l.startsWith(partial)).map((l) => ({
-            display: l,
-            insert: l,
-          }));
-        case "tag":
-          return props.knownTags
-            .filter((t) => t.toLowerCase().includes(partial))
-            .slice(0, MAX_SUGGESTIONS)
-            .map((t) => ({ display: t, insert: t }));
-        case "package":
-          return ["mine", ...props.knownPackages]
-            .filter((p) => p.toLowerCase().includes(partial))
-            .slice(0, MAX_SUGGESTIONS)
-            .map((p) => ({ display: p, insert: p }));
-        case "is":
-          return IS_SUGGESTIONS.filter((s) => s.startsWith(partial)).map((s) => ({
-            display: s,
-            insert: s,
-          }));
-        case "age":
-          return AGE_SUGGESTIONS.filter((a) => a.startsWith(partial)).map((a) => ({
-            display: a,
-            insert: a,
-          }));
-        default:
-          return [];
-      }
-    }
-
-    const partial = ctx.partial.toLowerCase();
-    if (!partial) return QUERY_KEYS.map((k) => ({ display: k, insert: k }));
-
-    const keySuggestions = QUERY_KEYS.filter((k) => k.toLowerCase().startsWith(partial)).map(
-      (k) => ({ display: k, insert: k })
-    );
-    const levelSuggestions = LEVEL_NAMES.filter((l) => l.startsWith(partial)).map((l) => ({
-      display: `${l} (level shorthand)`,
-      insert: l,
-    }));
-    return [...keySuggestions, ...levelSuggestions].slice(0, MAX_SUGGESTIONS);
-  });
+  const suggestions = createMemo(() =>
+    getQueryBarSuggestions(draft(), props.knownTags, props.knownPackages)
+  );
 
   const hasSuggestions = () => open() && suggestions().length > 0;
 
@@ -524,7 +426,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div ref={containerRef} style={{ position: "relative", flex: "1", "min-width": "280px" }}>
+    <div ref={containerRef} style={queryBarRootStyle()}>
       {/* ── Pill + draft input container ─────────────────────────────────── */}
       {/*                                                                      */}
       {/* Single flex-wrap container. Everything is an inline flex item:       */}
@@ -534,35 +436,9 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
       {/* unit — preventing the buttons from separating from the input.        */}
       {/* ⌕ and ✕ are inline (no absolute positioning) so they follow         */}
       {/* the natural flex height as pills wrap to multiple rows.              */}
-      <div
-        onClick={() => draftRef?.focus()}
-        style={{
-          display: "flex",
-          "flex-wrap": "wrap",
-          "align-items": "center",
-          gap: "3px",
-          "min-height": "26px",
-          padding: "3px 6px",
-          background: "var(--bg-primary)",
-          border: `1px solid ${isActive() ? "var(--accent)" : "var(--border)"}`,
-          "border-radius": "4px",
-          cursor: "text",
-          transition: "border-color 0.1s",
-        }}
-      >
+      <div onClick={() => draftRef?.focus()} style={queryBarContainerStyle(isActive())}>
         {/* Search icon — inline flex item, always at start of first row */}
-        <span
-          style={{
-            "flex-shrink": "0",
-            color: "var(--text-muted)",
-            "font-size": "11px",
-            "pointer-events": "none",
-            opacity: "0.6",
-            "line-height": "1",
-          }}
-        >
-          ⌕
-        </span>
+        <span style={searchIconStyle()}>⌕</span>
 
         {/* ── Pill groups ─────────────────────────────────────────────── */}
         <For each={pillGroups()}>
@@ -571,153 +447,56 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
               <>
                 {/* OR badge between groups */}
                 <Show when={gi() > 0}>
-                  <span
-                    style={{
-                      "font-size": "9px",
-                      "font-weight": "700",
-                      "letter-spacing": "0.05em",
-                      color: "var(--accent)",
-                      background: "rgba(var(--accent-rgb,59,130,246),0.13)",
-                      border: "1px solid rgba(var(--accent-rgb,59,130,246),0.35)",
-                      "border-radius": "10px",
-                      padding: "1px 5px",
-                      "flex-shrink": "0",
-                      "user-select": "none",
-                    }}
-                  >
-                    OR
-                  </span>
+                  <QueryBarOrBadge />
                 </Show>
 
                 {/* Group container: visible box only when 2+ groups exist */}
-                <div style={multiGroup() ? groupBoxStyle() : { display: "contents" }}>
+                <div style={multiGroup() ? queryBarGroupBoxStyle() : { display: "contents" }}>
                   {/* Tokens in this group */}
                   <For each={group}>
-                    {(token, ti) => {
-                      const s = getTokenStyle(token);
-                      const negated = token.startsWith("-");
-                      return (
-                        <>
-                          <Show
-                            when={
-                              inlineEdit()?.groupIdx === gi() && inlineEdit()?.tokenIdx === ti()
-                            }
-                          >
-                            <input
-                              ref={inlineEditRef}
-                              type="text"
-                              spellcheck={false}
-                              value={inlineEdit()?.text ?? ""}
-                              onInput={handleInlineInput}
-                              onKeyDown={handleInlineKeyDown}
-                              onBlur={handleInlineBlur}
-                              onClick={(e) => e.stopPropagation()}
-                              onMouseDown={(e) => e.stopPropagation()}
-                              placeholder="Edit filter…"
-                              style={{ ...inlineSlotStyle(), flex: "0 1 auto" }}
-                            />
-                          </Show>
-                          {/* AND badge between pills in the same group */}
-                          <Show when={ti() > 0}>
-                            <span
-                              style={{
-                                "font-size": "9px",
-                                "font-weight": "600",
-                                "letter-spacing": "0.04em",
-                                color: "var(--text-muted)",
-                                border: "1px dashed var(--border)",
-                                "border-radius": "10px",
-                                padding: "1px 5px",
-                                "flex-shrink": "0",
-                                "user-select": "none",
-                              }}
-                            >
-                              AND
-                            </span>
-                          </Show>
-
-                          {/* Token pill — stop click bubbling so the container does not
-                              focus the draft on the same gesture (would skip focusing
-                              the inline editor and leave the pill removed). */}
-                          <span
-                            onClick={(e) => e.stopPropagation()}
-                            style={{
-                              display: "inline-flex",
-                              "align-items": "center",
-                              gap: "2px",
-                              "font-size": "10px",
-                              "font-family": "var(--font-mono)",
-                              color: s.color,
-                              background: s.bg,
-                              border: `1px solid ${s.border}`,
-                              "border-radius": "10px",
-                              padding: "1px 4px 1px 6px",
-                              "flex-shrink": "0",
-                              "white-space": "nowrap",
-                              opacity: negated ? "0.65" : "1",
+                    {(token, ti) => (
+                      <>
+                        <Show
+                          when={inlineEdit()?.groupIdx === gi() && inlineEdit()?.tokenIdx === ti()}
+                        >
+                          <QueryBarInlineEditInput
+                            inputRef={(el) => {
+                              inlineEditRef = el;
                             }}
-                          >
-                            <span
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                editToken(gi(), ti(), token);
-                              }}
-                              title="Edit filter"
-                              style={{ cursor: "text", "user-select": "none" }}
-                            >
-                              {token}
-                            </span>
-                            <button
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                removeToken(gi(), ti());
-                              }}
-                              title="Remove filter"
-                              style={{
-                                background: "none",
-                                border: "none",
-                                color: s.color,
-                                cursor: "pointer",
-                                padding: "0 1px",
-                                "font-size": "9px",
-                                "line-height": "1",
-                                opacity: "0.55",
-                                display: "flex",
-                                "align-items": "center",
-                              }}
-                              onMouseEnter={(e) => {
-                                (e.currentTarget as HTMLElement).style.opacity = "1";
-                              }}
-                              onMouseLeave={(e) => {
-                                (e.currentTarget as HTMLElement).style.opacity = "0.55";
-                              }}
-                            >
-                              ✕
-                            </button>
-                          </span>
-                        </>
-                      );
-                    }}
+                            value={inlineEdit()?.text ?? ""}
+                            onInput={handleInlineInput}
+                            onKeyDown={handleInlineKeyDown}
+                            onBlur={handleInlineBlur}
+                            style={{ flex: "0 1 auto" }}
+                          />
+                        </Show>
+                        {/* AND badge between pills in the same group */}
+                        <Show when={ti() > 0}>
+                          <QueryBarAndBadge />
+                        </Show>
+
+                        <QueryBarPill
+                          token={token}
+                          onEdit={() => editToken(gi(), ti(), token)}
+                          onRemove={() => removeToken(gi(), ti())}
+                        />
+                      </>
+                    )}
                   </For>
                   <Show
                     when={
                       inlineEdit()?.groupIdx === gi() && inlineEdit()?.tokenIdx === group.length
                     }
                   >
-                    <input
-                      ref={inlineEditRef}
-                      type="text"
-                      spellcheck={false}
+                    <QueryBarInlineEditInput
+                      inputRef={(el) => {
+                        inlineEditRef = el;
+                      }}
                       value={inlineEdit()?.text ?? ""}
                       onInput={handleInlineInput}
                       onKeyDown={handleInlineKeyDown}
                       onBlur={handleInlineBlur}
-                      onClick={(e) => e.stopPropagation()}
-                      onMouseDown={(e) => e.stopPropagation()}
-                      placeholder="Edit filter…"
-                      style={{ ...inlineSlotStyle(), flex: "0 1 auto" }}
+                      style={{ flex: "0 1 auto" }}
                     />
                   </Show>
                 </div>
@@ -727,76 +506,37 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
         </For>
 
         <Show when={inlineEditOrphanAfterOrBranch()}>
-          <span
-            onClick={(e) => e.stopPropagation()}
-            style={{ display: "inline-flex", "align-items": "center", gap: "3px" }}
-          >
-            <span
-              style={{
-                "font-size": "9px",
-                "font-weight": "700",
-                "letter-spacing": "0.05em",
-                color: "var(--accent)",
-                background: "rgba(var(--accent-rgb,59,130,246),0.13)",
-                border: "1px solid rgba(var(--accent-rgb,59,130,246),0.35)",
-                "border-radius": "10px",
-                padding: "1px 5px",
-                "flex-shrink": "0",
-                "user-select": "none",
+          <span onClick={(e) => e.stopPropagation()} style={queryBarOrphanInlineEditStyle()}>
+            <QueryBarOrBadge />
+            <QueryBarInlineEditInput
+              inputRef={(el) => {
+                inlineEditRef = el;
               }}
-            >
-              OR
-            </span>
-            <input
-              ref={inlineEditRef}
-              type="text"
-              spellcheck={false}
               value={inlineEdit()?.text ?? ""}
               onInput={handleInlineInput}
               onKeyDown={handleInlineKeyDown}
               onBlur={handleInlineBlur}
-              onClick={(e) => e.stopPropagation()}
-              onMouseDown={(e) => e.stopPropagation()}
-              placeholder="Edit filter…"
-              style={{ ...inlineSlotStyle(), "flex-shrink": "1" }}
+              style={{ "flex-shrink": "1" }}
             />
           </span>
         </Show>
 
         <Show when={!!inlineEdit() && totalPillCount() === 0}>
-          <input
-            ref={inlineEditRef}
-            type="text"
-            spellcheck={false}
+          <QueryBarInlineEditInput
+            inputRef={(el) => {
+              inlineEditRef = el;
+            }}
             value={inlineEdit()?.text ?? ""}
             onInput={handleInlineInput}
             onKeyDown={handleInlineKeyDown}
             onBlur={handleInlineBlur}
-            onClick={(e) => e.stopPropagation()}
-            onMouseDown={(e) => e.stopPropagation()}
-            placeholder="Edit filter…"
-            style={{ ...inlineSlotStyle(), "flex-shrink": "1" }}
+            style={{ "flex-shrink": "1" }}
           />
         </Show>
 
         {/* OR badge before the draft when it starts a new group */}
         <Show when={draftInNewGroup() && hasAnyPills()}>
-          <span
-            style={{
-              "font-size": "9px",
-              "font-weight": "700",
-              "letter-spacing": "0.05em",
-              color: "var(--accent)",
-              background: "rgba(var(--accent-rgb,59,130,246),0.13)",
-              border: "1px solid rgba(var(--accent-rgb,59,130,246),0.35)",
-              "border-radius": "10px",
-              padding: "1px 5px",
-              "flex-shrink": "0",
-              "user-select": "none",
-            }}
-          >
-            OR
-          </span>
+          <QueryBarOrBadge />
         </Show>
 
         {/* ── Input row — draft + connector buttons + clear ──────────────── */}
@@ -805,15 +545,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
         {/* input and buttons always stay together on the same line.           */}
         {/* min-width forces this group to wrap as a unit when pills fill      */}
         {/* the available horizontal space.                                    */}
-        <div
-          style={{
-            flex: "1",
-            display: "flex",
-            "align-items": "center",
-            gap: "3px",
-            "min-width": "180px",
-          }}
-        >
+        <div style={queryBarInputRowStyle()}>
           {/* Draft input */}
           <input
             ref={draftRef}
@@ -831,58 +563,26 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
                 ? "Add condition…"
                 : (props.placeholder ?? "Filter… (level:error, tag:App, is:crash…)")
             }
-            style={{
-              flex: "1",
-              "min-width": "0", // allow shrinking below content size in flex
-              background: "transparent",
-              border: "none",
-              color: "var(--text-primary)",
-              "font-size": "11px",
-              "font-family": "var(--font-mono)",
-              outline: "none",
-              padding: "1px 0",
-            }}
+            style={queryBarDraftInputStyle()}
           />
 
           {/* + AND / + OR connector buttons */}
           <Show when={isActive()}>
-            <div style={{ display: "flex", gap: "3px", "flex-shrink": "0" }}>
-              <button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  handleAddAndConnector();
-                }}
+            <div style={queryBarConnectorGroupStyle()}>
+              <QueryBarConnectorButton
                 title="Add AND condition — both conditions must match"
-                style={connectorBtnStyle()}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLElement).style.color = "var(--success)";
-                  (e.currentTarget as HTMLElement).style.borderColor = "var(--success)";
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLElement).style.color = "var(--text-muted)";
-                  (e.currentTarget as HTMLElement).style.borderColor = "var(--border)";
-                }}
+                hoverColor="var(--success)"
+                onMouseDown={handleAddAndConnector}
               >
                 + AND
-              </button>
-              <button
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  handleAddOrGroup();
-                }}
+              </QueryBarConnectorButton>
+              <QueryBarConnectorButton
                 title="Add OR group — entries matching either group will be shown"
-                style={connectorBtnStyle()}
-                onMouseEnter={(e) => {
-                  (e.currentTarget as HTMLElement).style.color = "var(--accent)";
-                  (e.currentTarget as HTMLElement).style.borderColor = "var(--accent)";
-                }}
-                onMouseLeave={(e) => {
-                  (e.currentTarget as HTMLElement).style.color = "var(--text-muted)";
-                  (e.currentTarget as HTMLElement).style.borderColor = "var(--border)";
-                }}
+                hoverColor="var(--accent)"
+                onMouseDown={handleAddOrGroup}
               >
                 + OR
-              </button>
+              </QueryBarConnectorButton>
             </div>
           </Show>
 
@@ -896,19 +596,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
                 draftRef?.focus();
               }}
               title="Clear all filters (Esc)"
-              style={{
-                "flex-shrink": "0",
-                background: "none",
-                border: "none",
-                color: "var(--text-muted)",
-                cursor: "pointer",
-                "font-size": "11px",
-                padding: "0 2px",
-                "line-height": "1",
-                display: "flex",
-                "align-items": "center",
-                opacity: "0.6",
-              }}
+              style={queryBarClearButtonStyle()}
               onMouseEnter={(e) => {
                 (e.currentTarget as HTMLElement).style.opacity = "1";
               }}
@@ -924,95 +612,15 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
 
       {/* ── Autocomplete dropdown ───────────────────────────────────────── */}
       <Show when={hasSuggestions()}>
-        <div
-          style={{
-            position: "absolute",
-            top: "calc(100% + 3px)",
-            left: "0",
-            "min-width": "220px",
-            "max-width": "360px",
-            "max-height": "260px",
-            "overflow-y": "auto",
-            background: "var(--bg-secondary)",
-            border: "1px solid var(--border)",
-            "border-radius": "4px",
-            "box-shadow": "0 6px 20px rgba(0,0,0,0.45)",
-            "z-index": "600",
-          }}
-        >
-          <For each={suggestions()}>
-            {(s, i) => {
-              const isSelected = () => i() === selectedIdx();
-              return (
-                <div
-                  onMouseDown={(e) => {
-                    e.preventDefault();
-                    applySelection(s.insert);
-                  }}
-                  onMouseEnter={() => setSelectedIdx(i())}
-                  style={{
-                    padding: "5px 10px",
-                    "font-size": "11px",
-                    "font-family": "var(--font-mono)",
-                    color: isSelected() ? "#fff" : "var(--text-primary)",
-                    background: isSelected() ? "var(--accent)" : "transparent",
-                    cursor: "pointer",
-                    "white-space": "nowrap",
-                    overflow: "hidden",
-                    "text-overflow": "ellipsis",
-                  }}
-                >
-                  {s.display}
-                </div>
-              );
-            }}
-          </For>
-          <div
-            style={{
-              padding: "4px 10px",
-              "font-size": "10px",
-              color: "var(--text-disabled, #4b5563)",
-              "border-top": "1px solid var(--border)",
-              "user-select": "none",
-            }}
-          >
-            ↑↓ navigate · Tab/Enter select · Esc close · && = AND · | = OR group
-          </div>
-        </div>
+        <QueryBarSuggestions
+          suggestions={suggestions()}
+          selectedIdx={selectedIdx()}
+          onSelect={applySelection}
+          onHover={setSelectedIdx}
+        />
       </Show>
     </div>
   );
-}
-
-// ── Style helper ──────────────────────────────────────────────────────────────
-
-function connectorBtnStyle(): Record<string, string> {
-  return {
-    background: "none",
-    border: "1px solid var(--border)",
-    color: "var(--text-muted)",
-    "border-radius": "4px",
-    cursor: "pointer",
-    "font-size": "10px",
-    "font-family": "var(--font-mono)",
-    padding: "2px 6px",
-    "white-space": "nowrap",
-    transition: "color 0.1s, border-color 0.1s",
-  };
-}
-
-function groupBoxStyle(): Record<string, string> {
-  return {
-    display: "inline-flex",
-    "align-items": "center",
-    gap: "3px",
-    padding: "3px 6px",
-    border: "1px solid rgba(255,255,255,0.10)",
-    "border-radius": "8px",
-    background: "rgba(255,255,255,0.04)",
-    "flex-shrink": "0",
-    "max-width": "100%",
-  };
 }
 
 export default QueryBar;

--- a/src/components/logcat/QueryBarParts.tsx
+++ b/src/components/logcat/QueryBarParts.tsx
@@ -1,0 +1,152 @@
+import { type JSX, For } from "solid-js";
+import type { QueryBarSuggestion } from "@/lib/logcat-query";
+import {
+  getQueryBarTokenStyle,
+  queryBarAndBadgeStyle,
+  queryBarConnectorButtonStyle,
+  queryBarInlineEditStyle,
+  queryBarOrBadgeStyle,
+  queryBarPillLabelStyle,
+  queryBarPillRemoveButtonStyle,
+  queryBarPillStyle,
+  suggestionFooterStyle,
+  suggestionItemStyle,
+  suggestionMenuStyle,
+} from "./querybar-styles";
+
+export function QueryBarOrBadge(): JSX.Element {
+  return <span style={queryBarOrBadgeStyle()}>OR</span>;
+}
+
+export function QueryBarAndBadge(): JSX.Element {
+  return <span style={queryBarAndBadgeStyle()}>AND</span>;
+}
+
+export function QueryBarInlineEditInput(props: {
+  value: string;
+  inputRef: (el: HTMLInputElement) => void;
+  onInput: (e: InputEvent) => void;
+  onKeyDown: (e: KeyboardEvent) => void;
+  onBlur: () => void;
+  style?: Record<string, string>;
+}): JSX.Element {
+  return (
+    <input
+      ref={props.inputRef}
+      type="text"
+      spellcheck={false}
+      value={props.value}
+      onInput={(e) => props.onInput(e)}
+      onKeyDown={(e) => props.onKeyDown(e)}
+      onBlur={() => props.onBlur()}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      placeholder="Edit filter..."
+      style={queryBarInlineEditStyle(props.style)}
+    />
+  );
+}
+
+export function QueryBarPill(props: {
+  token: string;
+  onEdit: () => void;
+  onRemove: () => void;
+}): JSX.Element {
+  const style = () => getQueryBarTokenStyle(props.token);
+
+  return (
+    <span
+      onClick={(e) => e.stopPropagation()}
+      style={queryBarPillStyle(style(), props.token.startsWith("-"))}
+    >
+      <span
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          props.onEdit();
+        }}
+        title="Edit filter"
+        style={queryBarPillLabelStyle()}
+      >
+        {props.token}
+      </span>
+      <button
+        onMouseDown={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          props.onRemove();
+        }}
+        title="Remove filter"
+        style={queryBarPillRemoveButtonStyle(style().color)}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLElement).style.opacity = "1";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLElement).style.opacity = "0.55";
+        }}
+      >
+        ✕
+      </button>
+    </span>
+  );
+}
+
+export function QueryBarConnectorButton(props: {
+  title: string;
+  hoverColor: string;
+  onMouseDown: () => void;
+  children: JSX.Element;
+}): JSX.Element {
+  return (
+    <button
+      onMouseDown={(e) => {
+        e.preventDefault();
+        props.onMouseDown();
+      }}
+      title={props.title}
+      style={queryBarConnectorButtonStyle()}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLElement).style.color = props.hoverColor;
+        (e.currentTarget as HTMLElement).style.borderColor = props.hoverColor;
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLElement).style.color = "var(--text-muted)";
+        (e.currentTarget as HTMLElement).style.borderColor = "var(--border)";
+      }}
+    >
+      {props.children}
+    </button>
+  );
+}
+
+export function QueryBarSuggestions(props: {
+  suggestions: readonly QueryBarSuggestion[];
+  selectedIdx: number;
+  onSelect: (insert: string) => void;
+  onHover: (idx: number) => void;
+}): JSX.Element {
+  return (
+    <div style={suggestionMenuStyle()}>
+      <For each={props.suggestions}>
+        {(suggestion, i) => {
+          const isSelected = () => i() === props.selectedIdx;
+          return (
+            <div
+              onMouseDown={(e) => {
+                e.preventDefault();
+                props.onSelect(suggestion.insert);
+              }}
+              onMouseEnter={() => props.onHover(i())}
+              style={suggestionItemStyle(isSelected())}
+            >
+              {suggestion.display}
+            </div>
+          );
+        }}
+      </For>
+      <div style={suggestionFooterStyle()}>
+        ↑↓ navigate · Tab/Enter select · Esc close · && = AND · | = OR group
+      </div>
+    </div>
+  );
+}

--- a/src/components/logcat/SavedFilterMenu.tsx
+++ b/src/components/logcat/SavedFilterMenu.tsx
@@ -1,0 +1,364 @@
+import { For, Show, createSignal, type JSX } from "solid-js";
+import { showToast } from "@/components/ui";
+import {
+  addSavedFilter,
+  deleteSavedFilter,
+  loadFilterStorage,
+  MAX_SAVED_FILTERS,
+  renameSavedFilter,
+  type SavedFilter,
+} from "@/lib/logcat-filter-storage";
+import { btnStyle } from "./logcat-styles";
+import {
+  logcatDropdownOverlayStyle,
+  logcatDropdownPanelStyle,
+  logcatDropdownRootStyle,
+  logcatDropdownSectionHeaderStyle,
+  logcatDropdownSeparatorStyle,
+} from "./logcat-dropdown-styles";
+
+interface LogcatPreset {
+  name: string;
+  query: string;
+  builtin?: true;
+}
+
+const BUILTIN_PRESETS: LogcatPreset[] = [
+  { name: "My App", query: "package:mine", builtin: true },
+  { name: "Crashes", query: "is:crash", builtin: true },
+  { name: "Errors+", query: "level:error", builtin: true },
+  { name: "Last 5 min", query: "age:5m", builtin: true },
+  { name: "My App OR Crashes", query: "package:mine | is:crash", builtin: true },
+];
+
+export function SavedFilterMenu(props: {
+  query: string;
+  isFiltered: boolean;
+  onApplyQuery: (query: string) => void;
+}): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const [savedFilters, setSavedFilters] = createSignal<SavedFilter[]>(loadFilterStorage().filters);
+  const [savingPreset, setSavingPreset] = createSignal(false);
+  const [presetNameDraft, setPresetNameDraft] = createSignal("");
+  const [renamingId, setRenamingId] = createSignal<string | null>(null);
+  const [renameDraft, setRenameDraft] = createSignal("");
+
+  function applyPreset(q: string) {
+    props.onApplyQuery(q.trimEnd() + " ");
+    setOpen(false);
+  }
+
+  function saveCurrentFilter() {
+    const name = presetNameDraft().trim();
+    if (!name) return;
+    try {
+      const saved = addSavedFilter(name, props.query);
+      setSavedFilters(loadFilterStorage().filters);
+      setSavingPreset(false);
+      setPresetNameDraft("");
+      showToast(`Saved filter "${saved.name}"`, "success");
+    } catch (e) {
+      showToast(String(e), "error");
+    }
+  }
+
+  function deleteSavedFilterItem(id: string) {
+    deleteSavedFilter(id);
+    setSavedFilters(loadFilterStorage().filters);
+  }
+
+  function startRename(filter: SavedFilter) {
+    setRenamingId(filter.id);
+    setRenameDraft(filter.name);
+  }
+
+  function commitRename() {
+    const id = renamingId();
+    if (id) {
+      renameSavedFilter(id, renameDraft());
+      setSavedFilters(loadFilterStorage().filters);
+    }
+    setRenamingId(null);
+    setRenameDraft("");
+  }
+
+  function cancelRename() {
+    setRenamingId(null);
+    setRenameDraft("");
+  }
+
+  return (
+    <div style={logcatDropdownRootStyle()}>
+      <button
+        onClick={() => {
+          setOpen((v) => !v);
+          setSavingPreset(false);
+          setRenamingId(null);
+        }}
+        title="Filter presets"
+        style={btnStyle("var(--text-muted)")}
+      >
+        ☰ Filters
+      </button>
+      <Show when={open()}>
+        <div
+          style={logcatDropdownPanelStyle({
+            align: "right",
+            minWidth: "260px",
+            maxWidth: "340px",
+          })}
+        >
+          <div style={{ padding: "6px 0" }}>
+            <div style={logcatDropdownSectionHeaderStyle()}>Quick Filters</div>
+            <For each={BUILTIN_PRESETS}>
+              {(p) => (
+                <div
+                  onClick={() => applyPreset(p.query)}
+                  style={{
+                    display: "flex",
+                    "align-items": "center",
+                    padding: "5px 10px",
+                    cursor: "pointer",
+                    color: "var(--text-primary)",
+                    "font-family": "var(--font-mono)",
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.06)";
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = "transparent";
+                  }}
+                >
+                  <span style={{ flex: "1" }}>{p.name}</span>
+                  <span
+                    style={{
+                      color: "var(--text-muted)",
+                      "font-size": "10px",
+                      "max-width": "130px",
+                      overflow: "hidden",
+                      "text-overflow": "ellipsis",
+                      "white-space": "nowrap",
+                    }}
+                  >
+                    {p.query}
+                  </span>
+                </div>
+              )}
+            </For>
+
+            <div style={logcatDropdownSeparatorStyle()} />
+            <div style={{ display: "flex", "align-items": "center", padding: "2px 10px 4px" }}>
+              <span
+                style={{
+                  "font-size": "10px",
+                  color: "var(--text-muted)",
+                  "text-transform": "uppercase",
+                  "letter-spacing": "0.05em",
+                  flex: "1",
+                }}
+              >
+                Saved
+              </span>
+              <span style={{ "font-size": "10px", color: "var(--text-muted)" }}>
+                {savedFilters().length} / {MAX_SAVED_FILTERS}
+              </span>
+            </div>
+
+            <Show when={savedFilters().length === 0}>
+              <div
+                style={{
+                  padding: "4px 10px 6px",
+                  "font-size": "10px",
+                  color: "var(--text-muted)",
+                  "font-style": "italic",
+                }}
+              >
+                No saved filters yet
+              </div>
+            </Show>
+
+            <For each={savedFilters()}>
+              {(f) => (
+                <div
+                  style={{
+                    display: "flex",
+                    "align-items": "center",
+                    padding: "4px 10px",
+                    cursor: "pointer",
+                    color: "var(--text-primary)",
+                    gap: "4px",
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.06)";
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = "transparent";
+                  }}
+                >
+                  <Show
+                    when={renamingId() === f.id}
+                    fallback={
+                      <>
+                        <span
+                          onClick={() => applyPreset(f.query)}
+                          style={{
+                            flex: "1",
+                            overflow: "hidden",
+                            "text-overflow": "ellipsis",
+                            "white-space": "nowrap",
+                          }}
+                          title={f.query}
+                        >
+                          {f.name}
+                        </span>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            startRename(f);
+                          }}
+                          style={{
+                            background: "none",
+                            border: "none",
+                            color: "var(--text-muted)",
+                            cursor: "pointer",
+                            padding: "0 3px",
+                            "font-size": "10px",
+                          }}
+                          title="Rename"
+                        >
+                          ✎
+                        </button>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            deleteSavedFilterItem(f.id);
+                          }}
+                          style={{
+                            background: "none",
+                            border: "none",
+                            color: "var(--text-muted)",
+                            cursor: "pointer",
+                            padding: "0 3px",
+                            "font-size": "10px",
+                          }}
+                          title="Delete"
+                        >
+                          ✕
+                        </button>
+                      </>
+                    }
+                  >
+                    <input
+                      type="text"
+                      value={renameDraft()}
+                      onInput={(e) => setRenameDraft(e.currentTarget.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.stopPropagation();
+                          commitRename();
+                        }
+                        if (e.key === "Escape") {
+                          e.stopPropagation();
+                          cancelRename();
+                        }
+                      }}
+                      autofocus
+                      style={{
+                        flex: "1",
+                        background: "var(--bg-primary)",
+                        border: "1px solid var(--accent)",
+                        color: "var(--text-primary)",
+                        "border-radius": "3px",
+                        padding: "2px 5px",
+                        "font-size": "11px",
+                        outline: "none",
+                      }}
+                    />
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        commitRename();
+                      }}
+                      style={btnStyle("var(--accent)")}
+                    >
+                      ✓
+                    </button>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        cancelRename();
+                      }}
+                      style={btnStyle("var(--text-muted)")}
+                    >
+                      ✕
+                    </button>
+                  </Show>
+                </div>
+              )}
+            </For>
+
+            <div style={logcatDropdownSeparatorStyle()} />
+            <Show
+              when={savingPreset()}
+              fallback={
+                <div
+                  onClick={() => {
+                    setSavingPreset(true);
+                    setPresetNameDraft("");
+                  }}
+                  style={{
+                    padding: "5px 10px",
+                    cursor: "pointer",
+                    color: props.isFiltered ? "var(--accent)" : "var(--text-muted)",
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.06)";
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLElement).style.background = "transparent";
+                  }}
+                >
+                  + Save current filter
+                </div>
+              }
+            >
+              <div style={{ display: "flex", gap: "4px", padding: "4px 8px" }}>
+                <input
+                  type="text"
+                  placeholder="Filter name…"
+                  value={presetNameDraft()}
+                  onInput={(e) => setPresetNameDraft(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") saveCurrentFilter();
+                    if (e.key === "Escape") setSavingPreset(false);
+                  }}
+                  autofocus
+                  style={{
+                    flex: "1",
+                    background: "var(--bg-primary)",
+                    border: "1px solid var(--border)",
+                    color: "var(--text-primary)",
+                    "border-radius": "3px",
+                    padding: "3px 6px",
+                    "font-size": "11px",
+                    outline: "none",
+                  }}
+                />
+                <button onClick={saveCurrentFilter} style={btnStyle("var(--accent)")}>
+                  Save
+                </button>
+              </div>
+            </Show>
+          </div>
+        </div>
+        <div
+          style={logcatDropdownOverlayStyle()}
+          onClick={() => {
+            setOpen(false);
+            cancelRename();
+          }}
+        />
+      </Show>
+    </div>
+  );
+}

--- a/src/components/logcat/logcat-dropdown-styles.ts
+++ b/src/components/logcat/logcat-dropdown-styles.ts
@@ -1,0 +1,41 @@
+export function logcatDropdownRootStyle(): Record<string, string> {
+  return { position: "relative", "flex-shrink": "0" };
+}
+
+export function logcatDropdownPanelStyle(options: {
+  align: "left" | "right";
+  minWidth: string;
+  maxWidth: string;
+}): Record<string, string> {
+  return {
+    position: "absolute",
+    top: "calc(100% + 4px)",
+    [options.align]: "0",
+    "min-width": options.minWidth,
+    "max-width": options.maxWidth,
+    background: "var(--bg-secondary)",
+    border: "1px solid var(--border)",
+    "border-radius": "4px",
+    "box-shadow": "0 6px 20px rgba(0,0,0,0.45)",
+    "z-index": "700",
+    "font-size": "11px",
+  };
+}
+
+export function logcatDropdownOverlayStyle(): Record<string, string> {
+  return { position: "fixed", inset: "0", "z-index": "699" };
+}
+
+export function logcatDropdownSeparatorStyle(margin = "4px 0"): Record<string, string> {
+  return { height: "1px", background: "var(--border)", margin };
+}
+
+export function logcatDropdownSectionHeaderStyle(): Record<string, string> {
+  return {
+    padding: "2px 10px 4px",
+    "font-size": "10px",
+    color: "var(--text-muted)",
+    "text-transform": "uppercase",
+    "letter-spacing": "0.05em",
+  };
+}

--- a/src/components/logcat/logcat-styles.ts
+++ b/src/components/logcat/logcat-styles.ts
@@ -1,0 +1,15 @@
+export function btnStyle(color: string): Record<string, string> {
+  return {
+    display: "flex",
+    "align-items": "center",
+    gap: "4px",
+    padding: "3px 8px",
+    background: "none",
+    border: "1px solid var(--border)",
+    color,
+    "border-radius": "4px",
+    cursor: "pointer",
+    "font-size": "11px",
+    "white-space": "nowrap",
+  };
+}

--- a/src/components/logcat/logcat-suggestion-runtime.test.ts
+++ b/src/components/logcat/logcat-suggestion-runtime.test.ts
@@ -1,0 +1,63 @@
+import { createRoot } from "solid-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LogcatEntry } from "@/lib/tauri-api";
+import { createLogcatSuggestionRuntime } from "./logcat-suggestion-runtime";
+
+function entry(overrides: Partial<LogcatEntry>): LogcatEntry {
+  return {
+    id: BigInt(overrides.id ?? 1),
+    timestamp: "01-01 00:00:00.000",
+    pid: 1,
+    tid: 1,
+    level: "info",
+    tag: "MainActivity",
+    message: "message",
+    package: "com.example.app",
+    kind: "normal",
+    isCrash: false,
+    flags: 0,
+    category: "general",
+    crashGroupId: null,
+    jsonBody: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createLogcatSuggestionRuntime", () => {
+  it("publishes ingested suggestions on immediate flush", () => {
+    vi.useFakeTimers();
+
+    createRoot((dispose) => {
+      const runtime = createLogcatSuggestionRuntime();
+      runtime.ingest([entry({ tag: "OkHttp", package: "com.example.network" })]);
+      runtime.flush(true);
+
+      vi.advanceTimersByTime(0);
+
+      expect(runtime.knownTags()).toEqual(["OkHttp"]);
+      expect(runtime.knownPackages()).toEqual(["com.example.network"]);
+      dispose();
+    });
+  });
+
+  it("cancels pending publication when cleared", () => {
+    vi.useFakeTimers();
+
+    createRoot((dispose) => {
+      const runtime = createLogcatSuggestionRuntime();
+      runtime.ingest([entry({ tag: "Retrofit", package: "com.example.api" })]);
+      runtime.flush();
+      runtime.clear();
+
+      vi.advanceTimersByTime(3_000);
+
+      expect(runtime.knownTags()).toEqual([]);
+      expect(runtime.knownPackages()).toEqual([]);
+      dispose();
+    });
+  });
+});

--- a/src/components/logcat/logcat-suggestion-runtime.ts
+++ b/src/components/logcat/logcat-suggestion-runtime.ts
@@ -1,0 +1,58 @@
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+import type { LogcatEntry } from "@/lib/tauri-api";
+import { createLogcatSuggestionIndex } from "@/lib/logcat-suggestions";
+
+export interface LogcatSuggestionRuntime {
+  knownPackages: Accessor<string[]>;
+  knownTags: Accessor<string[]>;
+  ingest(entries: LogcatEntry[]): void;
+  flush(immediate?: boolean): void;
+  clear(): void;
+}
+
+export function createLogcatSuggestionRuntime(): LogcatSuggestionRuntime {
+  const [knownPackages, setKnownPackages] = createSignal<string[]>([]);
+  const [knownTags, setKnownTags] = createSignal<string[]>([]);
+  let suggestTimer: ReturnType<typeof setTimeout> | null = null;
+  const suggestionIndex = createLogcatSuggestionIndex({
+    maxPackages: 500,
+    maxTags: 500,
+    maxVisibleTags: 50,
+  });
+
+  function clearTimer(): void {
+    if (suggestTimer !== null) {
+      clearTimeout(suggestTimer);
+      suggestTimer = null;
+    }
+  }
+
+  function publishSuggestions(): void {
+    suggestTimer = null;
+    setKnownPackages(suggestionIndex.packages());
+    setKnownTags(suggestionIndex.tags());
+  }
+
+  function clear(): void {
+    suggestionIndex.clear();
+    setKnownPackages([]);
+    setKnownTags([]);
+    clearTimer();
+  }
+
+  onCleanup(clearTimer);
+
+  return {
+    knownPackages,
+    knownTags,
+    ingest(entries) {
+      suggestionIndex.ingest(entries);
+    },
+    flush(immediate = false) {
+      if (suggestTimer !== null && !immediate) return;
+      clearTimer();
+      suggestTimer = setTimeout(publishSuggestions, immediate ? 0 : 3_000);
+    },
+    clear,
+  };
+}

--- a/src/components/logcat/querybar-styles.ts
+++ b/src/components/logcat/querybar-styles.ts
@@ -1,0 +1,293 @@
+export interface QueryBarTokenStyle {
+  color: string;
+  bg: string;
+  border: string;
+}
+
+export function getQueryBarTokenStyle(tokenText: string): QueryBarTokenStyle {
+  const token = tokenText.startsWith("-") ? tokenText.slice(1) : tokenText;
+  if (token.startsWith("level:")) {
+    return {
+      color: "var(--warning)",
+      bg: "color-mix(in srgb, var(--warning) 13%, transparent)",
+      border: "color-mix(in srgb, var(--warning) 35%, transparent)",
+    };
+  }
+  if (token.startsWith("tag:") || token.startsWith("tag~:")) {
+    return {
+      color: "var(--info)",
+      bg: "color-mix(in srgb, var(--info) 13%, transparent)",
+      border: "color-mix(in srgb, var(--info) 35%, transparent)",
+    };
+  }
+  if (token.startsWith("message:") || token.startsWith("message~:") || token.startsWith("msg:")) {
+    return {
+      color: "var(--success)",
+      bg: "color-mix(in srgb, var(--success) 11%, transparent)",
+      border: "color-mix(in srgb, var(--success) 35%, transparent)",
+    };
+  }
+  if (token.startsWith("package:") || token.startsWith("pkg:")) {
+    return {
+      color: "var(--accent)",
+      bg: "color-mix(in srgb, var(--accent) 13%, transparent)",
+      border: "color-mix(in srgb, var(--accent) 40%, transparent)",
+    };
+  }
+  if (token.startsWith("age:")) {
+    return {
+      color: "var(--accent)",
+      bg: "color-mix(in srgb, var(--accent) 13%, transparent)",
+      border: "color-mix(in srgb, var(--accent) 35%, transparent)",
+    };
+  }
+  if (token.startsWith("is:")) {
+    return {
+      color: "var(--error)",
+      bg: "color-mix(in srgb, var(--error) 13%, transparent)",
+      border: "color-mix(in srgb, var(--error) 35%, transparent)",
+    };
+  }
+  return {
+    color: "var(--text-secondary)",
+    bg: "rgba(255,255,255,0.07)",
+    border: "var(--border)",
+  };
+}
+
+export function queryBarRootStyle(): Record<string, string> {
+  return { position: "relative", flex: "1", "min-width": "280px" };
+}
+
+export function queryBarContainerStyle(active: boolean): Record<string, string> {
+  return {
+    display: "flex",
+    "flex-wrap": "wrap",
+    "align-items": "center",
+    gap: "3px",
+    "min-height": "26px",
+    padding: "3px 6px",
+    background: "var(--bg-primary)",
+    border: `1px solid ${active ? "var(--accent)" : "var(--border)"}`,
+    "border-radius": "4px",
+    cursor: "text",
+    transition: "border-color 0.1s",
+  };
+}
+
+export function searchIconStyle(): Record<string, string> {
+  return {
+    "flex-shrink": "0",
+    color: "var(--text-muted)",
+    "font-size": "11px",
+    "pointer-events": "none",
+    opacity: "0.6",
+    "line-height": "1",
+  };
+}
+
+export function queryBarGroupBoxStyle(): Record<string, string> {
+  return {
+    display: "inline-flex",
+    "align-items": "center",
+    gap: "3px",
+    padding: "3px 6px",
+    border: "1px solid rgba(255,255,255,0.10)",
+    "border-radius": "8px",
+    background: "rgba(255,255,255,0.04)",
+    "flex-shrink": "0",
+    "max-width": "100%",
+  };
+}
+
+export function queryBarOrBadgeStyle(): Record<string, string> {
+  return {
+    "font-size": "9px",
+    "font-weight": "700",
+    "letter-spacing": "0.05em",
+    color: "var(--accent)",
+    background: "rgba(var(--accent-rgb,59,130,246),0.13)",
+    border: "1px solid rgba(var(--accent-rgb,59,130,246),0.35)",
+    "border-radius": "10px",
+    padding: "1px 5px",
+    "flex-shrink": "0",
+    "user-select": "none",
+  };
+}
+
+export function queryBarAndBadgeStyle(): Record<string, string> {
+  return {
+    "font-size": "9px",
+    "font-weight": "600",
+    "letter-spacing": "0.04em",
+    color: "var(--text-muted)",
+    border: "1px dashed var(--border)",
+    "border-radius": "10px",
+    padding: "1px 5px",
+    "flex-shrink": "0",
+    "user-select": "none",
+  };
+}
+
+export function queryBarPillStyle(
+  tokenStyle: QueryBarTokenStyle,
+  negated: boolean
+): Record<string, string> {
+  return {
+    display: "inline-flex",
+    "align-items": "center",
+    gap: "2px",
+    "font-size": "10px",
+    "font-family": "var(--font-mono)",
+    color: tokenStyle.color,
+    background: tokenStyle.bg,
+    border: `1px solid ${tokenStyle.border}`,
+    "border-radius": "10px",
+    padding: "1px 4px 1px 6px",
+    "flex-shrink": "0",
+    "white-space": "nowrap",
+    opacity: negated ? "0.65" : "1",
+  };
+}
+
+export function queryBarPillLabelStyle(): Record<string, string> {
+  return { cursor: "text", "user-select": "none" };
+}
+
+export function queryBarPillRemoveButtonStyle(color: string): Record<string, string> {
+  return {
+    background: "none",
+    border: "none",
+    color,
+    cursor: "pointer",
+    padding: "0 1px",
+    "font-size": "9px",
+    "line-height": "1",
+    opacity: "0.55",
+    display: "flex",
+    "align-items": "center",
+  };
+}
+
+export function queryBarInlineEditStyle(
+  overrides: Record<string, string> = {}
+): Record<string, string> {
+  return {
+    flex: "1",
+    "min-width": "120px",
+    "max-width": "420px",
+    background: "var(--bg-primary)",
+    border: "1px solid var(--accent)",
+    color: "var(--text-primary)",
+    "font-size": "11px",
+    "font-family": "var(--font-mono)",
+    "border-radius": "10px",
+    padding: "1px 6px",
+    outline: "none",
+    ...overrides,
+  };
+}
+
+export function queryBarOrphanInlineEditStyle(): Record<string, string> {
+  return { display: "inline-flex", "align-items": "center", gap: "3px" };
+}
+
+export function queryBarInputRowStyle(): Record<string, string> {
+  return {
+    flex: "1",
+    display: "flex",
+    "align-items": "center",
+    gap: "3px",
+    "min-width": "180px",
+  };
+}
+
+export function queryBarDraftInputStyle(): Record<string, string> {
+  return {
+    flex: "1",
+    "min-width": "0",
+    background: "transparent",
+    border: "none",
+    color: "var(--text-primary)",
+    "font-size": "11px",
+    "font-family": "var(--font-mono)",
+    outline: "none",
+    padding: "1px 0",
+  };
+}
+
+export function queryBarConnectorGroupStyle(): Record<string, string> {
+  return { display: "flex", gap: "3px", "flex-shrink": "0" };
+}
+
+export function queryBarConnectorButtonStyle(): Record<string, string> {
+  return {
+    background: "none",
+    border: "1px solid var(--border)",
+    color: "var(--text-muted)",
+    "border-radius": "4px",
+    cursor: "pointer",
+    "font-size": "10px",
+    "font-family": "var(--font-mono)",
+    padding: "2px 6px",
+    "white-space": "nowrap",
+    transition: "color 0.1s, border-color 0.1s",
+  };
+}
+
+export function queryBarClearButtonStyle(): Record<string, string> {
+  return {
+    "flex-shrink": "0",
+    background: "none",
+    border: "none",
+    color: "var(--text-muted)",
+    cursor: "pointer",
+    "font-size": "11px",
+    padding: "0 2px",
+    "line-height": "1",
+    display: "flex",
+    "align-items": "center",
+    opacity: "0.6",
+  };
+}
+
+export function suggestionMenuStyle(): Record<string, string> {
+  return {
+    position: "absolute",
+    top: "calc(100% + 3px)",
+    left: "0",
+    "min-width": "220px",
+    "max-width": "360px",
+    "max-height": "260px",
+    "overflow-y": "auto",
+    background: "var(--bg-secondary)",
+    border: "1px solid var(--border)",
+    "border-radius": "4px",
+    "box-shadow": "0 6px 20px rgba(0,0,0,0.45)",
+    "z-index": "600",
+  };
+}
+
+export function suggestionItemStyle(selected: boolean): Record<string, string> {
+  return {
+    padding: "5px 10px",
+    "font-size": "11px",
+    "font-family": "var(--font-mono)",
+    color: selected ? "#fff" : "var(--text-primary)",
+    background: selected ? "var(--accent)" : "transparent",
+    cursor: "pointer",
+    "white-space": "nowrap",
+    overflow: "hidden",
+    "text-overflow": "ellipsis",
+  };
+}
+
+export function suggestionFooterStyle(): Record<string, string> {
+  return {
+    padding: "4px 10px",
+    "font-size": "10px",
+    color: "var(--text-disabled, #4b5563)",
+    "border-top": "1px solid var(--border)",
+    "user-select": "none",
+  };
+}

--- a/src/lib/logcat-filter-spec.ts
+++ b/src/lib/logcat-filter-spec.ts
@@ -1,0 +1,103 @@
+import type { LogcatFilterSpec } from "@/lib/tauri-api";
+import {
+  getFrontendOnlyTokens,
+  getMinePackage,
+  type FilterGroup,
+  type QueryToken,
+} from "@/lib/logcat-query";
+
+const LEVEL_PRIORITY_MAP: Record<string, number> = {
+  verbose: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+  fatal: 5,
+};
+
+const EMPTY_FILTER_SPEC: LogcatFilterSpec = {
+  minLevel: null,
+  tag: null,
+  text: null,
+  package: null,
+  onlyCrashes: false,
+};
+
+export function emptyLogcatFilterSpec(): LogcatFilterSpec {
+  return { ...EMPTY_FILTER_SPEC };
+}
+
+/**
+ * Extract the subset of query tokens that can be applied by the Rust backend.
+ * Complex tokens stay frontend-only so the backend never over-filters.
+ */
+export function tokensToFilterSpec(tokens: QueryToken[]): LogcatFilterSpec {
+  const spec = emptyLogcatFilterSpec();
+
+  for (const token of tokens) {
+    if ("negate" in token && token.negate) continue;
+
+    switch (token.type) {
+      case "level":
+        if (!spec.minLevel) spec.minLevel = token.value;
+        break;
+      case "tag":
+        if (!token.regex && !spec.tag) spec.tag = token.value;
+        break;
+      case "message":
+        if (!token.regex && !spec.text) spec.text = token.value;
+        break;
+      case "package": {
+        if (!spec.package) {
+          const pkg = token.value === "mine" ? (getMinePackage() ?? null) : token.value;
+          if (pkg) spec.package = pkg;
+        }
+        break;
+      }
+      case "is":
+        if (token.value === "crash") spec.onlyCrashes = true;
+        break;
+      case "freetext":
+        if (!spec.text) spec.text = token.value;
+        break;
+    }
+  }
+
+  return spec;
+}
+
+/**
+ * Compute the most permissive backend filter that is safe for all OR groups.
+ * Precise OR semantics remain in the frontend.
+ */
+export function groupsToFilterSpec(groups: FilterGroup[]): LogcatFilterSpec {
+  if (groups.length === 0) return emptyLogcatFilterSpec();
+  if (groups.length === 1) return tokensToFilterSpec(groups[0]);
+
+  const specs = groups.map((g) => tokensToFilterSpec(g));
+
+  const levels = specs.map((s) => (s.minLevel ? (LEVEL_PRIORITY_MAP[s.minLevel] ?? 0) : 0));
+  const minLevelPriority = Math.min(...levels);
+  const minLevel =
+    minLevelPriority === 0
+      ? null
+      : (Object.entries(LEVEL_PRIORITY_MAP).find(([, v]) => v === minLevelPriority)?.[0] ?? null);
+
+  const tags = specs.map((s) => s.tag);
+  const tag = tags.every((t) => t !== null && t === tags[0]) ? tags[0] : null;
+
+  const texts = specs.map((s) => s.text);
+  const text = texts.every((t) => t !== null && t === texts[0]) ? texts[0] : null;
+
+  const pkgs = specs.map((s) => s.package);
+  const packageFilter = pkgs.every((p) => p !== null && p === pkgs[0]) ? pkgs[0] : null;
+
+  const onlyCrashes = specs.every((s) => s.onlyCrashes);
+
+  return { minLevel, tag, text, package: packageFilter, onlyCrashes };
+}
+
+export function hasAnyFrontendOnlyLogic(groups: FilterGroup[]): boolean {
+  if (groups.length > 1) return true;
+  return getFrontendOnlyTokens(groups[0] ?? []).length > 0;
+}

--- a/src/lib/logcat-query.test.ts
+++ b/src/lib/logcat-query.test.ts
@@ -1810,6 +1810,14 @@ describe("getQueryBarSuggestions", () => {
     ]);
   });
 
+  it("suggests mine and matching known packages for the pkg alias", () => {
+    const suggestions = getQueryBarSuggestions("pkg:m", [], ["com.example.main"]);
+    expect(suggestions).toEqual([
+      { display: "mine", insert: "mine" },
+      { display: "com.example.main", insert: "com.example.main" },
+    ]);
+  });
+
   it("caps suggestions to the requested maximum", () => {
     const tags = Array.from({ length: 20 }, (_, i) => `Tag${i}`);
     const suggestions = getQueryBarSuggestions("tag:tag", tags, [], 5);

--- a/src/lib/logcat-query.test.ts
+++ b/src/lib/logcat-query.test.ts
@@ -30,6 +30,7 @@ import {
   serializeQueryBarCommittedPart,
   splitRawQueryParts,
   commitQueryBarDraft,
+  getQueryBarSuggestions,
   setMinePackage,
   isStackTraceLine,
   parseStackFrame,
@@ -1784,6 +1785,40 @@ describe("getActiveTokenContext — negated freetext partial is de-negated", () 
     expect(ctx.key).toBeNull();
     expect(ctx.partial).toBe("ta");
     expect(ctx.offset).toBe(12);
+  });
+});
+
+// ── getQueryBarSuggestions ───────────────────────────────────────────────────
+
+describe("getQueryBarSuggestions", () => {
+  it("suggests query keys for an empty draft", () => {
+    const suggestions = getQueryBarSuggestions("", [], []);
+    expect(suggestions.map((s) => s.insert)).toContain("level:");
+    expect(suggestions.map((s) => s.insert)).toContain("tag:");
+  });
+
+  it("suggests matching known tags for a tag key", () => {
+    const suggestions = getQueryBarSuggestions("tag:ok", ["OkHttp", "Retrofit"], []);
+    expect(suggestions).toEqual([{ display: "OkHttp", insert: "OkHttp" }]);
+  });
+
+  it("suggests mine and matching known packages for a package key", () => {
+    const suggestions = getQueryBarSuggestions("package:m", [], ["com.example.main"]);
+    expect(suggestions).toEqual([
+      { display: "mine", insert: "mine" },
+      { display: "com.example.main", insert: "com.example.main" },
+    ]);
+  });
+
+  it("caps suggestions to the requested maximum", () => {
+    const tags = Array.from({ length: 20 }, (_, i) => `Tag${i}`);
+    const suggestions = getQueryBarSuggestions("tag:tag", tags, [], 5);
+    expect(suggestions).toHaveLength(5);
+  });
+
+  it("preserves level shorthand suggestions for freetext partials", () => {
+    const suggestions = getQueryBarSuggestions("err", [], []);
+    expect(suggestions).toContainEqual({ display: "error (level shorthand)", insert: "error" });
   });
 });
 

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -55,6 +55,67 @@ export const QUERY_KEYS = [
 export const AGE_SUGGESTIONS = ["30s", "1m", "5m", "15m", "1h", "6h", "1d"];
 export const IS_SUGGESTIONS = ["crash", "stacktrace"];
 
+export interface QueryBarSuggestion {
+  display: string;
+  insert: string;
+}
+
+export function getQueryBarSuggestions(
+  draft: string,
+  knownTags: readonly string[],
+  knownPackages: readonly string[],
+  maxSuggestions = 10
+): QueryBarSuggestion[] {
+  const ctx = getActiveTokenContext(draft);
+
+  if (ctx.key) {
+    const partial = ctx.partial.toLowerCase();
+    switch (ctx.key.toLowerCase()) {
+      case "level":
+        return LEVEL_NAMES.filter((level) => level.startsWith(partial))
+          .slice(0, maxSuggestions)
+          .map((level) => ({ display: level, insert: level }));
+      case "tag":
+        return knownTags
+          .filter((tag) => tag.toLowerCase().includes(partial))
+          .slice(0, maxSuggestions)
+          .map((tag) => ({ display: tag, insert: tag }));
+      case "package":
+        return ["mine", ...knownPackages]
+          .filter((packageName) => packageName.toLowerCase().includes(partial))
+          .slice(0, maxSuggestions)
+          .map((packageName) => ({ display: packageName, insert: packageName }));
+      case "is":
+        return IS_SUGGESTIONS.filter((suggestion) => suggestion.startsWith(partial))
+          .slice(0, maxSuggestions)
+          .map((suggestion) => ({ display: suggestion, insert: suggestion }));
+      case "age":
+        return AGE_SUGGESTIONS.filter((age) => age.startsWith(partial))
+          .slice(0, maxSuggestions)
+          .map((age) => ({ display: age, insert: age }));
+      default:
+        return [];
+    }
+  }
+
+  const partial = ctx.partial.toLowerCase();
+  if (!partial) {
+    return QUERY_KEYS.slice(0, maxSuggestions).map((key) => ({ display: key, insert: key }));
+  }
+
+  const keySuggestions = QUERY_KEYS.filter((key) => key.toLowerCase().startsWith(partial)).map(
+    (key) => ({ display: key, insert: key })
+  );
+  const levelSuggestions = LEVEL_NAMES.filter((level) => level.startsWith(partial)).map(
+    (level) => ({
+      display: `${level} (level shorthand)`,
+      insert: level,
+    })
+  );
+
+  return [...keySuggestions, ...levelSuggestions].slice(0, maxSuggestions);
+}
+
 const LEVEL_PRIORITY: Record<string, number> = {
   verbose: 0,
   v: 0,

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -81,6 +81,7 @@ export function getQueryBarSuggestions(
           .slice(0, maxSuggestions)
           .map((tag) => ({ display: tag, insert: tag }));
       case "package":
+      case "pkg":
         return ["mine", ...knownPackages]
           .filter((packageName) => packageName.toLowerCase().includes(partial))
           .slice(0, maxSuggestions)

--- a/src/lib/logcat-suggestions.test.ts
+++ b/src/lib/logcat-suggestions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { LogcatEntry } from "@/lib/tauri-api";
+import { createLogcatSuggestionIndex } from "./logcat-suggestions";
+
+function entry(id: number, tag: string, pkg?: string): LogcatEntry {
+  return {
+    id: BigInt(id),
+    timestamp: "01-01 00:00:00.000",
+    level: "debug",
+    tag,
+    message: "message",
+    pid: 1,
+    tid: 1,
+    package: pkg ?? null,
+    isCrash: false,
+    crashGroupId: null,
+    jsonBody: null,
+    flags: 0,
+    kind: "normal",
+    category: "general",
+  };
+}
+
+describe("createLogcatSuggestionIndex", () => {
+  it("bounds remembered packages and tags while preserving ranked tag suggestions", () => {
+    const index = createLogcatSuggestionIndex({ maxPackages: 3, maxTags: 4, maxVisibleTags: 2 });
+
+    index.ingest([
+      entry(1, "Noisy", "com.example.one"),
+      entry(2, "Noisy", "com.example.two"),
+      entry(3, "Rare", "com.example.three"),
+      entry(4, "Noisy", "com.example.four"),
+      entry(5, "Other", "com.example.five"),
+      entry(6, "Other"),
+      entry(7, "IgnoredSeparator", "com.example.six"),
+      { ...entry(8, "ProcessDied", "com.example.seven"), kind: "processDied" },
+    ]);
+
+    expect(index.packages()).toHaveLength(3);
+    expect(index.packages()).toEqual(["com.example.five", "com.example.seven", "com.example.six"]);
+    expect(index.tags()).toEqual(["Noisy", "Other"]);
+  });
+
+  it("clears all accumulated suggestion data", () => {
+    const index = createLogcatSuggestionIndex({ maxPackages: 3, maxTags: 3, maxVisibleTags: 3 });
+
+    index.ingest([entry(1, "App", "com.example")]);
+    index.clear();
+
+    expect(index.packages()).toEqual([]);
+    expect(index.tags()).toEqual([]);
+  });
+});

--- a/src/lib/logcat-suggestions.ts
+++ b/src/lib/logcat-suggestions.ts
@@ -1,0 +1,69 @@
+import type { LogcatEntry } from "@/lib/tauri-api";
+
+export interface LogcatSuggestionIndexOptions {
+  maxPackages: number;
+  maxTags: number;
+  maxVisibleTags: number;
+}
+
+export interface LogcatSuggestionIndex {
+  ingest(entries: LogcatEntry[]): void;
+  packages(): string[];
+  tags(): string[];
+  clear(): void;
+}
+
+function rememberCappedKey<T>(map: Map<T, number>, key: T, value: number, cap: number): void {
+  if (map.has(key)) {
+    map.set(key, value);
+    return;
+  }
+  map.set(key, value);
+  while (map.size > cap) {
+    const oldest = map.keys().next().value as T | undefined;
+    if (oldest === undefined) break;
+    map.delete(oldest);
+  }
+}
+
+export function createLogcatSuggestionIndex(
+  options: LogcatSuggestionIndexOptions
+): LogcatSuggestionIndex {
+  const packageSeenAt = new Map<string, number>();
+  const tagFreqMap = new Map<string, number>();
+  let sequence = 0;
+
+  return {
+    ingest(entries: LogcatEntry[]) {
+      for (const entry of entries) {
+        sequence += 1;
+        if (entry.package) {
+          rememberCappedKey(packageSeenAt, entry.package, sequence, options.maxPackages);
+        }
+        if (!entry.kind || entry.kind === "normal") {
+          const nextCount = (tagFreqMap.get(entry.tag) ?? 0) + 1;
+          if (tagFreqMap.has(entry.tag) || tagFreqMap.size < options.maxTags) {
+            tagFreqMap.set(entry.tag, nextCount);
+          }
+        }
+      }
+    },
+    packages() {
+      return Array.from(packageSeenAt.entries())
+        .sort((a, b) => a[1] - b[1])
+        .map(([pkg]) => pkg)
+        .sort();
+    },
+    tags() {
+      return Array.from(tagFreqMap.entries())
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, options.maxVisibleTags)
+        .map(([tag]) => tag);
+    },
+    clear() {
+      packageSeenAt.clear();
+      tagFreqMap.clear();
+      sequence = 0;
+    },
+  };
+}

--- a/src/lib/logcat-suggestions.ts
+++ b/src/lib/logcat-suggestions.ts
@@ -50,7 +50,6 @@ export function createLogcatSuggestionIndex(
     },
     packages() {
       return Array.from(packageSeenAt.entries())
-        .sort((a, b) => a[1] - b[1])
         .map(([pkg]) => pkg)
         .sort();
     },

--- a/src/services/logcat.service.test.ts
+++ b/src/services/logcat.service.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { createLatestOnlyGuard } from "./logcat.service";
+
+describe("createLatestOnlyGuard", () => {
+  it("marks only the newest request token as current", () => {
+    const guard = createLatestOnlyGuard();
+
+    const first = guard.begin();
+    const second = guard.begin();
+
+    expect(guard.isLatest(first)).toBe(false);
+    expect(guard.isLatest(second)).toBe(true);
+  });
+
+  it("can invalidate in-flight work without starting a replacement", () => {
+    const guard = createLatestOnlyGuard();
+
+    const token = guard.begin();
+    guard.invalidate();
+
+    expect(guard.isLatest(token)).toBe(false);
+  });
+});

--- a/src/services/logcat.service.ts
+++ b/src/services/logcat.service.ts
@@ -1,0 +1,21 @@
+export interface LatestOnlyGuard {
+  begin(): number;
+  isLatest(token: number): boolean;
+  invalidate(): void;
+}
+
+export function createLatestOnlyGuard(): LatestOnlyGuard {
+  let latest = 0;
+  return {
+    begin() {
+      latest += 1;
+      return latest;
+    },
+    isLatest(token: number) {
+      return token === latest;
+    },
+    invalidate() {
+      latest += 1;
+    },
+  };
+}

--- a/src/stores/logcat.store.test.ts
+++ b/src/stores/logcat.store.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { LogcatEntry } from "@/lib/tauri-api";
+import { appendEntriesIncremental, computeCrashIndices } from "./logcat.store";
+
+function entry(id: number, isCrash = false): LogcatEntry {
+  return {
+    id: BigInt(id),
+    timestamp: "01-01 00:00:00.000",
+    level: isCrash ? "fatal" : "debug",
+    tag: `Tag${id}`,
+    message: `message ${id}`,
+    pid: 1,
+    tid: 1,
+    package: null,
+    isCrash,
+    crashGroupId: null,
+    jsonBody: null,
+    flags: 0,
+    kind: "normal",
+    category: "general",
+  };
+}
+
+describe("logcat store helpers", () => {
+  it("appends without replacing arrays when no eviction is needed", () => {
+    const entries = [entry(1), entry(2, true), entry(3)];
+    const crashIndices = [1];
+    const originalEntries = entries;
+    const originalCrashIndices = crashIndices;
+
+    const dropped = appendEntriesIncremental(entries, crashIndices, [entry(4), entry(5, true)], 10);
+
+    expect(dropped).toBe(0);
+    expect(entries).toBe(originalEntries);
+    expect(crashIndices).toBe(originalCrashIndices);
+    expect(entries.map((e) => e.id)).toEqual([1n, 2n, 3n, 4n, 5n]);
+    expect(crashIndices).toEqual([1, 4]);
+  });
+
+  it("strictly caps entries and rebuilds crash indices only after eviction", () => {
+    const entries = [entry(1), entry(2, true), entry(3)];
+    const crashIndices = [1];
+
+    const dropped = appendEntriesIncremental(
+      entries,
+      crashIndices,
+      [entry(4), entry(5, true), entry(6)],
+      4
+    );
+
+    expect(dropped).toBe(2);
+    expect(entries.map((e) => e.id)).toEqual([3n, 4n, 5n, 6n]);
+    expect(crashIndices).toEqual([2]);
+  });
+
+  it("handles a batch larger than the cap", () => {
+    const entries = [entry(1)];
+    const crashIndices: number[] = [];
+    const dropped = appendEntriesIncremental(
+      entries,
+      crashIndices,
+      [entry(2), entry(3, true), entry(4)],
+      2
+    );
+
+    expect(dropped).toBe(2);
+    expect(entries.map((e) => e.id)).toEqual([3n, 4n]);
+    expect(crashIndices).toEqual([0]);
+  });
+
+  it("computes crash indices for an existing list", () => {
+    expect(computeCrashIndices([entry(1, true), entry(2), entry(3, true)])).toEqual([0, 2]);
+  });
+});

--- a/src/stores/logcat.store.ts
+++ b/src/stores/logcat.store.ts
@@ -1,0 +1,85 @@
+import { createStore, produce } from "solid-js/store";
+import type { LogcatEntry } from "@/lib/tauri-api";
+
+interface LogcatStore {
+  entries: LogcatEntry[];
+  streaming: boolean;
+  crashIndicesFull: number[];
+  ringBufferTotal: number | null;
+}
+
+export const [logcatState, setLogcatState] = createStore<LogcatStore>({
+  entries: [],
+  streaming: false,
+  crashIndicesFull: [],
+  ringBufferTotal: null,
+});
+
+export function computeCrashIndices(entries: LogcatEntry[]): number[] {
+  return entries.reduce<number[]>((acc, entry, index) => {
+    if (entry.isCrash) acc.push(index);
+    return acc;
+  }, []);
+}
+
+function replaceCrashIndices(target: number[], entries: LogcatEntry[]): void {
+  target.splice(0, target.length);
+  entries.forEach((entry, index) => {
+    if (entry.isCrash) target.push(index);
+  });
+}
+
+export function appendEntriesIncremental(
+  entries: LogcatEntry[],
+  crashIndices: number[],
+  incomingEntries: LogcatEntry[],
+  cap: number
+): number {
+  const safeCap = Math.max(0, Math.floor(cap));
+  const baseLen = entries.length;
+
+  for (const entry of incomingEntries) {
+    entries.push(entry);
+  }
+
+  const dropped = Math.max(0, entries.length - safeCap);
+  if (dropped > 0) {
+    entries.splice(0, dropped);
+    replaceCrashIndices(crashIndices, entries);
+    return dropped;
+  }
+
+  incomingEntries.forEach((entry, index) => {
+    if (entry.isCrash) crashIndices.push(baseLen + index);
+  });
+
+  return 0;
+}
+
+export function replaceLogcatEntries(entries: LogcatEntry[]): void {
+  setLogcatState("entries", entries);
+  setLogcatState("crashIndicesFull", computeCrashIndices(entries));
+}
+
+export function clearLogcatEntries(): void {
+  setLogcatState("entries", []);
+  setLogcatState("crashIndicesFull", []);
+}
+
+export function appendLogcatEntries(entries: LogcatEntry[], cap: number): number {
+  let dropped = 0;
+  setLogcatState(
+    produce((state) => {
+      dropped = appendEntriesIncremental(state.entries, state.crashIndicesFull, entries, cap);
+    })
+  );
+  return dropped;
+}
+
+export function setLogcatStreaming(streaming: boolean): void {
+  setLogcatState("streaming", streaming);
+}
+
+export function setLogcatRingBufferTotal(total: number | null): void {
+  setLogcatState("ringBufferTotal", total);
+}


### PR DESCRIPTION
## Summary

refact for better structure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Logcat experience into modular pieces with saved filters, smarter suggestions, and a JSON detail panel. Rust pipeline now uses bounded queues with centralized level parsing for better stability and lower memory use.

- **New Features**
  - Saved Filters menu with presets and rename/delete.
  - Query suggestions via a live index (tags, packages, levels).
  - Age pills and a package dropdown in filter controls.
  - JSON detail panel with copy-to-clipboard.
  - Toolbar: start/stop, pause, restart, clear, export, auto-scroll, crash navigation, copy selection.

- **Refactors**
  - Split Logcat UI into focused components: `LogcatRows`, `LogcatToolbar`, `LogcatFilterControls`, `SavedFilterMenu`, `QueryBarParts`, and styles.
  - Moved backend filter conversion to `src/lib/logcat-filter-spec.ts`; added `logcat.store` and `logcat.service` (`createLatestOnlyGuard`) for state and request control.
  - Rust: switched to bounded `tokio::sync::mpsc::Receiver`, added caps for raw-line buffering and `MAX_BATCH_SIZE`, and reused `logcat::parse_level_str`.
  - Added tests for query suggestions, suggestion runtime/index, filter spec, store append/eviction, and service guard.
  - Docs cleanup and rename: `docs/DOMAIN_PATTERN.md` ➜ `docs/DOMAIN_PATTERNS.md`; simplified best practices and user guide; updated references in templates and guides.

<sup>Written for commit 0f03813b69738908b919c9393188490aba92cee6. Summary will update on new commits. <a href="https://cubic.dev/pr/thiagodmont/keynobi/pull/42?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

