### PR TITLE
Feat/logcat click filter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,14 @@
 - **Mutex discipline**: Lock Rust state, clone what you need, drop the lock, then do I/O. Never hold a Mutex across an `await`.
 - **Bounded collections**: Every in-memory collection that grows must have an explicit cap (see `BEST_PRACTICES.md`).
 - **No `unwrap()` in production Rust**: Use `?` or `.map_err(...)`. `expect()` is allowed only for programmer-error invariants.
+- **Do not commit**: The superpower spec and plan files.
 
 ## Testing Instructions
 
 ### Frontend
+This command should be run after the development is completed to guarantee that the development is working properly. 
 ```bash
 npm run test              # run all frontend tests once
-npm run test:watch        # watch mode during development
 npm run test:ui           # Vitest browser UI
 npm run lint              # Check lint rules
 npm run typescript:check  # Check typescript 

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -146,6 +146,7 @@ Press **Enter** to commit a typed condition as a filter pill. Use **+ AND** and 
 - JSON messages show a `{}` badge; open it to view formatted JSON.
 - Arrow keys move the selected row when focus is not in the query bar.
 - Selecting a row pauses follow-tail until you jump back to the end.
+- In **Entry Detail**, click a tag, package, level, PID, TID, time, or message value to add it to the query bar as an **AND** or **OR** filter. Select part of the message before clicking to filter by only that selected text.
 
 Logcat keeps a bounded ring buffer. Configure the ring size and max visible lines under **Settings -> Logcat**.
 

--- a/docs/superpowers/specs/2026-04-29-logcat-click-to-filter-design.md
+++ b/docs/superpowers/specs/2026-04-29-logcat-click-to-filter-design.md
@@ -1,0 +1,99 @@
+# Logcat Click-To-Filter Design
+
+## Goal
+
+Let users turn values from the log entry detail panel into query-bar filter pills without typing. Clicking a value in **Entry Detail** opens a floating context menu with **Add as AND** and **Add as OR** actions.
+
+## User Experience
+
+The interaction starts in `LogEntryDetailPanel`. Every visible metadata value is clickable:
+
+- Tag
+- Package
+- Level
+- PID
+- TID
+- Time
+- Message
+
+Clicking one of these values opens a floated menu anchored to the clicked value, visually similar to a right-click context menu. The menu overlays the panel and does not change the detail panel layout. The menu closes when the user chooses an action, clicks outside it, presses Escape, or selects another value.
+
+For the message field, the user can either click without a text selection to filter by the full message or select part of the message text before clicking to filter by the selected text. Selected text takes precedence over the full message.
+
+## Filter Mapping
+
+Clicked values become committed query-bar tokens:
+
+| Entry Detail value | Query token |
+| --- | --- |
+| Tag | `tag:<value>` |
+| Package | `package:<value>` |
+| Level | `level:<lowercase-level>` |
+| PID | `pid:<number>` |
+| TID | `tid:<number>` |
+| Time | `time:"<timestamp>"` |
+| Full message | `message:"<message>"` |
+| Selected message text | `message:"<selected text>"` |
+
+Token values that can contain spaces, quotes, pipes, or other query separators are quoted and escaped before insertion. Numeric values are inserted without quotes. Empty package values are not filterable.
+
+## AND And OR Semantics
+
+The floating menu has two actions:
+
+- **Add as AND** inserts the new token into the current group. It appends to the existing query using the same committed-token convention as the query bar, with `&&` used only when needed for an explicit visual connector.
+- **Add as OR** inserts the new token as a new OR group by appending `| <token>`.
+
+If the query is empty, both actions produce the same single-token query because there is no existing condition to combine with.
+
+The resulting query string always ends with a trailing space so the query bar renders the inserted token as a committed pill instead of leaving it as draft text.
+
+## Architecture
+
+`LogEntryDetailPanel` remains a presentational component. It receives an optional callback such as `onAddFilter` and emits `{ token, mode }` when the user chooses a menu action. It does not own or parse the global query string.
+
+`LogcatPanel` continues to own the active query through `updateQuery`. It passes an `onAddFilter` handler down to `LogEntryDetailPanel`, appends the emitted token with AND or OR semantics, and lets the existing query persistence and backend-filter synchronization effects run.
+
+Pure query-building helpers live in `src/lib/logcat-query.ts` so token creation, quoting, and append behavior can be tested outside Solid components. The existing query bar remains the single visible source of truth for active filters.
+
+## Query Parser Changes
+
+`src/lib/logcat-query.ts` adds three token types:
+
+- `pid`
+- `tid`
+- `time`
+
+`pid` and `tid` match exact numeric values against `entry.pid` and `entry.tid`. `time` matches exact timestamp text against `entry.timestamp`.
+
+These filters are evaluated in the frontend. They are not added to `LogcatFilterSpec` because the Rust backend filter currently has no fields for PID, TID, or exact timestamp, and adding backend support is unnecessary for this UI-focused feature.
+
+## Accessibility And Interaction Details
+
+Clickable values use button semantics where practical so they are keyboard reachable. The menu supports Escape to close and uses normal button items for the AND and OR choices.
+
+The menu is positioned from the clicked element's bounding rectangle and clamped to the viewport. It has a high enough z-index to float above the detail panel but stays scoped to logcat UI styling.
+
+## Error Handling
+
+If a value cannot produce a useful token, the detail panel does not open the menu for that value. This applies to missing package values and empty selected message text. If the selected message text is whitespace-only, the full message fallback is used only when the click target is the message field itself.
+
+## Testing
+
+Frontend tests cover:
+
+- Query parsing and matching for `pid:`, `tid:`, and `time:`.
+- Token quoting and escaping for message and timestamp values.
+- AND insertion into an empty and non-empty query.
+- OR insertion into an empty and non-empty query.
+- `LogEntryDetailPanel` opening a floating menu when a filterable value is clicked.
+- Menu actions emitting the expected token and mode.
+- Message text selection taking precedence over the full message.
+
+No Rust tests or TypeScript binding regeneration are required because the IPC model does not change.
+
+## Documentation Updates
+
+Update `docs/USER_MANUAL.md` under the Logcat section to mention that Entry Detail values can be clicked to create AND/OR filters.
+
+`docs/CODE_PATTERN.md`, `docs/DOMAIN_PATTERNS.md`, and `docs/BEST_PRACTICES.md` do not need updates unless implementation introduces a new reusable query-building pattern beyond this feature.

--- a/src/components/logcat/LogEntryDetailPanel.module.css
+++ b/src/components/logcat/LogEntryDetailPanel.module.css
@@ -89,6 +89,34 @@
   white-space: nowrap;
 }
 
+.cellValueButton {
+  background: transparent;
+  border: 0;
+  color: var(--text-primary);
+  cursor: context-menu;
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  margin: 0;
+  max-width: 100%;
+  overflow: hidden;
+  padding: 0;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cellValueButton:hover,
+.cellValueButton:focus-visible,
+.messageValue[role="button"]:hover,
+.messageValue[role="button"]:focus-visible {
+  color: var(--accent);
+  outline: none;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
 .messageArea {
   flex: 1;
   overflow: auto;
@@ -103,4 +131,38 @@
   margin: 0;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+.messageValue[role="button"] {
+  cursor: context-menu;
+}
+
+.filterMenu {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 35%);
+  display: flex;
+  flex-direction: column;
+  min-width: 140px;
+  padding: 4px;
+  position: fixed;
+  z-index: 1000;
+}
+
+.filterMenuItem {
+  background: transparent;
+  border: 0;
+  border-radius: 3px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 6px 9px;
+  text-align: left;
+}
+
+.filterMenuItem:hover,
+.filterMenuItem:focus-visible {
+  background: var(--bg-hover);
+  outline: none;
 }

--- a/src/components/logcat/LogEntryDetailPanel.test.tsx
+++ b/src/components/logcat/LogEntryDetailPanel.test.tsx
@@ -102,16 +102,41 @@ describe("LogEntryDetailPanel", () => {
 
   it("uses selected message text instead of the full message", () => {
     const onAddFilter = vi.fn();
-    vi.spyOn(window, "getSelection").mockReturnValue({
-      toString: () => "line 42",
-    } as ReturnType<typeof window.getSelection>);
     render(() => (
       <LogEntryDetailPanel entry={ENTRY} onClose={() => {}} onAddFilter={onAddFilter} />
     ));
+    const message = screen.getByText("NullPointerException at line 42");
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "line 42",
+      anchorNode: message.firstChild,
+      focusNode: message.firstChild,
+    } as unknown as ReturnType<typeof window.getSelection>);
+
+    fireEvent.click(message);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add as OR" }));
+
+    expect(onAddFilter).toHaveBeenCalledWith({ token: 'message:"line 42"', mode: "or" });
+  });
+
+  it("ignores selected text outside the message field", () => {
+    const onAddFilter = vi.fn();
+    const outside = document.createTextNode("outside selection");
+    document.body.appendChild(outside);
+    render(() => (
+      <LogEntryDetailPanel entry={ENTRY} onClose={() => {}} onAddFilter={onAddFilter} />
+    ));
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "outside selection",
+      anchorNode: outside,
+      focusNode: outside,
+    } as unknown as ReturnType<typeof window.getSelection>);
 
     fireEvent.click(screen.getByText("NullPointerException at line 42"));
     fireEvent.click(screen.getByRole("menuitem", { name: "Add as OR" }));
 
-    expect(onAddFilter).toHaveBeenCalledWith({ token: 'message:"line 42"', mode: "or" });
+    expect(onAddFilter).toHaveBeenCalledWith({
+      token: 'message:"NullPointerException at line 42"',
+      mode: "or",
+    });
   });
 });

--- a/src/components/logcat/LogEntryDetailPanel.test.tsx
+++ b/src/components/logcat/LogEntryDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
 import { LogEntryDetailPanel } from "./LogEntryDetailPanel";
 import type { LogcatEntry } from "@/lib/tauri-api";
@@ -39,11 +39,14 @@ describe("LogEntryDetailPanel", () => {
   it("calls onClose when close button is clicked", () => {
     let closed = false;
     render(() => (
-      <LogEntryDetailPanel entry={ENTRY} onClose={() => { closed = true; }} />
+      <LogEntryDetailPanel
+        entry={ENTRY}
+        onClose={() => {
+          closed = true;
+        }}
+      />
     ));
-    const closeBtn = screen.getAllByRole("button").find(
-      (b) => b.getAttribute("title") === "Close"
-    );
+    const closeBtn = screen.getAllByRole("button").find((b) => b.getAttribute("title") === "Close");
     expect(closeBtn).not.toBeUndefined();
     closeBtn!.click();
     expect(closed).toBe(true);
@@ -52,9 +55,63 @@ describe("LogEntryDetailPanel", () => {
   it("calls onClose when Escape is pressed", () => {
     let closed = false;
     render(() => (
-      <LogEntryDetailPanel entry={ENTRY} onClose={() => { closed = true; }} />
+      <LogEntryDetailPanel
+        entry={ENTRY}
+        onClose={() => {
+          closed = true;
+        }}
+      />
     ));
     fireEvent.keyDown(document, { key: "Escape" });
     expect(closed).toBe(true);
+  });
+
+  it("opens a floating filter menu when a metadata value is clicked", () => {
+    render(() => <LogEntryDetailPanel entry={ENTRY} onClose={() => {}} onAddFilter={() => {}} />);
+
+    fireEvent.click(screen.getByText("MainActivity"));
+
+    expect(screen.getByRole("menu")).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Add as AND" })).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Add as OR" })).not.toBeNull();
+  });
+
+  it("emits the clicked metadata token with the selected mode", () => {
+    const onAddFilter = vi.fn();
+    render(() => (
+      <LogEntryDetailPanel entry={ENTRY} onClose={() => {}} onAddFilter={onAddFilter} />
+    ));
+
+    fireEvent.click(screen.getByText("MainActivity"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add as AND" }));
+
+    expect(onAddFilter).toHaveBeenCalledWith({ token: "tag:MainActivity", mode: "and" });
+  });
+
+  it("emits OR filters for package values", () => {
+    const onAddFilter = vi.fn();
+    render(() => (
+      <LogEntryDetailPanel entry={ENTRY} onClose={() => {}} onAddFilter={onAddFilter} />
+    ));
+
+    fireEvent.click(screen.getByText("com.example.app"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add as OR" }));
+
+    expect(onAddFilter).toHaveBeenCalledWith({ token: "package:com.example.app", mode: "or" });
+  });
+
+  it("uses selected message text instead of the full message", () => {
+    const onAddFilter = vi.fn();
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "line 42",
+    } as ReturnType<typeof window.getSelection>);
+    render(() => (
+      <LogEntryDetailPanel entry={ENTRY} onClose={() => {}} onAddFilter={onAddFilter} />
+    ));
+
+    fireEvent.click(screen.getByText("NullPointerException at line 42"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add as OR" }));
+
+    expect(onAddFilter).toHaveBeenCalledWith({ token: 'message:"line 42"', mode: "or" });
   });
 });

--- a/src/components/logcat/LogEntryDetailPanel.test.tsx
+++ b/src/components/logcat/LogEntryDetailPanel.test.tsx
@@ -139,4 +139,27 @@ describe("LogEntryDetailPanel", () => {
       mode: "or",
     });
   });
+
+  it("ignores selected text that crosses outside the message field", () => {
+    const onAddFilter = vi.fn();
+    const outside = document.createTextNode("outside selection");
+    document.body.appendChild(outside);
+    render(() => (
+      <LogEntryDetailPanel entry={ENTRY} onClose={() => {}} onAddFilter={onAddFilter} />
+    ));
+    const message = screen.getByText("NullPointerException at line 42");
+    vi.spyOn(window, "getSelection").mockReturnValue({
+      toString: () => "line 42 plus outside selection",
+      anchorNode: message.firstChild,
+      focusNode: outside,
+    } as unknown as ReturnType<typeof window.getSelection>);
+
+    fireEvent.click(message);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add as OR" }));
+
+    expect(onAddFilter).toHaveBeenCalledWith({
+      token: 'message:"NullPointerException at line 42"',
+      mode: "or",
+    });
+  });
 });

--- a/src/components/logcat/LogEntryDetailPanel.tsx
+++ b/src/components/logcat/LogEntryDetailPanel.tsx
@@ -106,13 +106,18 @@ export function LogEntryDetailPanel(props: LogEntryDetailPanelProps) {
     setFilterMenu({ token, ...menuPositionFor(target) });
   }
 
-  function selectedMessageText(): string | null {
-    const selected = window.getSelection?.()?.toString().trim();
-    return selected || null;
+  function selectedMessageText(target: HTMLElement): string | null {
+    const selection = window.getSelection?.();
+    const selected = selection?.toString().trim();
+    if (!selection || !selected) return null;
+
+    const anchorInside = selection.anchorNode ? target.contains(selection.anchorNode) : false;
+    const focusInside = selection.focusNode ? target.contains(selection.focusNode) : false;
+    return anchorInside || focusInside ? selected : null;
   }
 
   function openMessageFilterMenu(target: HTMLElement): void {
-    openFilterMenu("message", selectedMessageText() ?? props.entry.message, target);
+    openFilterMenu("message", selectedMessageText(target) ?? props.entry.message, target);
   }
 
   function addFilter(mode: LogEntryDetailFilterMode): void {

--- a/src/components/logcat/LogEntryDetailPanel.tsx
+++ b/src/components/logcat/LogEntryDetailPanel.tsx
@@ -113,7 +113,7 @@ export function LogEntryDetailPanel(props: LogEntryDetailPanelProps) {
 
     const anchorInside = selection.anchorNode ? target.contains(selection.anchorNode) : false;
     const focusInside = selection.focusNode ? target.contains(selection.focusNode) : false;
-    return anchorInside || focusInside ? selected : null;
+    return anchorInside && focusInside ? selected : null;
   }
 
   function openMessageFilterMenu(target: HTMLElement): void {

--- a/src/components/logcat/LogEntryDetailPanel.tsx
+++ b/src/components/logcat/LogEntryDetailPanel.tsx
@@ -1,6 +1,11 @@
-import { onCleanup, onMount } from "solid-js";
+import { Show, createSignal, onCleanup, onMount } from "solid-js";
 import { showToast } from "@/components/ui";
 import type { LogcatEntry } from "@/lib/tauri-api";
+import {
+  buildLogEntryDetailFilterToken,
+  type LogEntryDetailFilterField,
+  type LogEntryDetailFilterMode,
+} from "@/lib/logcat-query";
 import { getLevelConfig } from "./logcat-levels";
 import styles from "./LogEntryDetailPanel.module.css";
 
@@ -12,6 +17,13 @@ function formatEntry(e: LogcatEntry): string {
 interface LogEntryDetailPanelProps {
   entry: LogcatEntry;
   onClose: () => void;
+  onAddFilter?: (filter: { token: string; mode: LogEntryDetailFilterMode }) => void;
+}
+
+interface FilterMenuState {
+  token: string;
+  x: number;
+  y: number;
 }
 
 function MetaCell(props: {
@@ -20,7 +32,12 @@ function MetaCell(props: {
   valueStyle?: Record<string, string>;
   borderRight?: boolean;
   borderLeft?: boolean;
+  filterField?: LogEntryDetailFilterField;
+  filterValue?: unknown;
+  onFilterClick?: (field: LogEntryDetailFilterField, value: unknown, target: HTMLElement) => void;
 }) {
+  const canFilter = () => props.filterField && props.value !== "—" && props.onFilterClick;
+
   return (
     <div
       class={[
@@ -32,15 +49,78 @@ function MetaCell(props: {
         .join(" ")}
     >
       <div class={styles.cellLabel}>{props.label}</div>
-      <div class={styles.cellValue} style={props.valueStyle}>
-        {props.value}
-      </div>
+      <Show
+        when={canFilter()}
+        fallback={
+          <div class={styles.cellValue} style={props.valueStyle}>
+            {props.value}
+          </div>
+        }
+      >
+        <button
+          type="button"
+          class={styles.cellValueButton}
+          style={props.valueStyle}
+          title={`Filter by ${props.label}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onFilterClick?.(
+              props.filterField!,
+              props.filterValue ?? props.value,
+              e.currentTarget
+            );
+          }}
+        >
+          {props.value}
+        </button>
+      </Show>
     </div>
   );
 }
 
 export function LogEntryDetailPanel(props: LogEntryDetailPanelProps) {
+  let menuRef: HTMLDivElement | undefined;
   const cfg = () => getLevelConfig(props.entry.level);
+  const [filterMenu, setFilterMenu] = createSignal<FilterMenuState | null>(null);
+
+  function menuPositionFor(target: HTMLElement): { x: number; y: number } {
+    const rect = target.getBoundingClientRect();
+    const menuWidth = 150;
+    const menuHeight = 72;
+    const maxX = Math.max(8, window.innerWidth - menuWidth - 8);
+    const maxY = Math.max(8, window.innerHeight - menuHeight - 8);
+    return {
+      x: Math.min(Math.max(8, rect.left), maxX),
+      y: Math.min(Math.max(8, rect.bottom + 4), maxY),
+    };
+  }
+
+  function openFilterMenu(
+    field: LogEntryDetailFilterField,
+    value: unknown,
+    target: HTMLElement
+  ): void {
+    if (!props.onAddFilter) return;
+    const token = buildLogEntryDetailFilterToken(field, value);
+    if (!token) return;
+    setFilterMenu({ token, ...menuPositionFor(target) });
+  }
+
+  function selectedMessageText(): string | null {
+    const selected = window.getSelection?.()?.toString().trim();
+    return selected || null;
+  }
+
+  function openMessageFilterMenu(target: HTMLElement): void {
+    openFilterMenu("message", selectedMessageText() ?? props.entry.message, target);
+  }
+
+  function addFilter(mode: LogEntryDetailFilterMode): void {
+    const menu = filterMenu();
+    if (!menu) return;
+    props.onAddFilter?.({ token: menu.token, mode });
+    setFilterMenu(null);
+  }
 
   function copyEntry() {
     navigator.clipboard.writeText(formatEntry(props.entry)).then(() => {
@@ -49,11 +129,28 @@ export function LogEntryDetailPanel(props: LogEntryDetailPanelProps) {
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "Escape") props.onClose();
+    if (e.key !== "Escape") return;
+    if (filterMenu()) {
+      setFilterMenu(null);
+      return;
+    }
+    props.onClose();
   }
 
-  onMount(() => document.addEventListener("keydown", handleKeyDown));
-  onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
+  function handleDocumentMouseDown(e: MouseEvent) {
+    if (!filterMenu()) return;
+    if (menuRef?.contains(e.target as globalThis.Node)) return;
+    setFilterMenu(null);
+  }
+
+  onMount(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("mousedown", handleDocumentMouseDown);
+  });
+  onCleanup(() => {
+    document.removeEventListener("keydown", handleKeyDown);
+    document.removeEventListener("mousedown", handleDocumentMouseDown);
+  });
 
   return (
     <div class={styles.panel}>
@@ -70,24 +167,103 @@ export function LogEntryDetailPanel(props: LogEntryDetailPanelProps) {
       </div>
 
       <div class={styles.grid}>
-        <MetaCell label="Tag" value={props.entry.tag} borderRight />
-        <MetaCell label="Package" value={props.entry.package ?? "—"} borderRight />
+        <MetaCell
+          label="Tag"
+          value={props.entry.tag}
+          borderRight
+          filterField="tag"
+          onFilterClick={openFilterMenu}
+        />
+        <MetaCell
+          label="Package"
+          value={props.entry.package ?? "—"}
+          borderRight
+          filterField="package"
+          filterValue={props.entry.package}
+          onFilterClick={openFilterMenu}
+        />
         <MetaCell
           label="Level"
           value={props.entry.level.toUpperCase()}
           valueStyle={{ color: cfg().color }}
+          filterField="level"
+          filterValue={props.entry.level}
+          onFilterClick={openFilterMenu}
         />
       </div>
 
       <div class={styles.grid}>
-        <MetaCell label="PID" value={String(props.entry.pid ?? "—")} borderRight />
-        <MetaCell label="TID" value={String(props.entry.tid ?? "—")} borderRight />
-        <MetaCell label="Time" value={props.entry.timestamp} />
+        <MetaCell
+          label="PID"
+          value={String(props.entry.pid ?? "—")}
+          borderRight
+          filterField="pid"
+          filterValue={props.entry.pid}
+          onFilterClick={openFilterMenu}
+        />
+        <MetaCell
+          label="TID"
+          value={String(props.entry.tid ?? "—")}
+          borderRight
+          filterField="tid"
+          filterValue={props.entry.tid}
+          onFilterClick={openFilterMenu}
+        />
+        <MetaCell
+          label="Time"
+          value={props.entry.timestamp}
+          filterField="time"
+          onFilterClick={openFilterMenu}
+        />
       </div>
 
       <div class={styles.messageArea}>
-        <pre class={styles.messageValue}>{props.entry.message}</pre>
+        <pre
+          class={styles.messageValue}
+          role={props.onAddFilter ? "button" : undefined}
+          tabIndex={props.onAddFilter ? 0 : undefined}
+          title={props.onAddFilter ? "Filter by message" : undefined}
+          onClick={(e) => {
+            e.stopPropagation();
+            openMessageFilterMenu(e.currentTarget);
+          }}
+          onKeyDown={(e) => {
+            if (e.key !== "Enter" && e.key !== " ") return;
+            e.preventDefault();
+            openMessageFilterMenu(e.currentTarget);
+          }}
+        >
+          {props.entry.message}
+        </pre>
       </div>
+
+      <Show when={filterMenu()}>
+        {(menu) => (
+          <div
+            ref={menuRef}
+            class={styles.filterMenu}
+            role="menu"
+            style={{ left: `${menu().x}px`, top: `${menu().y}px` }}
+          >
+            <button
+              type="button"
+              role="menuitem"
+              class={styles.filterMenuItem}
+              onClick={() => addFilter("and")}
+            >
+              Add as AND
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              class={styles.filterMenuItem}
+              onClick={() => addFilter("or")}
+            >
+              Add as OR
+            </button>
+          </div>
+        )}
+      </Show>
     </div>
   );
 }

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { LogcatFilterSpec, LogStats, ProcessedEntry } from "@/bindings";
+import {
+  replaceLogcatEntries,
+  setLogcatRingBufferTotal,
+  setLogcatStreaming,
+} from "@/stores/logcat.store";
+import { LogcatPanel } from "./LogcatPanel";
+
+const ROW_TITLE = "Click to copy · Shift+click to select range";
+
+const BASE_ENTRY = {
+  id: 1n,
+  timestamp: "04-29 13:00:00.000",
+  pid: 1234,
+  tid: 5678,
+  level: "info",
+  tag: "MainActivity",
+  message: "Activity started",
+  package: "com.example.app",
+  kind: "normal",
+  isCrash: false,
+  flags: 0,
+  category: "lifecycle",
+  crashGroupId: null,
+  jsonBody: null,
+} satisfies ProcessedEntry;
+
+function emptyFilter(): LogcatFilterSpec {
+  return { minLevel: null, tag: null, text: null, package: null, onlyCrashes: false };
+}
+
+function priority(level: string): number {
+  switch (level.toLowerCase()) {
+    case "verbose":
+      return 0;
+    case "debug":
+      return 1;
+    case "info":
+      return 2;
+    case "warn":
+      return 3;
+    case "error":
+      return 4;
+    case "fatal":
+      return 5;
+    default:
+      return 6;
+  }
+}
+
+function filterEntries(entries: ProcessedEntry[], spec: LogcatFilterSpec): ProcessedEntry[] {
+  return entries.filter((entry) => {
+    if (spec.onlyCrashes && !entry.isCrash) return false;
+    if (spec.minLevel && priority(entry.level) < priority(spec.minLevel)) return false;
+    if (spec.tag && !entry.tag.toLowerCase().includes(spec.tag.toLowerCase())) return false;
+    if (
+      spec.text &&
+      !entry.message.toLowerCase().includes(spec.text.toLowerCase()) &&
+      !entry.tag.toLowerCase().includes(spec.text.toLowerCase())
+    ) {
+      return false;
+    }
+    if (
+      spec.package &&
+      !(entry.package ?? entry.tag).toLowerCase().includes(spec.package.toLowerCase())
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function installLogcatPanelMocks(entries: ProcessedEntry[]): void {
+  let activeFilter = emptyFilter();
+
+  vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
+    switch (command) {
+      case "get_logcat_entries":
+        return filterEntries(entries, activeFilter);
+      case "get_logcat_status":
+        return false;
+      case "get_logcat_stats":
+        return {
+          totalIngested: BigInt(entries.length),
+          countsByLevel: [0n, 0n, 0n, 0n, 0n, 0n, 0n],
+          crashCount: 0n,
+          jsonCount: 0n,
+          packagesSeen: 1,
+          bufferUsagePct: 0,
+          bufferEntryCount: BigInt(entries.length),
+        } satisfies LogStats;
+      case "set_logcat_filter": {
+        const payload = args as { filterSpec?: LogcatFilterSpec };
+        activeFilter = payload.filterSpec ?? emptyFilter();
+        return undefined;
+      }
+      default:
+        return undefined;
+    }
+  });
+
+  vi.mocked(listen).mockResolvedValue(() => {});
+}
+
+describe("LogcatPanel Entry Detail click-to-filter integration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    replaceLogcatEntries([]);
+    setLogcatStreaming(false);
+    setLogcatRingBufferTotal(null);
+    vi.clearAllMocks();
+
+    if (!window.ResizeObserver) {
+      class MockResizeObserver {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+      }
+      window.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
+    }
+  });
+
+  afterEach(() => {
+    replaceLogcatEntries([]);
+    setLogcatStreaming(false);
+    setLogcatRingBufferTotal(null);
+  });
+
+  it("adds a clicked Entry Detail metadata value to the visible query bar", async () => {
+    installLogcatPanelMocks([BASE_ENTRY]);
+    render(() => <LogcatPanel />);
+
+    fireEvent.click(await screen.findByText("Activity started"));
+    fireEvent.click(screen.getByTitle("Filter by Tag"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add as AND" }));
+
+    expect(await screen.findByText("tag:MainActivity")).not.toBeNull();
+    await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(1));
+  });
+
+  it("keeps quoted message detail filters intact after a QueryBar rebuild", async () => {
+    const quotedEntry = {
+      ...BASE_ENTRY,
+      id: 2n,
+      tag: "QuotedTag",
+      message: 'hello "quoted" value',
+    } satisfies ProcessedEntry;
+    installLogcatPanelMocks([quotedEntry]);
+    render(() => <LogcatPanel />);
+
+    fireEvent.click(await screen.findByText('hello "quoted" value'));
+    fireEvent.click(screen.getByTitle("Filter by message"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add as AND" }));
+
+    expect(await screen.findByText('message:hello "quoted" value')).not.toBeNull();
+
+    const input = screen.getByRole("textbox");
+    fireEvent.input(input, { target: { value: "tag:QuotedTag" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(await screen.findByText("tag:QuotedTag")).not.toBeNull();
+    await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(1));
+    expect(screen.getAllByText('hello "quoted" value').length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -36,6 +36,8 @@ import {
   setPackageInQuery,
   getPackageFromQuery,
   setMinePackage,
+  appendLogEntryDetailFilterToken,
+  type LogEntryDetailFilterMode,
   type FilterGroup,
 } from "@/lib/logcat-query";
 import { projectState } from "@/stores/project.store";
@@ -210,6 +212,10 @@ export function LogcatPanel(): JSX.Element {
   function handlePackageSelect(pkg: string | null) {
     const q = setPackageInQuery(query(), pkg);
     updateQuery(q.trimEnd() ? q.trimEnd() + " " : "");
+  }
+
+  function handleDetailFilter(filter: { token: string; mode: LogEntryDetailFilterMode }) {
+    updateQuery(appendLogEntryDetailFilterToken(query(), filter.token, filter.mode));
   }
 
   async function refreshLogcatRingStats(): Promise<void> {
@@ -816,7 +822,11 @@ export function LogcatPanel(): JSX.Element {
       {/* ── Entry Detail Panel ────────────────────────────────────────────── */}
       <Show when={selectedDetailEntry()}>
         {(entry) => (
-          <LogEntryDetailPanel entry={entry()} onClose={() => setSelectedDetailEntry(null)} />
+          <LogEntryDetailPanel
+            entry={entry()}
+            onClose={() => setSelectedDetailEntry(null)}
+            onAddFilter={handleDetailFilter}
+          />
         )}
       </Show>
     </div>

--- a/src/lib/logcat-query.test.ts
+++ b/src/lib/logcat-query.test.ts
@@ -31,6 +31,8 @@ import {
   splitRawQueryParts,
   commitQueryBarDraft,
   getQueryBarSuggestions,
+  buildLogEntryDetailFilterToken,
+  appendLogEntryDetailFilterToken,
   setMinePackage,
   isStackTraceLine,
   parseStackFrame,
@@ -110,6 +112,32 @@ describe("parseQuery — level tokens", () => {
   it("parses warn shorthand", () => {
     const tokens = parseQuery("warn");
     expect(tokens[0]).toMatchObject({ type: "level", value: "warn" });
+  });
+});
+
+describe("parseQuery — Entry Detail tokens", () => {
+  it("parses pid, tid, and quoted time tokens", () => {
+    expect(parseQuery('pid:1234 tid:5678 time:"01-23 12:34:56.789"')).toEqual([
+      { type: "pid", value: 1234, negate: false },
+      { type: "tid", value: 5678, negate: false },
+      { type: "time", value: "01-23 12:34:56.789", negate: false },
+    ]);
+  });
+
+  it("parses escaped quotes inside quoted values", () => {
+    const tokens = parseQuery('message:"hello \\"quoted\\" value"');
+    expect(tokens[0]).toMatchObject({
+      type: "message",
+      value: 'hello "quoted" value',
+      negate: false,
+    });
+  });
+
+  it("ignores invalid numeric pid and tid filters", () => {
+    expect(parseQuery("pid:abc tid:-1")).toEqual([
+      { type: "freetext", value: "pid:abc", negate: false },
+      { type: "freetext", value: "tid:-1", negate: false },
+    ]);
   });
 });
 
@@ -458,6 +486,23 @@ describe("matchesQuery — all tokens must match (AND logic)", () => {
   });
 });
 
+describe("matchesQuery — Entry Detail tokens", () => {
+  it("matches exact pid, tid, and timestamp values", () => {
+    const tokens = parseQuery('pid:1234 tid:5678 time:"01-23 12:34:56.789"');
+    expect(matchesQuery(makeEntry(), tokens, NOW)).toBe(true);
+    expect(matchesQuery(makeEntry({ pid: 9999 }), tokens, NOW)).toBe(false);
+    expect(matchesQuery(makeEntry({ tid: 9999 }), tokens, NOW)).toBe(false);
+    expect(matchesQuery(makeEntry({ timestamp: "01-23 12:34:56.000" }), tokens, NOW)).toBe(false);
+  });
+
+  it("supports negated pid, tid, and time filters", () => {
+    expect(matchesQuery(makeEntry({ pid: 4321 }), parseQuery("-pid:1234"), NOW)).toBe(true);
+    expect(matchesQuery(makeEntry({ pid: 1234 }), parseQuery("-pid:1234"), NOW)).toBe(false);
+    expect(matchesQuery(makeEntry({ tid: 8765 }), parseQuery("-tid:5678"), NOW)).toBe(true);
+    expect(matchesQuery(makeEntry(), parseQuery('-time:"01-23 00:00:00.000"'), NOW)).toBe(true);
+  });
+});
+
 // ── parseLogcatTimestamp ──────────────────────────────────────────────────────
 
 describe("parseLogcatTimestamp", () => {
@@ -745,6 +790,14 @@ describe("committedEndsWithOrSeparator", () => {
 describe("serializeQueryBarCommittedPart", () => {
   it("quotes message value with spaces", () => {
     expect(serializeQueryBarCommittedPart("message:hello world")).toBe('message:"hello world"');
+  });
+
+  it("escapes literal quotes when rebuilding quoted message filters", () => {
+    const state = parseQueryBarState('message:"hello \\"quoted\\" value" ');
+    expect(state.committed).toEqual(['message:hello "quoted" value']);
+    expect(state.committed.map(serializeQueryBarCommittedPart).join(" ")).toBe(
+      'message:"hello \\"quoted\\" value"'
+    );
   });
 
   it("passes through structural tokens", () => {
@@ -2012,6 +2065,45 @@ describe("addAndConnector — idempotent: does not accumulate duplicate &&", () 
 describe("addOrGroup — idempotent: does not accumulate duplicate |", () => {
   it("returns unchanged string when it already ends with |", () => {
     expect(addOrGroup("level:error |")).toBe("level:error |");
+  });
+});
+
+describe("Entry Detail filter token helpers", () => {
+  it("builds tokens for all Entry Detail fields", () => {
+    expect(buildLogEntryDetailFilterToken("tag", "MainActivity")).toBe("tag:MainActivity");
+    expect(buildLogEntryDetailFilterToken("package", "com.example.app")).toBe(
+      "package:com.example.app"
+    );
+    expect(buildLogEntryDetailFilterToken("level", "ERROR")).toBe("level:error");
+    expect(buildLogEntryDetailFilterToken("pid", 1234)).toBe("pid:1234");
+    expect(buildLogEntryDetailFilterToken("tid", 5678)).toBe("tid:5678");
+    expect(buildLogEntryDetailFilterToken("time", "01-23 12:34:56.789")).toBe(
+      'time:"01-23 12:34:56.789"'
+    );
+    expect(buildLogEntryDetailFilterToken("message", 'hello "world" | timeout')).toBe(
+      'message:"hello \\"world\\" | timeout"'
+    );
+  });
+
+  it("returns null for empty or invalid values", () => {
+    expect(buildLogEntryDetailFilterToken("package", null)).toBeNull();
+    expect(buildLogEntryDetailFilterToken("tag", "   ")).toBeNull();
+    expect(buildLogEntryDetailFilterToken("pid", "abc")).toBeNull();
+  });
+
+  it("appends tokens with AND or OR semantics and commits the pill", () => {
+    expect(appendLogEntryDetailFilterToken("", "tag:MainActivity", "and")).toBe(
+      "tag:MainActivity "
+    );
+    expect(appendLogEntryDetailFilterToken("level:error ", "tag:MainActivity", "and")).toBe(
+      "level:error && tag:MainActivity "
+    );
+    expect(appendLogEntryDetailFilterToken("level:error ", "tag:MainActivity", "or")).toBe(
+      "level:error | tag:MainActivity "
+    );
+    expect(appendLogEntryDetailFilterToken("level:error | ", "tag:MainActivity", "or")).toBe(
+      "level:error | tag:MainActivity "
+    );
   });
 });
 

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -31,6 +31,9 @@ export type QueryToken =
   | { type: "tag"; value: string; negate: boolean; regex: boolean }
   | { type: "message"; value: string; negate: boolean; regex: boolean }
   | { type: "package"; value: string; negate: boolean }
+  | { type: "pid"; value: number; negate: boolean }
+  | { type: "tid"; value: number; negate: boolean }
+  | { type: "time"; value: string; negate: boolean }
   | { type: "age"; seconds: number }
   | { type: "is"; value: string }
   | { type: "freetext"; value: string; negate: boolean };
@@ -48,6 +51,9 @@ export const QUERY_KEYS = [
   "message~:",
   "-message:",
   "package:",
+  "pid:",
+  "tid:",
+  "time:",
   "age:",
   "is:",
 ];
@@ -167,7 +173,16 @@ export function splitRawQueryParts(raw: string): string[] {
   const parts: string[] = [];
   let current = "";
   let inQuote = false;
-  for (const ch of raw) {
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inQuote && ch === "\\" && i + 1 < raw.length) {
+      const next = raw[i + 1];
+      if (next === '"' || next === "\\") {
+        current += next;
+        i++;
+        continue;
+      }
+    }
     if (ch === '"') {
       inQuote = !inQuote;
       continue;
@@ -203,6 +218,14 @@ export function parseQueryBarState(value: string): { committed: string[]; draft:
 
   for (let i = 0; i < value.length; i++) {
     const ch = value[i];
+    if (inQuote && ch === "\\" && i + 1 < value.length) {
+      const next = value[i + 1];
+      if (next === '"' || next === "\\") {
+        current += next;
+        i++;
+        continue;
+      }
+    }
     if (ch === '"') {
       inQuote = !inQuote;
       continue;
@@ -275,6 +298,23 @@ export function parseQuery(raw: string): QueryToken[] {
         case "package":
         case "pkg":
           tokens.push({ type: "package", value, negate });
+          break;
+        case "pid":
+          if (/^\d+$/.test(value)) {
+            tokens.push({ type: "pid", value: Number(value), negate });
+          } else {
+            tokens.push({ type: "freetext", value: p, negate });
+          }
+          break;
+        case "tid":
+          if (/^\d+$/.test(value)) {
+            tokens.push({ type: "tid", value: Number(value), negate });
+          } else {
+            tokens.push({ type: "freetext", value: p, negate });
+          }
+          break;
+        case "time":
+          tokens.push({ type: "time", value, negate });
           break;
         case "age": {
           const secs = parseAge(value);
@@ -484,6 +524,18 @@ function matchToken(entry: LogcatEntry, token: QueryToken, now: number): boolean
       const matches = haystack.includes(resolvedValue.toLowerCase());
       return token.negate ? !matches : matches;
     }
+    case "pid": {
+      const matches = entry.pid === token.value;
+      return token.negate ? !matches : matches;
+    }
+    case "tid": {
+      const matches = entry.tid === token.value;
+      return token.negate ? !matches : matches;
+    }
+    case "time": {
+      const matches = entry.timestamp === token.value;
+      return token.negate ? !matches : matches;
+    }
     case "age": {
       const entryTime = parseLogcatTimestamp(entry.timestamp);
       if (entryTime === 0) return true; // unparseable → keep
@@ -559,6 +611,101 @@ export function setPackageInQuery(query: string, pkg: string | null): string {
   return withoutPkg ? `${withoutPkg} package:${pkg}` : `package:${pkg}`;
 }
 
+export type LogEntryDetailFilterField =
+  | "tag"
+  | "package"
+  | "level"
+  | "pid"
+  | "tid"
+  | "time"
+  | "message";
+
+export type LogEntryDetailFilterMode = "and" | "or";
+
+function normalizeDetailString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeDetailNumber(value: unknown): number | null {
+  const n =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && /^\d+$/.test(value.trim())
+        ? Number(value.trim())
+        : NaN;
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+function quoteLogcatFilterValue(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function formatLogcatFilterValue(value: string, forceQuote = false): string {
+  return forceQuote || /[\s"|]/.test(value) ? quoteLogcatFilterValue(value) : value;
+}
+
+export function buildLogEntryDetailFilterToken(
+  field: LogEntryDetailFilterField,
+  value: unknown
+): string | null {
+  switch (field) {
+    case "tag": {
+      const text = normalizeDetailString(value);
+      return text ? `tag:${formatLogcatFilterValue(text)}` : null;
+    }
+    case "package": {
+      const text = normalizeDetailString(value);
+      return text ? `package:${formatLogcatFilterValue(text)}` : null;
+    }
+    case "level": {
+      const text = normalizeDetailString(value);
+      return text ? `level:${text.toLowerCase()}` : null;
+    }
+    case "pid": {
+      const n = normalizeDetailNumber(value);
+      return n === null ? null : `pid:${n}`;
+    }
+    case "tid": {
+      const n = normalizeDetailNumber(value);
+      return n === null ? null : `tid:${n}`;
+    }
+    case "time": {
+      const text = normalizeDetailString(value);
+      return text ? `time:${formatLogcatFilterValue(text, true)}` : null;
+    }
+    case "message": {
+      const text = normalizeDetailString(value);
+      return text ? `message:${formatLogcatFilterValue(text, true)}` : null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function appendLogEntryDetailFilterToken(
+  query: string,
+  token: string,
+  mode: LogEntryDetailFilterMode
+): string {
+  const cleanToken = token.trim();
+  if (!cleanToken) return query;
+
+  const trimmed = query.trimEnd();
+  if (!trimmed) return `${cleanToken} `;
+
+  if (mode === "or") {
+    return trimmed.endsWith("|") ? `${trimmed} ${cleanToken} ` : `${trimmed} | ${cleanToken} `;
+  }
+
+  if (trimmed.endsWith("|") || trimmed.endsWith("&&") || trimmed.endsWith("&")) {
+    return `${trimmed} ${cleanToken} `;
+  }
+  return `${trimmed} && ${cleanToken} `;
+}
+
 /**
  * Extract the value of the first `package:` token from a raw query string.
  * Returns null when no package token is present.
@@ -584,6 +731,7 @@ export function getPackageFromQuery(query: string): string | null {
  *   • negated (-X)   — backend has no negation support
  *   • tag~: / msg~:  — backend does substring only, not regex
  *   • is:stacktrace  — backend does not have a stacktrace filter
+ *   • pid/tid/time   — backend filter spec has no exact metadata slots
  *
  * Overflow tokens (second+ occurrence of a backend-handled type):
  *   • 2nd+ level:    — only the first minLevel is sent
@@ -636,6 +784,10 @@ export function getFrontendOnlyTokens(tokens: QueryToken[]): QueryToken[] {
           packageConsumed = true;
           return false;
         }
+        return true;
+      case "pid":
+      case "tid":
+      case "time":
         return true;
       case "is":
         // is:crash → onlyCrashes flag (boolean, no overflow); handled above for stacktrace
@@ -954,6 +1106,10 @@ export function applyInlineEditCommit(
 
 const MESSAGE_TOKEN_FOR_EDIT = /^(-?)((?:message~)|(?:message)|(?:msg)):(.+)$/s;
 
+function escapeQuotedQueryValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 /**
  * Serialize one committed query-bar segment for the raw query string.
  * Values that contain spaces (would split across tokens) are wrapped in `"`.
@@ -967,14 +1123,14 @@ export function serializeQueryBarCommittedPart(part: string): string {
   const body = neg ? part.slice(1) : part;
   const c = body.indexOf(":");
   if (c < 0) {
-    const inner = (neg ? body : part).replace(/"/g, "");
+    const inner = escapeQuotedQueryValue(neg ? body : part);
     return neg ? `-"${inner}"` : `"${inner}"`;
   }
   if (c <= 0 || c >= body.length - 1) return part;
 
   const keyColon = body.slice(0, c + 1);
   const value = body.slice(c + 1);
-  const inner = value.replace(/"/g, "");
+  const inner = escapeQuotedQueryValue(value);
   return `${neg ? "-" : ""}${keyColon}"${inner}"`;
 }
 
@@ -1002,7 +1158,13 @@ function splitOnOrSeparator(raw: string): string[] {
   const segments: string[] = [];
   let current = "";
   let inQuote = false;
-  for (const ch of raw) {
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inQuote && ch === "\\" && i + 1 < raw.length) {
+      current += ch + raw[i + 1];
+      i++;
+      continue;
+    }
     if (ch === '"') {
       inQuote = !inQuote;
       current += ch;
@@ -1103,6 +1265,10 @@ function lastOuterPipeIndex(text: string): number {
   let lastPipe = -1;
   for (let i = 0; i < text.length; i++) {
     const ch = text[i];
+    if (inQuote && ch === "\\" && i + 1 < text.length) {
+      i++;
+      continue;
+    }
     if (ch === '"') inQuote = !inQuote;
     else if (ch === "|" && !inQuote) lastPipe = i;
   }
@@ -1116,10 +1282,18 @@ function lastOuterPipeIndex(text: string): number {
 function nextOuterPipeIndex(query: string, fromIdx: number): number {
   let inQuote = false;
   for (let i = 0; i < fromIdx; i++) {
+    if (inQuote && query[i] === "\\" && i + 1 < query.length) {
+      i++;
+      continue;
+    }
     if (query[i] === '"') inQuote = !inQuote;
   }
   for (let i = fromIdx; i < query.length; i++) {
     const ch = query[i];
+    if (inQuote && ch === "\\" && i + 1 < query.length) {
+      i++;
+      continue;
+    }
     if (ch === '"') inQuote = !inQuote;
     else if (ch === "|" && !inQuote) return i;
   }


### PR DESCRIPTION
## Summary

Adding the ability to click and filter from logs details.

<img width="1402" height="875" alt="Screenshot 2026-04-29 at 2 21 15 PM" src="https://github.com/user-attachments/assets/da9378a1-019c-4569-ab57-df7b9e693504" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add click-to-filter in Logcat Entry Detail. Click Tag, Package, Level, PID, TID, Time, or Message to add AND/OR filter pills in the query bar with correct quoting; adds `pid`, `tid`, and `time` tokens.

- **New Features**
  - Click a value to open a small anchored menu; choose Add as AND or Add as OR to insert a committed token (with trailing space). `LogcatPanel` appends with `&&` or `|` only when needed.
  - Message clicks use selected text inside the message when available; otherwise the full message.
  - Added `pid:`, `tid:`, and `time:"..."` tokens; `pid`/`tid` are numeric; `time` is quoted. All three are parsed and matched in the frontend.
  - Quote/backslash escaping for `message:` and `time:` ensures tokens round‑trip through the Query Bar and don’t break on OR/AND reconstruction.
  - Menu supports keyboard (Enter/Space), and closes on outside click or Escape (Escape closes the menu first). `LogEntryDetailPanel` stays presentational; docs updated to include this behavior.

<sup>Written for commit 1c712a909818a5676dafa3551bcfe62a3c8b867c. Summary will update on new commits. <a href="https://cubic.dev/pr/thiagodmont/keynobi/pull/43?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



