### PR TITLE
Feat/log mode

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -61,7 +61,7 @@ Sidebars and status:
 - **Projects sidebar** on the left: saved Android projects.
 - **Devices sidebar** on the right: physical devices and emulators.
 - **Status bar** at the bottom: settings, project, health, build status, MCP, updates, variant, memory, and log folder size.
-- **Title bar pin**: toggle **Keep window on top** to keep Keynobi above other applications until you turn it off or close the window.
+- **Title bar controls**: toggle **Log Mode** to focus the window on Logcat, or **Keep window on top** to keep Keynobi above other applications until you turn it off or close the window.
 
 ---
 
@@ -110,6 +110,8 @@ The active device and active variant are used automatically. Click the variant p
 ## Logcat
 
 The Logcat tab streams logs from the selected Android device.
+
+Use **Log Mode** from the title bar when logs are the main task. It hides the project sidebar, device sidebar, and main tab strip while keeping the Logcat toolbar, filters, query bar, and bottom status bar visible. Turning Log Mode off restores the tab and sidebar layout you had before entering it.
 
 ### Controls
 

--- a/src/App.log-mode.test.tsx
+++ b/src/App.log-mode.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./App";
+import { clearActions, getAction } from "@/lib/action-registry";
+import { resetUIStateForTests, uiState } from "@/stores/ui.store";
+
+vi.mock("@/components/layout/TitleBar", () => ({
+  default: () => <div data-testid="title-bar" />,
+}));
+
+vi.mock("@/components/layout/StatusBar", () => ({
+  default: () => <div data-testid="status-bar" />,
+}));
+
+vi.mock("@/components/projects/ProjectSidebar", () => ({
+  ProjectSidebar: () => <aside data-testid="project-sidebar" />,
+}));
+
+vi.mock("@/components/device/DeviceSidebar", () => ({
+  DeviceSidebar: () => <aside data-testid="device-sidebar" />,
+}));
+
+vi.mock("@/components/logcat/LogcatPanel", () => ({
+  LogcatPanel: () => <section data-testid="logcat-panel" />,
+}));
+
+vi.mock("@/components/build/BuildPanel", () => ({
+  BuildPanel: () => <section data-testid="build-panel" />,
+}));
+
+vi.mock("@/components/ui-hierarchy/LayoutViewerPanel", () => ({
+  LayoutViewerPanel: () => <section data-testid="layout-panel" />,
+}));
+
+vi.mock("@/components/common/ErrorBoundary", () => ({
+  AppErrorBoundary: (props: { children: unknown }) => <>{props.children}</>,
+}));
+
+vi.mock("@/components/ui", () => ({
+  ToastContainer: () => <div data-testid="toast-container" />,
+  DialogHost: () => <div data-testid="dialog-host" />,
+  CommandPalette: () => <div data-testid="command-palette" />,
+  openPalette: vi.fn(),
+  showDialog: vi.fn().mockResolvedValue("dismissed"),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@/components/settings/SettingsPanel", () => ({
+  SettingsPanel: () => <div data-testid="settings-panel" />,
+  openSettings: vi.fn(),
+}));
+
+vi.mock("@/components/health/HealthPanel", () => ({
+  HealthPanel: () => <div data-testid="health-panel" />,
+  openHealthPanel: vi.fn(),
+}));
+
+vi.mock("@/components/mcp/McpPanel", () => ({
+  McpPanel: () => <div data-testid="mcp-panel" />,
+  openMcpPanel: vi.fn(),
+}));
+
+vi.mock("@/components/projects/ProjectInfoEditor", () => ({
+  ProjectInfoEditor: () => <div data-testid="project-info-editor" />,
+  openProjectInfoEditor: vi.fn(),
+}));
+
+vi.mock("@/components/device/DevicePickerDialog", () => ({
+  DevicePickerDialog: () => <div data-testid="device-picker-dialog" />,
+}));
+
+vi.mock("@/components/onboarding/OnboardingWizard", () => ({
+  OnboardingWizard: () => <div data-testid="onboarding-wizard" />,
+}));
+
+vi.mock("@/components/build/VariantSelector", () => ({
+  openVariantPicker: vi.fn(),
+}));
+
+vi.mock("@/lib/keybindings", () => ({
+  initKeybindings: vi.fn(),
+  registerKeybinding: vi.fn(),
+}));
+
+vi.mock("@/stores/settings.store", () => ({
+  loadSettings: vi.fn().mockResolvedValue(undefined),
+  settingsState: { telemetry: { enabled: false } },
+}));
+
+vi.mock("@/lib/telemetry/sentry-web", () => ({
+  captureSentryException: vi.fn(),
+  initSentryWeb: vi.fn(),
+}));
+
+vi.mock("@/stores/onboarding.store", () => ({
+  tryOpenOnboardingAfterLoad: vi.fn(),
+  openOnboardingWizard: vi.fn(),
+}));
+
+vi.mock("@/services/project.service", () => ({
+  openProjectFolder: vi.fn().mockResolvedValue(undefined),
+  refreshProjectsList: vi.fn().mockResolvedValue(undefined),
+  restoreLastProject: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/services/build.service", () => ({
+  initBuildService: vi.fn().mockResolvedValue(undefined),
+  runBuild: vi.fn().mockResolvedValue(undefined),
+  runAndDeploy: vi.fn().mockResolvedValue(undefined),
+  cancelBuild: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/stores/device.store", () => ({
+  initDevices: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/tauri-api", () => ({
+  formatError: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  sendNativeSentryTestEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/services/update.service", () => ({
+  dismissUpdate: vi.fn(),
+  openUpdateRelease: vi.fn().mockResolvedValue(undefined),
+  refreshAppUpdate: vi.fn().mockResolvedValue({ available: false }),
+  shouldDismissUpdatePrompt: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@/stores/mcp.store", () => ({
+  initMcpListeners: vi.fn(),
+  loadMcpActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("App Log Mode shell", () => {
+  beforeEach(() => {
+    clearActions();
+    resetUIStateForTests();
+  });
+
+  it("registers a command action that toggles Log Mode", async () => {
+    render(() => <App />);
+
+    await waitFor(() => expect(getAction("view.toggleLogMode")).toBeDefined());
+
+    getAction("view.toggleLogMode")!.action();
+
+    expect(uiState.logMode.active).toBe(true);
+  });
+
+  it("hides navigation chrome while keeping Logcat and status visible in Log Mode", async () => {
+    render(() => <App />);
+
+    expect(screen.getByTestId("project-sidebar")).not.toBeNull();
+    expect(screen.getByTestId("device-sidebar")).not.toBeNull();
+    expect(screen.getByRole("tablist", { name: "Main panels" })).not.toBeNull();
+
+    await waitFor(() => expect(getAction("view.toggleLogMode")).toBeDefined());
+    getAction("view.toggleLogMode")!.action();
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("project-sidebar")).toBeNull();
+      expect(screen.queryByTestId("device-sidebar")).toBeNull();
+      expect(screen.queryByRole("tablist", { name: "Main panels" })).toBeNull();
+    });
+
+    expect(screen.getByTestId("title-bar")).not.toBeNull();
+    expect(screen.getByTestId("status-bar")).not.toBeNull();
+    expect(screen.getByTestId("logcat-panel")).not.toBeNull();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import { type JSX, For, onMount, onCleanup, createEffect } from "solid-js";
+import { type JSX, For, onMount, onCleanup, createEffect, Show } from "solid-js";
 import {
   uiState,
   setActiveTab,
   toggleSidebar,
   toggleDeviceSidebar,
+  toggleLogMode,
   type MainTab,
 } from "@/stores/ui.store";
 import TitleBar from "@/components/layout/TitleBar";
@@ -225,6 +226,12 @@ export function App(): JSX.Element {
       category: "View",
       action: () => toggleSidebar(),
     });
+    registerAction({
+      id: "view.toggleLogMode",
+      label: "Toggle Log Mode",
+      category: "View",
+      action: () => toggleLogMode(),
+    });
 
     // ── File ────────────────────────────────────────────────────────────────
     registerKeyAndAction({
@@ -416,6 +423,8 @@ export function App(): JSX.Element {
     { id: "build", label: "Build" },
   ];
 
+  const logModeActive = () => uiState.logMode.active;
+
   return (
     <div
       style={{
@@ -433,63 +442,67 @@ export function App(): JSX.Element {
         {/* Body: left sidebar + main column + right device sidebar */}
         <div style={{ flex: "1", display: "flex", "flex-direction": "row", overflow: "hidden" }}>
           {/* Left project sidebar */}
-          <ProjectSidebar />
+          <Show when={!logModeActive()}>
+            <ProjectSidebar />
+          </Show>
 
           {/* Main column: tab bar + panels */}
           <div
             style={{ flex: "1", display: "flex", "flex-direction": "column", overflow: "hidden" }}
           >
             {/* Tab bar */}
-            <div
-              role="tablist"
-              aria-label="Main panels"
-              style={{
-                display: "flex",
-                "align-items": "center",
-                height: "36px",
-                background: "var(--bg-tertiary)",
-                "border-bottom": "1px solid var(--border)",
-                "padding-left": "12px",
-                "flex-shrink": "0",
-                gap: "2px",
-              }}
-            >
-              <For each={tabs}>
-                {(tab) => {
-                  const isActive = () => uiState.activeTab === tab.id;
-                  return (
-                    <button
-                      role="tab"
-                      aria-selected={isActive()}
-                      aria-controls={`panel-${tab.id}`}
-                      data-testid={`main-tab-${tab.id}`}
-                      onClick={() => setActiveTab(tab.id)}
-                      style={{
-                        padding: "0 16px",
-                        height: "36px",
-                        "font-size": "12px",
-                        display: "flex",
-                        "align-items": "center",
-                        color: isActive() ? "var(--text-primary)" : "var(--text-muted)",
-                        background: isActive() ? "var(--bg-secondary)" : "none",
-                        "border-bottom": isActive()
-                          ? "2px solid var(--accent)"
-                          : "2px solid transparent",
-                        cursor: "pointer",
-                        border: "none",
-                        "border-top": "none",
-                        "border-left": "none",
-                        "border-right": "none",
-                        "font-weight": isActive() ? "500" : "normal",
-                        transition: "color 0.1s",
-                      }}
-                    >
-                      {tab.label}
-                    </button>
-                  );
+            <Show when={!logModeActive()}>
+              <div
+                role="tablist"
+                aria-label="Main panels"
+                style={{
+                  display: "flex",
+                  "align-items": "center",
+                  height: "36px",
+                  background: "var(--bg-tertiary)",
+                  "border-bottom": "1px solid var(--border)",
+                  "padding-left": "12px",
+                  "flex-shrink": "0",
+                  gap: "2px",
                 }}
-              </For>
-            </div>
+              >
+                <For each={tabs}>
+                  {(tab) => {
+                    const isActive = () => uiState.activeTab === tab.id;
+                    return (
+                      <button
+                        role="tab"
+                        aria-selected={isActive()}
+                        aria-controls={`panel-${tab.id}`}
+                        data-testid={`main-tab-${tab.id}`}
+                        onClick={() => setActiveTab(tab.id)}
+                        style={{
+                          padding: "0 16px",
+                          height: "36px",
+                          "font-size": "12px",
+                          display: "flex",
+                          "align-items": "center",
+                          color: isActive() ? "var(--text-primary)" : "var(--text-muted)",
+                          background: isActive() ? "var(--bg-secondary)" : "none",
+                          "border-bottom": isActive()
+                            ? "2px solid var(--accent)"
+                            : "2px solid transparent",
+                          cursor: "pointer",
+                          border: "none",
+                          "border-top": "none",
+                          "border-left": "none",
+                          "border-right": "none",
+                          "font-weight": isActive() ? "500" : "normal",
+                          transition: "color 0.1s",
+                        }}
+                      >
+                        {tab.label}
+                      </button>
+                    );
+                  }}
+                </For>
+              </div>
+            </Show>
 
             {/* Panel content area */}
             <div
@@ -534,7 +547,9 @@ export function App(): JSX.Element {
           </div>
 
           {/* Right device sidebar */}
-          <DeviceSidebar />
+          <Show when={!logModeActive()}>
+            <DeviceSidebar />
+          </Show>
         </div>
       </AppErrorBoundary>
 

--- a/src/components/layout/TitleBar.test.tsx
+++ b/src/components/layout/TitleBar.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetUIStateForTests, uiState } from "@/stores/ui.store";
 import { TitleBar } from "./TitleBar";
 
 describe("TitleBar", () => {
@@ -12,6 +13,7 @@ describe("TitleBar", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetUIStateForTests();
     appWindow.isAlwaysOnTop.mockResolvedValue(false);
     appWindow.setAlwaysOnTop.mockResolvedValue(undefined);
     vi.mocked(getCurrentWindow).mockReturnValue(
@@ -78,5 +80,32 @@ describe("TitleBar", () => {
     resolveInitialState(true);
 
     await waitFor(() => expect(button.getAttribute("aria-pressed")).toBe("true"));
+  });
+
+  it("toggles Log Mode from the title bar", () => {
+    render(() => <TitleBar />);
+
+    const button = screen.getByRole("button", { name: /log mode/i });
+    expect(uiState.logMode.active).toBe(false);
+    expect(button.getAttribute("title")).toBe("Enter Log Mode");
+
+    fireEvent.click(button);
+
+    expect(uiState.logMode.active).toBe(true);
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+    expect(button.getAttribute("title")).toBe("Exit Log Mode");
+  });
+
+  it("exits Log Mode when the active Log Mode button is clicked again", () => {
+    render(() => <TitleBar />);
+
+    const button = screen.getByRole("button", { name: /log mode/i });
+    fireEvent.click(button);
+    expect(uiState.logMode.active).toBe(true);
+
+    fireEvent.click(button);
+
+    expect(uiState.logMode.active).toBe(false);
+    expect(button.getAttribute("aria-pressed")).toBe(null);
   });
 });

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -1,7 +1,7 @@
 import { type JSX, Show, createSignal, onMount } from "solid-js";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { projectState } from "@/stores/project.store";
-import { uiState } from "@/stores/ui.store";
+import { toggleLogMode, uiState } from "@/stores/ui.store";
 import { isBuilding, isDeploying } from "@/stores/build.store";
 import { runAndDeploy, cancelBuild } from "@/services/build.service";
 import { formatError } from "@/lib/tauri-api";
@@ -58,6 +58,10 @@ export function TitleBar(): JSX.Element {
     return "Run App — build, install & launch (Cmd+R)";
   };
 
+  const logModeActive = () => uiState.logMode.active;
+
+  const logModeButtonTitle = () => (logModeActive() ? "Exit Log Mode" : "Enter Log Mode");
+
   async function handleAlwaysOnTopToggle() {
     if (alwaysOnTopBusy()) return;
     const next = !alwaysOnTop();
@@ -110,6 +114,38 @@ export function TitleBar(): JSX.Element {
           {projectState.projectName ? `Keynobi — ${projectState.projectName}` : "Keynobi"}
         </span>
       </div>
+      <button
+        type="button"
+        onClick={() => toggleLogMode()}
+        onMouseDown={(e) => e.stopPropagation()}
+        aria-pressed={logModeActive() ? "true" : undefined}
+        title={logModeButtonTitle()}
+        style={{
+          "flex-shrink": "0",
+          padding: "0 10px",
+          height: "28px",
+          "font-size": "12px",
+          display: "flex",
+          "align-items": "center",
+          gap: "6px",
+          color: logModeActive() ? "var(--text-primary)" : "var(--text-muted)",
+          background: logModeActive() ? "var(--bg-secondary)" : "transparent",
+          "border-bottom": logModeActive() ? "2px solid var(--accent)" : "2px solid transparent",
+          "box-sizing": "border-box",
+          cursor: "pointer",
+          border: "none",
+          "border-radius": "4px",
+          "font-weight": logModeActive() ? "500" : "normal",
+          transition: "color 0.1s, background 0.1s",
+        }}
+      >
+        <Icon
+          name="terminal"
+          size={13}
+          color={logModeActive() ? "var(--accent)" : "currentColor"}
+        />
+        Log Mode
+      </button>
       <button
         type="button"
         onClick={() => void handleAlwaysOnTopToggle()}

--- a/src/stores/ui.store.test.ts
+++ b/src/stores/ui.store.test.ts
@@ -1,52 +1,123 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
-  uiState,
-  setUIState,
+  enterLogMode,
+  exitLogMode,
+  resetUIStateForTests,
   setActiveTab,
+  setDeviceSidebarCollapsed,
+  setSidebarCollapsed,
+  toggleLogMode,
+  uiState,
 } from "./ui.store";
 
-// Reset state to defaults before each test.
-function resetUIState() {
-  setUIState({
-    activeTab: "logcat",
-    bottomPanelHeight: 300,
-  });
-}
-
-// ── setActiveTab ──────────────────────────────────────────────────────────────
-
-describe("setActiveTab", () => {
-  beforeEach(resetUIState);
-
-  it("starts on the logcat tab", () => {
-    expect(uiState.activeTab).toBe("logcat");
+describe("ui.store", () => {
+  beforeEach(() => {
+    resetUIStateForTests();
   });
 
-  it("switches to logcat", () => {
-    setActiveTab("logcat");
-    expect(uiState.activeTab).toBe("logcat");
+  describe("setActiveTab", () => {
+    it("starts on the logcat tab", () => {
+      expect(uiState.activeTab).toBe("logcat");
+    });
+
+    it("switches to logcat", () => {
+      setActiveTab("logcat");
+      expect(uiState.activeTab).toBe("logcat");
+    });
+
+    it("switches to logcat tab then back to build", () => {
+      setActiveTab("logcat");
+      expect(uiState.activeTab).toBe("logcat");
+      setActiveTab("build");
+      expect(uiState.activeTab).toBe("build");
+    });
   });
 
-  it("switches to logcat tab then back to build", () => {
-    setActiveTab("logcat");
-    expect(uiState.activeTab).toBe("logcat");
-    setActiveTab("build");
-    expect(uiState.activeTab).toBe("build");
+  describe("bottomPanelHeight", () => {
+    it("defaults to 300", () => {
+      expect(uiState.bottomPanelHeight).toBe(300);
+    });
+  });
+
+  describe("Log Mode", () => {
+    it("defaults to inactive with no snapshot", () => {
+      expect(uiState.logMode.active).toBe(false);
+      expect(uiState.logMode.snapshot).toBe(null);
+    });
+
+    it("enters Log Mode by snapshotting current layout and switching to logcat", () => {
+      setActiveTab("layout");
+      setSidebarCollapsed(true);
+      setDeviceSidebarCollapsed(false);
+
+      enterLogMode();
+
+      expect(uiState.activeTab).toBe("logcat");
+      expect(uiState.logMode.active).toBe(true);
+      expect(uiState.logMode.snapshot).toEqual({
+        activeTab: "layout",
+        sidebarCollapsed: true,
+        deviceSidebarCollapsed: false,
+      });
+    });
+
+    it("exits Log Mode by restoring the captured layout exactly", () => {
+      setActiveTab("build");
+      setSidebarCollapsed(false);
+      setDeviceSidebarCollapsed(true);
+      enterLogMode();
+
+      exitLogMode();
+
+      expect(uiState.logMode.active).toBe(false);
+      expect(uiState.logMode.snapshot).toBe(null);
+      expect(uiState.activeTab).toBe("build");
+      expect(uiState.sidebarCollapsed).toBe(false);
+      expect(uiState.deviceSidebarCollapsed).toBe(true);
+    });
+
+    it("does not overwrite the original snapshot when enter is called repeatedly", () => {
+      setActiveTab("layout");
+      setSidebarCollapsed(true);
+      setDeviceSidebarCollapsed(false);
+      enterLogMode();
+
+      setSidebarCollapsed(false);
+      setDeviceSidebarCollapsed(true);
+      enterLogMode();
+
+      expect(uiState.logMode.snapshot).toEqual({
+        activeTab: "layout",
+        sidebarCollapsed: true,
+        deviceSidebarCollapsed: false,
+      });
+    });
+
+    it("toggles Log Mode on and off", () => {
+      setActiveTab("layout");
+
+      toggleLogMode();
+      expect(uiState.logMode.active).toBe(true);
+      expect(uiState.activeTab).toBe("logcat");
+
+      toggleLogMode();
+      expect(uiState.logMode.active).toBe(false);
+      expect(uiState.activeTab).toBe("layout");
+    });
+
+    it("exits Log Mode and opens the requested tab when navigating away", () => {
+      setActiveTab("layout");
+      setSidebarCollapsed(true);
+      setDeviceSidebarCollapsed(true);
+      enterLogMode();
+
+      setActiveTab("build");
+
+      expect(uiState.logMode.active).toBe(false);
+      expect(uiState.logMode.snapshot).toBe(null);
+      expect(uiState.activeTab).toBe("build");
+      expect(uiState.sidebarCollapsed).toBe(true);
+      expect(uiState.deviceSidebarCollapsed).toBe(true);
+    });
   });
 });
-
-// ── bottomPanelHeight ─────────────────────────────────────────────────────────
-
-describe("bottomPanelHeight", () => {
-  beforeEach(resetUIState);
-
-  it("defaults to 300", () => {
-    expect(uiState.bottomPanelHeight).toBe(300);
-  });
-
-  it("can be updated", () => {
-    setUIState("bottomPanelHeight", 400);
-    expect(uiState.bottomPanelHeight).toBe(400);
-  });
-});
-

--- a/src/stores/ui.store.ts
+++ b/src/stores/ui.store.ts
@@ -5,24 +5,115 @@ import { showToast } from "@/components/ui";
 
 export type MainTab = "build" | "logcat" | "layout";
 
+export interface LogModeSnapshot {
+  activeTab: MainTab;
+  sidebarCollapsed: boolean;
+  deviceSidebarCollapsed: boolean;
+}
+
+interface LogModeState {
+  active: boolean;
+  snapshot: LogModeSnapshot | null;
+}
+
 interface UIState {
   activeTab: MainTab;
   bottomPanelHeight: number;
   sidebarCollapsed: boolean;
   deviceSidebarCollapsed: boolean;
+  logMode: LogModeState;
 }
 
-const [uiState, setUIState] = createStore<UIState>({
-  activeTab: "logcat",
-  bottomPanelHeight: 300,
-  sidebarCollapsed: false,
-  deviceSidebarCollapsed: false,
-});
+function defaultLogModeState(): LogModeState {
+  return {
+    active: false,
+    snapshot: null,
+  };
+}
+
+function defaultUIState(): UIState {
+  return {
+    activeTab: "logcat",
+    bottomPanelHeight: 300,
+    sidebarCollapsed: false,
+    deviceSidebarCollapsed: false,
+    logMode: defaultLogModeState(),
+  };
+}
+
+const [uiState, setUIState] = createStore<UIState>(defaultUIState());
 
 export { uiState, setUIState };
 
-export function setActiveTab(tab: MainTab) {
+export function resetUIStateForTests(): void {
+  setUIState(defaultUIState());
+}
+
+function restoreLogModeSnapshot(nextActiveTab?: MainTab): void {
+  const snapshot = uiState.logMode.snapshot;
+
+  if (snapshot) {
+    setUIState({
+      activeTab: nextActiveTab ?? snapshot.activeTab,
+      bottomPanelHeight: uiState.bottomPanelHeight,
+      sidebarCollapsed: snapshot.sidebarCollapsed,
+      deviceSidebarCollapsed: snapshot.deviceSidebarCollapsed,
+      logMode: defaultLogModeState(),
+    });
+    return;
+  }
+
+  setUIState({
+    activeTab: nextActiveTab ?? "logcat",
+    bottomPanelHeight: uiState.bottomPanelHeight,
+    sidebarCollapsed: false,
+    deviceSidebarCollapsed: false,
+    logMode: defaultLogModeState(),
+  });
+}
+
+export function setActiveTab(tab: MainTab): void {
+  if (uiState.logMode.active && tab !== "logcat") {
+    restoreLogModeSnapshot(tab);
+    return;
+  }
+
   setUIState("activeTab", tab);
+}
+
+export function enterLogMode(): void {
+  if (uiState.logMode.active) return;
+
+  const snapshot: LogModeSnapshot = {
+    activeTab: uiState.activeTab,
+    sidebarCollapsed: uiState.sidebarCollapsed,
+    deviceSidebarCollapsed: uiState.deviceSidebarCollapsed,
+  };
+
+  setUIState({
+    activeTab: "logcat",
+    bottomPanelHeight: uiState.bottomPanelHeight,
+    sidebarCollapsed: uiState.sidebarCollapsed,
+    deviceSidebarCollapsed: uiState.deviceSidebarCollapsed,
+    logMode: {
+      active: true,
+      snapshot,
+    },
+  });
+}
+
+export function exitLogMode(): void {
+  if (!uiState.logMode.active) return;
+  restoreLogModeSnapshot();
+}
+
+export function toggleLogMode(): void {
+  if (uiState.logMode.active) {
+    exitLogMode();
+    return;
+  }
+
+  enterLogMode();
 }
 
 export function setSidebarCollapsed(v: boolean): void {


### PR DESCRIPTION
## Summary

Added log mode, which will focus only on the log feature when enabled.

<img width="1412" height="905" alt="Screenshot 2026-05-04 at 12 41 37 PM" src="https://github.com/user-attachments/assets/5b641cc7-4ef2-4322-bb56-fee36905b710" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Log Mode to focus the app on Logcat by hiding navigation chrome and sidebars. It includes a title bar toggle and a command action that restores your previous layout when you exit.

- **New Features**
  - Title bar “Log Mode” button with pressed state and tooltips (Enter/Exit Log Mode).
  - Command action `view.toggleLogMode` to toggle Log Mode from the command palette.
  - In Log Mode: project sidebar, device sidebar, and main tab bar are hidden; Logcat panel and status bar stay visible; switches to Logcat automatically.
  - Exiting restores your previous tab and sidebar state; navigating to another tab exits Log Mode.
  - Updated user manual and added tests covering the toggle, layout changes, and action registration.

<sup>Written for commit 8ef644158b5c0f2632be16dc957436228926645b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

