### PR TITLE
Feat/improviments

### DIFF
--- a/docs/CODE_PATTERN.md
+++ b/docs/CODE_PATTERN.md
@@ -133,6 +133,7 @@ Components should delegate side effects to services or store actions. Components
 ### SolidJS Reactivity
 
 - Use `createMemo` for derived values used in render paths or multiple places.
+- Do not create `createMemo` or `createEffect` at module scope in singleton stores. Export plain accessor functions for store-derived values, or create effects inside a component/root so Solid can own and dispose the computation.
 - Call signals/memos in JSX: `{label()}`, not `{label}`.
 - Register `onCleanup` for timers, subscriptions, and listeners.
 - Guard async flows where stale responses can arrive out of order.

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -148,10 +148,10 @@ Press **Enter** to commit a typed condition as a filter pill. Use **+ AND** and 
 - ANRs get an ANR badge.
 - JSON messages show a `{}` badge; open it to view formatted JSON.
 - Arrow keys move the selected row when focus is not in the query bar.
-- Selecting a row pauses follow-tail until you jump back to the end.
+- Scrolling away from the end or selecting a row pauses follow-tail until you use **Jump to end**.
 - In **Entry Detail**, click a tag, package, level, PID, TID, time, or message value to add it to the query bar as an **AND** or **OR** filter. Select part of the message before clicking to filter by only that selected text.
 
-Logcat keeps a bounded ring buffer. Configure the ring size and max visible lines under **Settings -> Logcat**.
+Logcat keeps a bounded ring buffer. Configure the ring size, max visible lines, and Logcat output font size under **Settings -> Logcat**.
 
 ---
 
@@ -207,7 +207,8 @@ Important settings:
 - **Android SDK Path**: required for ADB, emulator support, and health checks.
 - **Java Home**: required for Gradle builds.
 - **Logcat auto-start** and **follow-tail** behavior.
-- **Logcat ring buffer size** and visible line cap.
+- **System font size** for app controls and panels.
+- **Logcat ring buffer size**, visible line cap, and output font size.
 - **Build log follow-tail** behavior.
 - **Anonymous crash reporting**.
 

--- a/e2e/ipc/settings-commands.spec.ts
+++ b/e2e/ipc/settings-commands.spec.ts
@@ -7,14 +7,14 @@ test.describe("settings IPC commands", () => {
         onboardingCompleted: boolean;
         appearance: { uiFontSize: number };
         build: { autoInstallOnBuild: boolean };
-        logcat: { autoStart: boolean };
+        logcat: { autoStart: boolean; outputFontSize: number };
       }>;
     });
     expect(settings).toMatchObject({
       onboardingCompleted: expect.any(Boolean),
       appearance: { uiFontSize: expect.any(Number) },
       build: { autoInstallOnBuild: expect.any(Boolean) },
-      logcat: { autoStart: expect.any(Boolean) },
+      logcat: { autoStart: expect.any(Boolean), outputFontSize: expect.any(Number) },
     });
   });
 

--- a/e2e/smoke/app-console.spec.ts
+++ b/e2e/smoke/app-console.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+
+test("app load does not emit Solid owner warnings", async ({ page }) => {
+  const solidOwnerWarnings: string[] = [];
+
+  page.on("console", (message) => {
+    if (
+      message.type() === "warning" &&
+      message.text().includes("computations created outside a `createRoot` or `render`")
+    ) {
+      solidOwnerWarnings.push(message.text());
+    }
+  });
+
+  await page.goto("/");
+  await page.waitForFunction(() => typeof window.__e2e__ !== "undefined", { timeout: 10_000 });
+
+  expect(solidOwnerWarnings).toEqual([]);
+});

--- a/e2e/smoke/logcat-regressions.spec.ts
+++ b/e2e/smoke/logcat-regressions.spec.ts
@@ -1,0 +1,153 @@
+import type { Locator, Page } from "@playwright/test";
+import { test, expect } from "../fixtures/app";
+
+const ROW_TITLE = "Click to copy · Shift+click to select range";
+
+type LogcatSeedEntry = {
+  id: number;
+  tag: string;
+  message: string;
+  level?: string;
+};
+
+async function openLogcatWithEmptyEntries(page: Page): Promise<void> {
+  await page.getByRole("tab", { name: "Logcat" }).click();
+  await page.evaluate(async () => {
+    await window.__e2e__.invoke("clear_logcat", {});
+  });
+}
+
+async function pushLogcatEntries(page: Page, entries: LogcatSeedEntry[]): Promise<void> {
+  await page.evaluate(async (seedEntries) => {
+    const payload = seedEntries.map((entry) => ({
+      id: BigInt(entry.id),
+      timestamp: "2026-05-06T12:00:00.000Z",
+      pid: 1234,
+      tid: 5678,
+      level: entry.level ?? "info",
+      tag: entry.tag,
+      message: entry.message,
+      package: "com.example.mockapp",
+      kind: "normal",
+      isCrash: false,
+      flags: 0,
+      category: "general",
+      crashGroupId: null,
+      jsonBody: null,
+    }));
+    await window.__e2e__.invoke("__e2e_append_logcat_entries", { entries: payload });
+  }, entries);
+}
+
+function makeScrollEntries(start: number, count: number): LogcatSeedEntry[] {
+  return Array.from({ length: count }, (_, offset) => {
+    const id = start + offset;
+    return {
+      id,
+      tag: "ScrollTag",
+      message: `Auto row ${String(id).padStart(3, "0")}`,
+    };
+  });
+}
+
+async function scrollState(scroller: Locator): Promise<{
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  maxScrollTop: number;
+}> {
+  return scroller.evaluate((element) => ({
+    scrollTop: Math.round(element.scrollTop),
+    scrollHeight: Math.round(element.scrollHeight),
+    clientHeight: Math.round(element.clientHeight),
+    maxScrollTop: Math.round(element.scrollHeight - element.clientHeight),
+  }));
+}
+
+test("logcat follow-tail stays paused after manual scrolling until Jump to end", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, makeScrollEntries(0, 90));
+
+  const scroller = page.getByTestId("logcat-virtual-list");
+  await expect(scroller).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Auto row 089")).toBeVisible({ timeout: 5_000 });
+
+  const initialBottom = await scrollState(scroller);
+  expect(initialBottom.scrollTop).toBeGreaterThan(0);
+
+  await scroller.evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await expect(page.getByText("Auto row 000")).toBeVisible({ timeout: 5_000 });
+
+  await pushLogcatEntries(page, makeScrollEntries(90, 1));
+  await page.waitForTimeout(100);
+  expect((await scrollState(scroller)).scrollTop).toBe(0);
+  await expect(page.getByText("Auto row 090")).not.toBeVisible();
+
+  const manualBottomTop = await scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight - element.clientHeight;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+    return Math.round(element.scrollTop);
+  });
+  await pushLogcatEntries(page, makeScrollEntries(91, 1));
+  await page.waitForTimeout(100);
+  const pausedAfterManualBottom = await scrollState(scroller);
+  expect(pausedAfterManualBottom.scrollTop).toBe(manualBottomTop);
+  expect(pausedAfterManualBottom.maxScrollTop).toBeGreaterThan(manualBottomTop);
+
+  await page.getByTitle("Scroll to end").click();
+  await page.waitForFunction(() => {
+    const element = document.querySelector('[data-testid="logcat-virtual-list"]');
+    if (!(element instanceof HTMLElement)) return false;
+    return Math.abs(element.scrollTop - (element.scrollHeight - element.clientHeight)) <= 1;
+  });
+  await expect(page.getByText("Auto row 091")).toBeVisible({ timeout: 5_000 });
+
+  const beforeFollowAppend = await scrollState(scroller);
+  await pushLogcatEntries(page, makeScrollEntries(92, 1));
+  await page.waitForFunction(() => {
+    const element = document.querySelector('[data-testid="logcat-virtual-list"]');
+    if (!(element instanceof HTMLElement)) return false;
+    return Math.abs(element.scrollTop - (element.scrollHeight - element.clientHeight)) <= 1;
+  });
+  const afterFollowAppend = await scrollState(scroller);
+  expect(afterFollowAppend.maxScrollTop).toBeGreaterThan(beforeFollowAppend.maxScrollTop);
+  expect(afterFollowAppend.scrollTop).toBe(afterFollowAppend.maxScrollTop);
+  await expect(page.getByText("Auto row 092")).toBeVisible({ timeout: 5_000 });
+});
+
+test("logcat detail panel opens for the clicked filtered row", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 100, tag: "AlphaTag", message: "Alpha unfiltered message" },
+    { id: 101, tag: "BetaTag", message: "Beta target message" },
+    { id: 102, tag: "GammaTag", message: "Gamma target message" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(3, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("message:target");
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(2, { timeout: 5_000 });
+  await page.getByText("Beta target message").click();
+
+  await expect(page.getByTitle("Filter by message")).toHaveText("Beta target message");
+});
+
+test("logcat package filter dropdown closes when the window loses focus", async ({ page }) => {
+  await page.getByRole("tab", { name: "Logcat" }).click();
+  await page.evaluate(async () => {
+    await window.__e2e__.invoke("start_logcat", {});
+  });
+  await expect(page.getByText("Activity started").first()).toBeVisible({ timeout: 5_000 });
+
+  await page.getByTitle("Filter by package").click();
+  await expect(page.getByPlaceholder("Search packages…")).toBeVisible();
+
+  await page.evaluate(() => window.dispatchEvent(new Event("blur")));
+
+  await expect(page.getByPlaceholder("Search packages…")).not.toBeVisible();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,11 @@ import { defineConfig, devices } from "@playwright/test";
 // @ts-expect-error process is a nodejs global
 const isCI = !!process.env.CI;
 
+// Playwright forces colored output for its reporters. In environments that also
+// set NO_COLOR, Node prints noisy FORCE_COLOR/NO_COLOR conflict warnings.
+// @ts-expect-error process is a nodejs global
+delete process.env.NO_COLOR;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,

--- a/src-tauri/src/models/settings.rs
+++ b/src-tauri/src/models/settings.rs
@@ -144,6 +144,10 @@ fn default_logcat_ring_max_entries() -> u32 {
     50_000
 }
 
+fn default_logcat_output_font_size() -> u32 {
+    11
+}
+
 /// Minimum logcat ring size and minimum `max_ui_lines`.
 pub const LOGCAT_RING_MIN: u32 = 1_000;
 /// Hard ceiling for logcat ring size (memory bound; `LogStore` clamps to this).
@@ -153,6 +157,8 @@ pub const LOGCAT_RING_DEFAULT: u32 = 50_000;
 
 /// Minimum `LogcatSettings.max_ui_lines` (same numeric floor as the ring minimum).
 pub const LOGCAT_MAX_UI_LINES_MIN: u32 = LOGCAT_RING_MIN;
+pub const LOGCAT_OUTPUT_FONT_SIZE_MIN: u32 = 9;
+pub const LOGCAT_OUTPUT_FONT_SIZE_MAX: u32 = 16;
 
 /// Logcat settings.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, TS)]
@@ -170,6 +176,9 @@ pub struct LogcatSettings {
     /// Maximum entries in the in-memory logcat ring before oldest lines are dropped.
     #[serde(default = "default_logcat_ring_max_entries")]
     pub ring_max_entries: u32,
+    /// Font size in pixels for Logcat output rows.
+    #[serde(default = "default_logcat_output_font_size")]
+    pub output_font_size: u32,
 }
 
 /// Clamp a user-provided ring size to the allowed range.
@@ -190,6 +199,9 @@ pub fn normalize_logcat_section(logcat: &mut LogcatSettings) {
     logcat.max_ui_lines = logcat
         .max_ui_lines
         .clamp(LOGCAT_MAX_UI_LINES_MIN, logcat.ring_max_entries);
+    logcat.output_font_size = logcat
+        .output_font_size
+        .clamp(LOGCAT_OUTPUT_FONT_SIZE_MIN, LOGCAT_OUTPUT_FONT_SIZE_MAX);
 }
 
 /// Telemetry / crash-reporting settings.
@@ -289,6 +301,7 @@ impl Default for LogcatSettings {
             auto_scroll_to_end: true,
             max_ui_lines: default_logcat_max_ui_lines(),
             ring_max_entries: default_logcat_ring_max_entries(),
+            output_font_size: default_logcat_output_font_size(),
         }
     }
 }
@@ -407,6 +420,7 @@ mod tests {
         assert!(parsed.logcat.auto_scroll_to_end);
         assert_eq!(parsed.logcat.max_ui_lines, 20_000);
         assert_eq!(parsed.logcat.ring_max_entries, 50_000);
+        assert_eq!(parsed.logcat.output_font_size, 11);
     }
 
     #[test]
@@ -416,29 +430,35 @@ mod tests {
             auto_scroll_to_end: true,
             ring_max_entries: 900,
             max_ui_lines: 99_000,
+            output_font_size: 99,
         };
         normalize_logcat_section(&mut l);
         assert_eq!(l.ring_max_entries, LOGCAT_RING_MIN);
         assert_eq!(l.max_ui_lines, LOGCAT_RING_MIN);
+        assert_eq!(l.output_font_size, LOGCAT_OUTPUT_FONT_SIZE_MAX);
 
         let mut l2 = LogcatSettings {
             auto_start: true,
             auto_scroll_to_end: true,
             ring_max_entries: 10_000,
             max_ui_lines: 50_000,
+            output_font_size: 3,
         };
         normalize_logcat_section(&mut l2);
         assert_eq!(l2.ring_max_entries, 10_000);
         assert_eq!(l2.max_ui_lines, 10_000);
+        assert_eq!(l2.output_font_size, LOGCAT_OUTPUT_FONT_SIZE_MIN);
 
         let mut l3 = LogcatSettings {
             auto_start: true,
             auto_scroll_to_end: true,
             ring_max_entries: 200_000,
             max_ui_lines: 20_000,
+            output_font_size: 13,
         };
         normalize_logcat_section(&mut l3);
         assert_eq!(l3.ring_max_entries, LOGCAT_RING_ABS_MAX);
         assert_eq!(l3.max_ui_lines, 20_000);
+        assert_eq!(l3.output_font_size, 13);
     }
 }

--- a/src/App.log-mode.test.tsx
+++ b/src/App.log-mode.test.tsx
@@ -83,6 +83,7 @@ vi.mock("@/lib/keybindings", () => ({
 }));
 
 vi.mock("@/stores/settings.store", () => ({
+  applyAppearanceSettings: vi.fn(),
   loadSettings: vi.fn().mockResolvedValue(undefined),
   settingsState: { telemetry: { enabled: false } },
 }));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import { DeviceSidebar } from "@/components/device/DeviceSidebar";
 import { DevicePickerDialog } from "@/components/device/DevicePickerDialog";
 import { registerKeybinding, initKeybindings } from "@/lib/keybindings";
 import { registerAction, type ActionCategory } from "@/lib/action-registry";
-import { loadSettings, settingsState } from "@/stores/settings.store";
+import { applyAppearanceSettings, loadSettings, settingsState } from "@/stores/settings.store";
 import { captureSentryException, initSentryWeb } from "@/lib/telemetry/sentry-web";
 import { tryOpenOnboardingAfterLoad, openOnboardingWizard } from "@/stores/onboarding.store";
 import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
@@ -97,6 +97,10 @@ export function App(): JSX.Element {
     // Access to create reactive dependency on telemetry setting.
     void settingsState.telemetry.enabled;
     initSentryWeb();
+  });
+
+  createEffect(() => {
+    applyAppearanceSettings();
   });
 
   onMount(async () => {

--- a/src/bindings/LogcatSettings.ts
+++ b/src/bindings/LogcatSettings.ts
@@ -19,4 +19,8 @@ maxUiLines: number,
 /**
  * Maximum entries in the in-memory logcat ring before oldest lines are dropped.
  */
-ringMaxEntries: number, };
+ringMaxEntries: number, 
+/**
+ * Font size in pixels for Logcat output rows.
+ */
+outputFontSize: number, };

--- a/src/components/common/LogViewer.component.test.tsx
+++ b/src/components/common/LogViewer.component.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LogEntry } from "@/bindings";
+import { LogViewer } from "./LogViewer";
+
+function makeEntry(id: number): LogEntry {
+  return {
+    id,
+    timestamp: "2026-05-06T12:00:00.000Z",
+    level: "info",
+    source: "build",
+    message: `line ${id}`,
+  };
+}
+
+function getScroller(container: HTMLElement): HTMLElement {
+  const scroller = Array.from(container.querySelectorAll("div")).find(
+    (el) => (el as HTMLElement).style.overflowY === "auto"
+  );
+  if (!(scroller instanceof HTMLElement)) {
+    throw new Error("Expected LogViewer to render a VirtualList scroller");
+  }
+  return scroller;
+}
+
+describe("LogViewer", () => {
+  beforeEach(() => {
+    if (typeof window !== "undefined" && !window.ResizeObserver) {
+      class MockResizeObserver {
+        observe = vi.fn();
+        unobserve = vi.fn();
+        disconnect = vi.fn();
+      }
+      window.ResizeObserver = MockResizeObserver as any;
+    }
+  });
+
+  it("scrolls to the end when the user manually resumes auto-scroll", () => {
+    const entries = Array.from({ length: 100 }, (_, i) => makeEntry(i + 1));
+    const { container } = render(() => (
+      <LogViewer entries={entries} showSource={false} defaultAutoScroll={true} />
+    ));
+    const scroller = getScroller(container);
+    Object.defineProperty(scroller, "clientHeight", { value: 200, writable: true });
+    Object.defineProperty(scroller, "scrollHeight", { value: 2000, writable: true });
+    Object.defineProperty(scroller, "scrollTop", { value: 0, writable: true });
+
+    fireEvent.scroll(scroller);
+    fireEvent.click(screen.getByTitle("Auto-scroll paused (click to resume)"));
+
+    expect(scroller.scrollTop).toBe(2000);
+  });
+});

--- a/src/components/common/LogViewer.tsx
+++ b/src/components/common/LogViewer.tsx
@@ -1,5 +1,5 @@
 import { type JSX, Show, createMemo, createSignal, onCleanup } from "solid-js";
-import { VirtualList } from "@/components/ui";
+import { VirtualList, type VirtualListHandle } from "@/components/ui";
 import { copyToClipboard } from "@/utils/clipboard";
 import { debounce } from "@/utils/debounce";
 import { formatBuildLogToolbarCount } from "./log-viewer-toolbar-count";
@@ -44,6 +44,7 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
 
   const updateDebouncedSearch = debounce((q: string) => setDebouncedSearch(q), 150);
   let copyTimeout: ReturnType<typeof setTimeout> | undefined;
+  let virtualListRef: VirtualListHandle | undefined;
 
   // Derive unique sorted sources from the current entries.
   const uniqueSources = createMemo(() => uniqueLogViewerSources(props.entries));
@@ -98,6 +99,15 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
     setDebouncedSearch("");
   }
 
+  function handleToggleAutoScroll(): void {
+    if (autoScroll()) {
+      setAutoScroll(false);
+      return;
+    }
+    setAutoScroll(true);
+    virtualListRef?.scrollToBottom();
+  }
+
   return (
     <div
       style={{
@@ -123,7 +133,7 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
         showTimestamps={showTimestamps()}
         onToggleTimestamps={() => setShowTimestamps((v) => !v)}
         autoScroll={autoScroll()}
-        onToggleAutoScroll={() => setAutoScroll((v) => !v)}
+        onToggleAutoScroll={handleToggleAutoScroll}
         copiedAll={copiedAll()}
         onCopyAll={handleCopyAll}
         canClear={props.onClear !== undefined}
@@ -158,7 +168,9 @@ export function LogViewer(props: LogViewerProps): JSX.Element {
             rowHeight={20}
             autoScroll={autoScroll()}
             onScrolledUp={() => setAutoScroll(false)}
-            onScrolledToBottom={() => setAutoScroll(true)}
+            handle={(api) => {
+              virtualListRef = api;
+            }}
             renderRow={(entry, index) => (
               <LogViewerRow
                 entry={entry}

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -166,4 +166,38 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
     await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(1));
     expect(screen.getAllByText('hello "quoted" value').length).toBeGreaterThan(0);
   });
+
+  it("opens detail for the clicked row after filtering changes visible indices", async () => {
+    const alphaEntry = {
+      ...BASE_ENTRY,
+      id: 10n,
+      tag: "AlphaTag",
+      message: "Alpha unfiltered message",
+    } satisfies ProcessedEntry;
+    const betaEntry = {
+      ...BASE_ENTRY,
+      id: 11n,
+      tag: "BetaTag",
+      message: "Beta target message",
+    } satisfies ProcessedEntry;
+    const gammaEntry = {
+      ...BASE_ENTRY,
+      id: 12n,
+      tag: "GammaTag",
+      message: "Gamma target message",
+    } satisfies ProcessedEntry;
+    installLogcatPanelMocks([alphaEntry, betaEntry, gammaEntry]);
+    render(() => <LogcatPanel />);
+
+    await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(3));
+
+    const input = screen.getByRole("textbox");
+    fireEvent.input(input, { target: { value: "message:target" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(2));
+    fireEvent.click(screen.getByText("Beta target message"));
+
+    expect(screen.getByTitle("Filter by message").textContent).toBe("Beta target message");
+  });
 });

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -25,7 +25,7 @@ import {
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { save } from "@tauri-apps/plugin-dialog";
 import { selectedDevice } from "@/stores/device.store";
-import { settingsState } from "@/stores/settings.store";
+import { logcatRowHeightForFontSize, settingsState } from "@/stores/settings.store";
 import { showToast } from "@/components/ui";
 import { VirtualList, type VirtualListHandle, isPaletteOpen } from "@/components/ui";
 import {
@@ -64,7 +64,7 @@ import {
 } from "@/stores/logcat.store";
 import { createLatestOnlyGuard } from "@/services/logcat.service";
 import { JsonDetailPanel } from "./LogcatJsonDetailPanel";
-import { LogcatVirtualRow, ROW_HEIGHT, SeparatorRow } from "./LogcatRows";
+import { LogcatVirtualRow, SeparatorRow } from "./LogcatRows";
 import { SavedFilterMenu } from "./SavedFilterMenu";
 import {
   LogcatFilterControls,
@@ -103,6 +103,9 @@ export function LogcatPanel(): JSX.Element {
 
   const [autoScroll, setAutoScroll] = createSignal(settingsState.logcat.autoScrollToEnd !== false);
   const [scrollCompensate, setScrollCompensate] = createSignal(0);
+  const rowHeight = createMemo(() =>
+    logcatRowHeightForFontSize(settingsState.logcat.outputFontSize)
+  );
   let virtualListRef: VirtualListHandle | undefined;
   const [paused, setPaused] = createSignal(false);
   const [restarting, setRestarting] = createSignal(false);
@@ -171,6 +174,14 @@ export function LogcatPanel(): JSX.Element {
     undefined,
     { equals: false }
   );
+
+  const filteredEntryIndexById = createMemo(() => {
+    const indexById = new Map<LogcatEntry["id"], number>();
+    filteredEntries().forEach((entry, index) => {
+      indexById.set(entry.id, index);
+    });
+    return indexById;
+  });
 
   // ── Incremental crash indices ─────────────────────────────────────────────────
   //
@@ -336,7 +347,7 @@ export function LogcatPanel(): JSX.Element {
         if (excess > 0) {
           replaceLogcatEntries(cap === 0 ? [] : logcatState.entries.slice(-cap));
           if (!followTailForList()) {
-            setScrollCompensate((c) => c + excess * ROW_HEIGHT);
+            setScrollCompensate((c) => c + excess * rowHeight());
           }
         }
       } else if (cap > prevLogcatMaxUi) {
@@ -400,7 +411,7 @@ export function LogcatPanel(): JSX.Element {
       if (paused()) return;
       const dropped = appendLogcatEntries(newEntries, maxUiLinesCap());
       if (dropped > 0 && !followTailForList()) {
-        setScrollCompensate((c) => c + dropped * ROW_HEIGHT);
+        setScrollCompensate((c) => c + dropped * rowHeight());
       }
 
       suggestions.ingest(newEntries);
@@ -549,17 +560,20 @@ export function LogcatPanel(): JSX.Element {
     return `${e.timestamp}  ${e.level.toUpperCase()}  ${pkg}${e.tag}: ${e.message}`;
   }
 
-  function handleRowClick(idx: number, e: MouseEvent) {
+  function currentEntryIndex(entry: LogcatEntry): number {
+    return filteredEntryIndexById().get(entry.id) ?? -1;
+  }
+
+  function handleRowClick(entry: LogcatEntry, e: MouseEvent) {
+    const idx = currentEntryIndex(entry);
+    if (idx < 0) return;
     if (e.shiftKey && selectionAnchor() !== null) {
       setSelectionEnd(idx);
     } else {
       setSelectionAnchor(idx);
       setSelectionEnd(null);
       // Plain click (no shift) — toggle detail panel
-      const entry = filteredEntries()[idx];
-      if (entry) {
-        setSelectedDetailEntry((prev) => (prev?.id === entry.id ? null : entry));
-      }
+      setSelectedDetailEntry((prev) => (prev?.id === entry.id ? null : entry));
     }
   }
 
@@ -778,11 +792,11 @@ export function LogcatPanel(): JSX.Element {
       <Show when={logcatState.entries.length > 0}>
         <VirtualList
           items={filteredEntries()}
-          rowHeight={ROW_HEIGHT}
+          rowHeight={rowHeight()}
           autoScroll={followTailForList()}
+          data-testid="logcat-virtual-list"
           scrollCompensate={scrollCompensate()}
           jumpTo={jumpTarget()}
-          onScrolledToBottom={() => setAutoScroll(true)}
           onScrolledUp={() => setAutoScroll(false)}
           handle={(api) => {
             virtualListRef = api;
@@ -790,23 +804,23 @@ export function LogcatPanel(): JSX.Element {
           style={{
             flex: "1",
             "font-family": "var(--font-mono)",
-            "font-size": "11px",
-            "line-height": `${ROW_HEIGHT}px`,
+            "font-size": "var(--font-size-logcat-output)",
+            "line-height": "var(--logcat-row-height)",
           }}
-          renderRow={(entry, idx) => {
+          renderRow={(entry) => {
             if (entry.kind === "processDied" || entry.kind === "processStarted") {
               return <SeparatorRow entry={entry} />;
             }
             return (
               <LogcatVirtualRow
                 entry={entry}
-                index={idx}
+                getIndex={() => currentEntryIndex(entry)}
                 getSelectionRange={getSelectionRange}
                 getAnchor={() => selectionAnchor()}
                 getEnd={() => selectionEnd()}
                 getDetailEntry={() => selectedDetailEntry()}
                 getJsonEntry={() => selectedJsonEntry()}
-                onRowClick={(e) => handleRowClick(idx, e)}
+                onRowClick={(e) => handleRowClick(entry, e)}
                 onJsonClick={(e) => handleJsonBadgeClick(e, entry)}
               />
             );

--- a/src/components/logcat/LogcatRows.test.tsx
+++ b/src/components/logcat/LogcatRows.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
+import type { LogcatEntry } from "@/lib/tauri-api";
+import { LogcatVirtualRow } from "./LogcatRows";
+
+const ENTRY: LogcatEntry = {
+  id: 1n,
+  timestamp: "2026-05-06T12:00:00.000Z",
+  pid: 123,
+  tid: 456,
+  level: "info",
+  tag: "MainActivity",
+  message: "Activity started",
+  package: "com.example.app",
+  kind: "normal",
+  isCrash: false,
+  flags: 0,
+  category: "general",
+  crashGroupId: null,
+  jsonBody: null,
+};
+
+describe("LogcatRows", () => {
+  it("sizes log output rows from the Logcat font CSS variables", () => {
+    render(() => (
+      <LogcatVirtualRow
+        entry={ENTRY}
+        getIndex={() => 0}
+        getSelectionRange={() => null}
+        getAnchor={() => null}
+        getEnd={() => null}
+        getDetailEntry={() => null}
+        getJsonEntry={() => null}
+        onRowClick={() => {}}
+        onJsonClick={() => {}}
+      />
+    ));
+
+    const row = screen.getByTitle("Click to copy · Shift+click to select range");
+
+    expect(row.style.fontSize).toBe("var(--font-size-logcat-output)");
+    expect(row.style.height).toBe("var(--logcat-row-height)");
+    expect(row.style.minHeight).toBe("var(--logcat-row-height)");
+  });
+});

--- a/src/components/logcat/LogcatRows.tsx
+++ b/src/components/logcat/LogcatRows.tsx
@@ -7,7 +7,7 @@ import { isProjectFrame, parseStackFrame } from "@/lib/logcat-query";
 import { LEVEL_CONFIG } from "./logcat-levels";
 import { rowFocusMarked, rowInSelectionRange } from "./logcat-row-selection";
 
-export const ROW_HEIGHT = 20;
+export const LOGCAT_ROW_HEIGHT_CSS = "var(--logcat-row-height)";
 
 const ENTRY_FLAGS = {
   CRASH: 1 << 0,
@@ -18,7 +18,7 @@ const ENTRY_FLAGS = {
 
 export function LogcatVirtualRow(props: {
   entry: LogcatEntry;
-  index: number;
+  getIndex: () => number;
   getSelectionRange: () => [number, number] | null;
   getAnchor: () => number | null;
   getEnd: () => number | null;
@@ -27,13 +27,14 @@ export function LogcatVirtualRow(props: {
   onRowClick: (e: MouseEvent) => void;
   onJsonClick: (e: MouseEvent) => void;
 }): JSX.Element {
+  const index = createMemo(() => props.getIndex());
   const inSelectionRange = createMemo(() =>
-    rowInSelectionRange(props.index, props.getSelectionRange())
+    rowInSelectionRange(index(), props.getSelectionRange())
   );
 
   const focusMarked = createMemo(() =>
     rowFocusMarked(
-      props.index,
+      index(),
       props.getAnchor(),
       props.getEnd(),
       props.getDetailEntry(),
@@ -65,8 +66,8 @@ export function SeparatorRow(props: { entry: LogcatEntry }): JSX.Element {
       style={{
         display: "flex",
         "align-items": "center",
-        height: `${ROW_HEIGHT}px`,
-        "min-height": `${ROW_HEIGHT}px`,
+        height: LOGCAT_ROW_HEIGHT_CSS,
+        "min-height": LOGCAT_ROW_HEIGHT_CSS,
         padding: "0 8px",
         background: isDied()
           ? "color-mix(in srgb, var(--error) 10%, transparent)"
@@ -217,8 +218,9 @@ function LogcatRow(props: {
         "align-items": "center",
         gap: "6px",
         padding: "0 10px",
-        height: `${ROW_HEIGHT}px`,
-        "min-height": `${ROW_HEIGHT}px`,
+        height: LOGCAT_ROW_HEIGHT_CSS,
+        "min-height": LOGCAT_ROW_HEIGHT_CSS,
+        "font-size": "var(--font-size-logcat-output)",
         background: defaultRowBackground(),
         "border-left": props.focusMarked
           ? "4px solid var(--accent)"

--- a/src/components/logcat/PackageDropdown.test.tsx
+++ b/src/components/logcat/PackageDropdown.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+import { PackageDropdown } from "./PackageDropdown";
+
+function renderPackageDropdown() {
+  return render(() => (
+    <PackageDropdown packages={["com.example.app"]} selected={null} onSelect={vi.fn()} />
+  ));
+}
+
+describe("PackageDropdown", () => {
+  it("closes when the window loses focus", () => {
+    renderPackageDropdown();
+
+    fireEvent.click(screen.getByTitle("Filter by package"));
+    expect(screen.getByPlaceholderText("Search packages…")).not.toBeNull();
+
+    window.dispatchEvent(new Event("blur"));
+
+    expect(screen.queryByPlaceholderText("Search packages…")).toBeNull();
+  });
+});

--- a/src/components/logcat/PackageDropdown.tsx
+++ b/src/components/logcat/PackageDropdown.tsx
@@ -8,7 +8,7 @@
  * `onSelect(null)` to clear the filter.
  */
 
-import { type JSX, createSignal, createMemo, For, Show } from "solid-js";
+import { type JSX, createSignal, createMemo, For, Show, onCleanup, onMount } from "solid-js";
 import { getMinePackage } from "@/lib/logcat-query";
 import {
   logcatDropdownOverlayStyle,
@@ -86,6 +86,25 @@ export function PackageDropdown(props: PackageDropdownProps): JSX.Element {
     setOpen(false);
     setSearch("");
   }
+
+  function closeDropdown() {
+    setOpen(false);
+    setSearch("");
+  }
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === "hidden") closeDropdown();
+  }
+
+  onMount(() => {
+    window.addEventListener("blur", closeDropdown);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+  });
+
+  onCleanup(() => {
+    window.removeEventListener("blur", closeDropdown);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+  });
 
   // ── Render ───────────────────────────────────────────────────────────────────
 
@@ -219,7 +238,7 @@ export function PackageDropdown(props: PackageDropdownProps): JSX.Element {
         </div>
 
         {/* Click-outside overlay */}
-        <div style={logcatDropdownOverlayStyle()} onClick={() => setOpen(false)} />
+        <div style={logcatDropdownOverlayStyle()} onClick={closeDropdown} />
       </Show>
     </div>
   );

--- a/src/components/logcat/SavedFilterMenu.test.tsx
+++ b/src/components/logcat/SavedFilterMenu.test.tsx
@@ -22,4 +22,15 @@ describe("SavedFilterMenu", () => {
     expect(panel?.getAttribute("style")).toContain("left: 0");
     expect(panel?.getAttribute("style")).not.toContain("right: 0");
   });
+
+  it("closes when the window loses focus", () => {
+    renderSavedFilterMenu();
+
+    fireEvent.click(screen.getByTitle("Filter presets"));
+    expect(screen.getByText("Quick Filters")).not.toBeNull();
+
+    window.dispatchEvent(new Event("blur"));
+
+    expect(screen.queryByText("Quick Filters")).toBeNull();
+  });
 });

--- a/src/components/logcat/SavedFilterMenu.tsx
+++ b/src/components/logcat/SavedFilterMenu.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createSignal, type JSX } from "solid-js";
+import { For, Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 import { showToast } from "@/components/ui";
 import {
   addSavedFilter,
@@ -86,6 +86,26 @@ export function SavedFilterMenu(props: {
     setRenamingId(null);
     setRenameDraft("");
   }
+
+  function closeMenu() {
+    setOpen(false);
+    setSavingPreset(false);
+    cancelRename();
+  }
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === "hidden") closeMenu();
+  }
+
+  onMount(() => {
+    window.addEventListener("blur", closeMenu);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+  });
+
+  onCleanup(() => {
+    window.removeEventListener("blur", closeMenu);
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+  });
 
   return (
     <div style={logcatDropdownRootStyle()}>
@@ -351,13 +371,7 @@ export function SavedFilterMenu(props: {
             </Show>
           </div>
         </div>
-        <div
-          style={logcatDropdownOverlayStyle()}
-          onClick={() => {
-            setOpen(false);
-            cancelRename();
-          }}
-        />
+        <div style={logcatDropdownOverlayStyle()} onClick={closeMenu} />
       </Show>
     </div>
   );

--- a/src/components/settings/SettingRow.tsx
+++ b/src/components/settings/SettingRow.tsx
@@ -20,11 +20,23 @@ export function SettingRow(props: SettingRowProps): JSX.Element {
       }}
     >
       <div style={{ flex: "1", "min-width": "0" }}>
-        <div style={{ "font-size": "13px", color: "var(--text-primary)", "font-weight": "500" }}>
+        <div
+          style={{
+            "font-size": "var(--font-size-ui)",
+            color: "var(--text-primary)",
+            "font-weight": "500",
+          }}
+        >
           {props.label}
         </div>
         <Show when={props.description}>
-          <div style={{ "font-size": "11px", color: "var(--text-muted)", "margin-top": "2px" }}>
+          <div
+            style={{
+              "font-size": "var(--font-size-ui-sm)",
+              color: "var(--text-muted)",
+              "margin-top": "2px",
+            }}
+          >
             {props.description}
           </div>
         </Show>
@@ -59,7 +71,11 @@ export function SettingNumberInput(props: {
         value={props.value}
         onInput={(v) => {
           const n = parseInt(v, 10);
-          if (!isNaN(n)) props.onChange(n);
+          if (!isNaN(n)) {
+            const min = props.min ?? Number.NEGATIVE_INFINITY;
+            const max = props.max ?? Number.POSITIVE_INFINITY;
+            props.onChange(Math.min(max, Math.max(min, n)));
+          }
         }}
       />
     </div>

--- a/src/components/settings/SettingsPanel.test.tsx
+++ b/src/components/settings/SettingsPanel.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { settingsState, updateSetting } from "@/stores/settings.store";
+import { openSettings, closeSettings, SettingsPanel } from "./SettingsPanel";
+
+vi.mock("@tauri-apps/api/app", () => ({
+  getVersion: vi.fn().mockResolvedValue("0.0.0-test"),
+}));
+
+describe("SettingsPanel", () => {
+  beforeEach(() => {
+    closeSettings();
+    updateSetting("logcat", "outputFontSize", 11);
+  });
+
+  it("lets the user change the Logcat output font size", async () => {
+    render(() => <SettingsPanel />);
+    openSettings();
+
+    fireEvent.click(screen.getByRole("button", { name: /tools/i }));
+    fireEvent.input(screen.getByPlaceholderText("Search settings..."), {
+      target: { value: "output font" },
+    });
+
+    expect(await screen.findByText("Logcat Output Font Size")).not.toBeNull();
+    const input = screen.getByDisplayValue("11");
+
+    fireEvent.input(input, { target: { value: "13" } });
+
+    expect(settingsState.logcat.outputFontSize).toBe(13);
+  });
+});

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -262,10 +262,10 @@ function UserSettings(props: { matchesSearch: (l: string, d?: string) => boolean
   return (
     <>
       <SectionHeader title="Appearance" />
-      <Show when={props.matchesSearch("UI Font Size", "Font size for UI elements")}>
+      <Show when={props.matchesSearch("System Font Size", "Font size for UI elements")}>
         <SettingRow
-          label="UI Font Size"
-          description="Font size for panels, sidebar, and status bar"
+          label="System Font Size"
+          description="Base font size for app controls, panels, sidebar, and status bar"
         >
           <SettingNumberInput
             value={settingsState.appearance.uiFontSize}
@@ -371,6 +371,26 @@ function ToolsSettings(props: { matchesSearch: (l: string, d?: string) => boolea
           <SettingToggle
             checked={settingsState.logcat.autoScrollToEnd}
             onChange={(v) => updateSetting("logcat", "autoScrollToEnd", v)}
+          />
+        </SettingRow>
+      </Show>
+      <Show
+        when={props.matchesSearch(
+          "Logcat Output Font Size",
+          "Font size for logcat output rows messages timestamps tags"
+        )}
+      >
+        <SettingRow
+          label="Logcat Output Font Size"
+          description="Font size for Logcat output rows. Filters and toolbar controls keep the system font size."
+        >
+          <SettingNumberInput
+            value={settingsState.logcat.outputFontSize}
+            min={9}
+            max={16}
+            onChange={(v) =>
+              updateSetting("logcat", "outputFontSize", Math.min(16, Math.max(9, v)))
+            }
           />
         </SettingRow>
       </Show>

--- a/src/components/ui/VirtualList/VirtualList.test.tsx
+++ b/src/components/ui/VirtualList/VirtualList.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@solidjs/testing-library";
+import { createSignal } from "solid-js";
 import { VirtualList } from "./VirtualList";
 
 describe("VirtualList", () => {
@@ -18,40 +19,51 @@ describe("VirtualList", () => {
   it("renders visible items", () => {
     const items = Array.from({ length: 10 }, (_, i) => `item-${i}`);
     const { container } = render(() => (
-      <VirtualList
-        items={items}
-        rowHeight={30}
-        renderRow={(item) => <div>{item}</div>}
-      />
+      <VirtualList items={items} rowHeight={30} renderRow={(item) => <div>{item}</div>} />
     ));
     // At least some items rendered (jsdom has no real scroll height, so all items may render)
     expect(container.textContent).toContain("item-0");
   });
 
-  it("calls onScrolledToBottom when scrolling near the end", () => {
-    const onScrolledToBottom = vi.fn();
+  it("does not re-enable auto-scroll when manually scrolling back to the bottom", () => {
+    const onScrolledUp = vi.fn();
     const items = Array.from({ length: 5 }, (_, i) => `item-${i}`);
-    const { container } = render(() => (
-      <VirtualList
-        items={items}
-        rowHeight={30}
-        renderRow={(item) => <div>{item}</div>}
-        onScrolledToBottom={onScrolledToBottom}
-      />
-    ));
-    // wasAtBottom starts as true, so we need to scroll away first, then back to trigger callback
-    const scroller = container.firstElementChild as HTMLElement;
+
+    function Harness() {
+      const [autoScroll, setAutoScroll] = createSignal(true);
+      return (
+        <>
+          <span data-testid="auto-scroll-state">{autoScroll() ? "on" : "off"}</span>
+          <VirtualList
+            items={items}
+            rowHeight={30}
+            renderRow={(item) => <div>{item}</div>}
+            autoScroll={autoScroll()}
+            onScrolledUp={() => {
+              onScrolledUp();
+              setAutoScroll(false);
+            }}
+            class="virtual-list-test"
+          />
+        </>
+      );
+    }
+
+    const { container } = render(() => <Harness />);
+    // wasAtBottom starts as true, so scrolling away disables follow-tail.
+    const state = container.querySelector('[data-testid="auto-scroll-state"]') as HTMLElement;
+    const scroller = container.querySelector(".virtual-list-test") as HTMLElement;
     Object.defineProperty(scroller, "clientHeight", { value: 200, writable: true });
     Object.defineProperty(scroller, "scrollHeight", { value: 1200, writable: true });
 
-    // First: scroll away from bottom (distFromBottom > threshold)
     Object.defineProperty(scroller, "scrollTop", { value: 0, writable: true });
     scroller.dispatchEvent(new Event("scroll"));
-    expect(onScrolledToBottom).toHaveBeenCalledTimes(0);
+    expect(onScrolledUp).toHaveBeenCalledOnce();
+    expect(state.textContent).toBe("off");
 
-    // Then: scroll to bottom (distFromBottom < threshold) to trigger callback
+    // Returning to the bottom manually should not re-enable follow-tail.
     Object.defineProperty(scroller, "scrollTop", { value: 1000, writable: true });
     scroller.dispatchEvent(new Event("scroll"));
-    expect(onScrolledToBottom).toHaveBeenCalledOnce();
+    expect(state.textContent).toBe("off");
   });
 });

--- a/src/components/ui/VirtualList/VirtualList.tsx
+++ b/src/components/ui/VirtualList/VirtualList.tsx
@@ -16,7 +16,6 @@
  *     rowHeight={20}
  *     renderRow={(item, index) => <MyRow entry={item} />}
  *     autoScroll={autoScroll()}
- *     onScrolledToBottom={() => setAutoScroll(true)}
  *     onScrolledUp={() => setAutoScroll(false)}
  *   />
  */
@@ -49,8 +48,6 @@ export interface VirtualListProps<T> {
    * user is already at the bottom (or auto-scroll has never been overridden).
    */
   autoScroll?: boolean;
-  /** Called when the user scrolls to within `bottomThreshold` px of the end. */
-  onScrolledToBottom?: () => void;
   /** Called when the user scrolls up away from the bottom. */
   onScrolledUp?: () => void;
   /** How many extra rows to render above and below the viewport. Default 30. */
@@ -62,6 +59,8 @@ export interface VirtualListProps<T> {
   bottomThreshold?: number;
   /** CSS class applied to the outer scrolling container. */
   class?: string;
+  /** Stable test selector for integration and e2e tests. */
+  "data-testid"?: string;
   /** Inline styles applied to the outer scrolling container. */
   style?: JSX.CSSProperties;
   /**
@@ -112,6 +111,7 @@ export function VirtualList<T>(props: VirtualListProps<T>): JSX.Element {
     // Expose imperative scroll APIs to the parent.
     props.handle?.({
       scrollToBottom: () => {
+        wasAtBottom = true;
         outerRef.scrollTop = outerRef.scrollHeight;
       },
       scrollToIndex: (index: number) => {
@@ -201,13 +201,11 @@ export function VirtualList<T>(props: VirtualListProps<T>): JSX.Element {
     const st = outerRef.scrollTop;
     setScrollTop(st);
 
-    const distFromBottom =
-      outerRef.scrollHeight - st - outerRef.clientHeight;
+    const distFromBottom = outerRef.scrollHeight - st - outerRef.clientHeight;
     const atBottom = distFromBottom < THRESHOLD();
 
     if (atBottom && !wasAtBottom) {
       wasAtBottom = true;
-      props.onScrolledToBottom?.();
     } else if (!atBottom && wasAtBottom) {
       wasAtBottom = false;
       props.onScrolledUp?.();
@@ -221,6 +219,7 @@ export function VirtualList<T>(props: VirtualListProps<T>): JSX.Element {
       ref={outerRef}
       onScroll={handleScroll}
       class={props.class}
+      data-testid={props["data-testid"]}
       style={{
         "overflow-y": "auto",
         "overflow-x": "hidden",

--- a/src/stores/build.store.ts
+++ b/src/stores/build.store.ts
@@ -1,5 +1,5 @@
 import { createStore, produce } from "solid-js/store";
-import { createMemo, createSignal } from "solid-js";
+import { createSignal } from "solid-js";
 import type { BuildError, BuildRecord, BuildLine, LogEntry } from "@/bindings";
 import { createLogStore, type LogStore } from "@/stores/log.store";
 import { clearBuildHistory as clearBuildHistoryApi } from "@/lib/tauri-api";
@@ -60,18 +60,29 @@ export const buildLogStore: LogStore = createLogStore({ maxEntries: 10_000 });
 // ── Derived ───────────────────────────────────────────────────────────────────
 
 /** Live elapsed time in milliseconds (only meaningful while running). */
-export const buildDurationMs = createMemo(() => {
+export function buildDurationMs(): number {
   _tick(); // reactive dependency — forces recompute every second while building
   if (buildState.phase !== "running" || !buildState.startedAt) {
     return buildState.durationMs ?? 0;
   }
   return Date.now() - buildState.startedAt;
-});
+}
 
-export const hasErrors = createMemo(() => buildState.errors.length > 0);
-export const hasWarnings = createMemo(() => buildState.warnings.length > 0);
-export const isBuilding = createMemo(() => buildState.phase === "running");
-export const isDeploying = createMemo(() => buildState.deployPhase !== null);
+export function hasErrors(): boolean {
+  return buildState.errors.length > 0;
+}
+
+export function hasWarnings(): boolean {
+  return buildState.warnings.length > 0;
+}
+
+export function isBuilding(): boolean {
+  return buildState.phase === "running";
+}
+
+export function isDeploying(): boolean {
+  return buildState.deployPhase !== null;
+}
 
 // ── Batching ──────────────────────────────────────────────────────────────────
 
@@ -81,10 +92,13 @@ let buildLogIdCounter = 0;
 
 export function lineToLogEntry(line: BuildLine): LogEntry {
   const level: LogEntry["level"] =
-    line.kind === "error" ? "error"
-    : line.kind === "warning" ? "warn"
-    : line.kind === "summary" || line.kind === "info" ? "info"
-    : "debug";
+    line.kind === "error"
+      ? "error"
+      : line.kind === "warning"
+        ? "warn"
+        : line.kind === "summary" || line.kind === "info"
+          ? "info"
+          : "debug";
 
   const message = line.file
     ? `${line.file}:${line.line ?? "?"}:${line.col ?? "?"} — ${line.content}`

--- a/src/stores/device.store.ts
+++ b/src/stores/device.store.ts
@@ -1,5 +1,4 @@
 import { createStore } from "solid-js/store";
-import { createMemo } from "solid-js";
 import type { Device, AvdInfo, SystemImageInfo, DeviceDefinition } from "@/bindings";
 import {
   refreshDevices,
@@ -40,21 +39,23 @@ export { deviceState };
 
 // ── Derived ───────────────────────────────────────────────────────────────────
 
-export const selectedDevice = createMemo(
-  () => deviceState.devices.find((d) => d.serial === deviceState.selectedSerial) ?? null
-);
+export function selectedDevice(): Device | null {
+  return deviceState.devices.find((d) => d.serial === deviceState.selectedSerial) ?? null;
+}
 
-export const onlineDevices = createMemo(() =>
-  deviceState.devices.filter((d) => d.connectionState === "online")
-);
+export function onlineDevices(): Device[] {
+  return deviceState.devices.filter((d) => d.connectionState === "online");
+}
 
-export const deviceCount = createMemo(() => onlineDevices().length);
+export function deviceCount(): number {
+  return onlineDevices().length;
+}
 
 /**
  * Set of AVD names that have a running emulator in the connected device list.
  * Matches by display name (lowercased, spaces normalized) against the emulator model name.
  */
-export const runningAvdNames = createMemo((): Set<string> => {
+export function runningAvdNames(): Set<string> {
   const running = new Set<string>();
   const emulators = deviceState.devices.filter(
     (d) => d.deviceKind === "emulator" && d.connectionState === "online"
@@ -64,14 +65,18 @@ export const runningAvdNames = createMemo((): Set<string> => {
     const normalizedAvd = avd.name.toLowerCase().replace(/[\s_-]/g, "");
     for (const em of emulators) {
       const emModel = (em.model ?? em.name).toLowerCase().replace(/[\s_-]/g, "");
-      if (normalizedAvd === emModel || emModel.includes(normalizedAvd) || normalizedAvd.includes(emModel)) {
+      if (
+        normalizedAvd === emModel ||
+        emModel.includes(normalizedAvd) ||
+        normalizedAvd.includes(emModel)
+      ) {
         running.add(avd.name);
         break;
       }
     }
   }
   return running;
-});
+}
 
 /** Running serial for a given AVD name, if it's currently online. */
 export function serialForAvd(avdName: string): string | null {

--- a/src/stores/health.store.ts
+++ b/src/stores/health.store.ts
@@ -11,7 +11,6 @@
  */
 
 import { createStore } from "solid-js/store";
-import { createMemo } from "solid-js";
 import { settingsState } from "@/stores/settings.store";
 import { runHealthChecks } from "@/lib/tauri-api";
 import type { SystemHealthReport } from "@/bindings";
@@ -78,12 +77,10 @@ export async function refreshHealthChecks(): Promise<void> {
 // ── Reactive checks (derived from stores) ────────────────────────────────────
 
 function openSettingsAction(): void {
-  import("@/components/settings/SettingsPanel").then(({ openSettings }) =>
-    openSettings()
-  );
+  import("@/components/settings/SettingsPanel").then(({ openSettings }) => openSettings());
 }
 
-export const healthChecks = createMemo<HealthCheck[]>(() => {
+export function healthChecks(): HealthCheck[] {
   const report = healthState.systemReport;
   const checks: HealthCheck[] = [];
 
@@ -97,20 +94,18 @@ export const healthChecks = createMemo<HealthCheck[]>(() => {
     status: !sdkPath
       ? "error"
       : sdkValid === false
-      ? "warning"
-      : sdkValid === true
-      ? "ok"
-      : "loading",
+        ? "warning"
+        : sdkValid === true
+          ? "ok"
+          : "loading",
     detail: !sdkPath
       ? "ANDROID_HOME not configured — Gradle cannot find the Android SDK"
       : sdkValid === false
-      ? `Path set but SDK not found at: ${sdkPath}`
-      : sdkValid === true
-      ? sdkPath
-      : "Checking…",
-    fix: !sdkPath
-      ? { label: "Open Settings", action: openSettingsAction }
-      : undefined,
+        ? `Path set but SDK not found at: ${sdkPath}`
+        : sdkValid === true
+          ? sdkPath
+          : "Checking…",
+    fix: !sdkPath ? { label: "Open Settings", action: openSettingsAction } : undefined,
   });
 
   // ── 2. ADB ──────────────────────────────────────────────────────────────────
@@ -120,23 +115,16 @@ export const healthChecks = createMemo<HealthCheck[]>(() => {
     id: "adb",
     category: "environment",
     name: "ADB (Android Debug Bridge)",
-    status: adbFound === undefined
-      ? "loading"
-      : adbFound
-      ? "ok"
-      : !sdkPath
-      ? "skip"
-      : "warning",
-    detail: adbFound === true
-      ? adbVersion ?? "Found in platform-tools"
-      : adbFound === false
-      ? "adb not found — device operations will not work"
-      : !sdkPath
-      ? "No SDK configured"
-      : "Checking…",
-    fix: adbFound === false
-      ? { label: "Open Settings", action: openSettingsAction }
-      : undefined,
+    status: adbFound === undefined ? "loading" : adbFound ? "ok" : !sdkPath ? "skip" : "warning",
+    detail:
+      adbFound === true
+        ? (adbVersion ?? "Found in platform-tools")
+        : adbFound === false
+          ? "adb not found — device operations will not work"
+          : !sdkPath
+            ? "No SDK configured"
+            : "Checking…",
+    fix: adbFound === false ? { label: "Open Settings", action: openSettingsAction } : undefined,
   });
 
   // ── 3. Emulator ─────────────────────────────────────────────────────────────
@@ -145,23 +133,24 @@ export const healthChecks = createMemo<HealthCheck[]>(() => {
     id: "emulator",
     category: "environment",
     name: "Android Emulator",
-    status: emulatorFound === undefined
-      ? "loading"
-      : emulatorFound
-      ? "ok"
-      : !sdkPath
-      ? "skip"
-      : "warning",
-    detail: emulatorFound === true
-      ? "Found in $ANDROID_HOME/emulator/"
-      : emulatorFound === false
-      ? "Emulator binary not found — cannot launch AVDs"
-      : !sdkPath
-      ? "No SDK configured"
-      : "Checking…",
-    fix: emulatorFound === false
-      ? { label: "Open Settings", action: openSettingsAction }
-      : undefined,
+    status:
+      emulatorFound === undefined
+        ? "loading"
+        : emulatorFound
+          ? "ok"
+          : !sdkPath
+            ? "skip"
+            : "warning",
+    detail:
+      emulatorFound === true
+        ? "Found in $ANDROID_HOME/emulator/"
+        : emulatorFound === false
+          ? "Emulator binary not found — cannot launch AVDs"
+          : !sdkPath
+            ? "No SDK configured"
+            : "Checking…",
+    fix:
+      emulatorFound === false ? { label: "Open Settings", action: openSettingsAction } : undefined,
   });
 
   // ── 3b. Android Studio CLI ──────────────────────────────────────────────────
@@ -170,16 +159,13 @@ export const healthChecks = createMemo<HealthCheck[]>(() => {
     id: "studio-command",
     category: "environment",
     name: "Android Studio CLI (studio)",
-    status: studioFound === undefined
-      ? "loading"
-      : studioFound
-      ? "ok"
-      : "warning",
-    detail: studioFound === true
-      ? "studio command found — crash stack frames can be opened directly"
-      : studioFound === false
-      ? "studio command not found — add Android Studio's MacOS bin dir to $PATH to enable jump-to-line"
-      : "Checking…",
+    status: studioFound === undefined ? "loading" : studioFound ? "ok" : "warning",
+    detail:
+      studioFound === true
+        ? "studio command found — crash stack frames can be opened directly"
+        : studioFound === false
+          ? "studio command not found — add Android Studio's MacOS bin dir to $PATH to enable jump-to-line"
+          : "Checking…",
   });
 
   // ── 4. Java / JDK ──────────────────────────────────────────────────────────
@@ -190,23 +176,20 @@ export const healthChecks = createMemo<HealthCheck[]>(() => {
     id: "java",
     category: "environment",
     name: "Java / JDK",
-    status: javaFound === false
-      ? "error"
-      : javaFound === true
-      ? "ok"
-      : !javaHome
-      ? "warning"
-      : "loading",
-    detail: javaFound === true
-      ? javaVersion ?? `Found at ${report?.javaBinUsed}`
-      : javaFound === false
-      ? `Not found at: ${report?.javaBinUsed ?? "java"} — Gradle compilation may fail`
-      : !javaHome
-      ? "Not configured — Gradle may use an incompatible JVM"
-      : "Checking…",
-    fix: javaFound === false || !javaHome
-      ? { label: "Open Settings", action: openSettingsAction }
-      : undefined,
+    status:
+      javaFound === false ? "error" : javaFound === true ? "ok" : !javaHome ? "warning" : "loading",
+    detail:
+      javaFound === true
+        ? (javaVersion ?? `Found at ${report?.javaBinUsed}`)
+        : javaFound === false
+          ? `Not found at: ${report?.javaBinUsed ?? "java"} — Gradle compilation may fail`
+          : !javaHome
+            ? "Not configured — Gradle may use an incompatible JVM"
+            : "Checking…",
+    fix:
+      javaFound === false || !javaHome
+        ? { label: "Open Settings", action: openSettingsAction }
+        : undefined,
   });
 
   // ── 5. App Directory ────────────────────────────────────────────────────────
@@ -215,33 +198,32 @@ export const healthChecks = createMemo<HealthCheck[]>(() => {
     id: "app-dir",
     category: "system",
     name: "App Data Directory",
-    status:
-      appDirOk === undefined ? "loading" : appDirOk ? "ok" : "error",
+    status: appDirOk === undefined ? "loading" : appDirOk ? "ok" : "error",
     detail:
       appDirOk === undefined
         ? "Checking ~/.keynobi/…"
         : appDirOk
-        ? "~/.keynobi/ is writable"
-        : "Cannot create ~/.keynobi/ — check file permissions",
+          ? "~/.keynobi/ is writable"
+          : "Cannot create ~/.keynobi/ — check file permissions",
   });
 
   return checks;
-});
+}
 
 // ── Overall health ────────────────────────────────────────────────────────────
 
-export const overallHealth = createMemo<OverallHealth>(() => {
+export function overallHealth(): OverallHealth {
   if (healthState.isRunning) return "loading";
   const checks = healthChecks();
   const active = checks.filter((c) => c.status !== "skip");
   if (active.some((c) => c.status === "error")) return "error";
   if (active.some((c) => c.status === "warning" || c.status === "loading")) return "warning";
   return "ok";
-});
+}
 
-export const healthSummary = createMemo(() => {
+export function healthSummary(): { ok: number; total: number } {
   const checks = healthChecks().filter((c) => c.status !== "skip");
   const ok = checks.filter((c) => c.status === "ok").length;
   const total = checks.length;
   return { ok, total };
-});
+}

--- a/src/stores/settings.store.test.ts
+++ b/src/stores/settings.store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import * as tauriApi from "@/lib/tauri-api";
 import {
+  applyAppearanceSettings,
   settingsState,
   updateSetting,
   loadSettings,
@@ -40,6 +41,10 @@ describe("settings.store", () => {
     expect(d.build.autoScrollBuildLog).toBe(true);
   });
 
+  it("has a separate default font size for Logcat output", () => {
+    expect(getDefaults().logcat.outputFontSize).toBe(11);
+  });
+
   it("updateSetting changes appearance settings", () => {
     updateSetting("appearance", "uiFontSize", 14);
     expect(settingsState.appearance.uiFontSize).toBe(14);
@@ -68,6 +73,28 @@ describe("settings.store", () => {
     updateSetting("android", "sdkPath", "/custom/sdk");
     expect(settingsState.android.sdkPath).toBe("/custom/sdk");
     updateSetting("android", "sdkPath", null);
+  });
+
+  it("updateSetting changes Logcat output font size", () => {
+    updateSetting("logcat", "outputFontSize", 13);
+    expect(settingsState.logcat.outputFontSize).toBe(13);
+    updateSetting("logcat", "outputFontSize", 11);
+  });
+
+  it("applies UI and Logcat font size CSS variables", () => {
+    updateSetting("appearance", "uiFontSize", 15);
+    updateSetting("logcat", "outputFontSize", 13);
+
+    applyAppearanceSettings();
+
+    expect(document.documentElement.style.getPropertyValue("--font-size-ui")).toBe("15px");
+    expect(document.documentElement.style.getPropertyValue("--font-size-logcat-output")).toBe(
+      "13px"
+    );
+
+    updateSetting("appearance", "uiFontSize", 12);
+    updateSetting("logcat", "outputFontSize", 11);
+    applyAppearanceSettings();
   });
 
   it("getDefaults returns the same constant reference", () => {

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -1,5 +1,4 @@
 import { createStore } from "solid-js/store";
-import { createEffect } from "solid-js";
 import {
   getSettings,
   saveSettings as saveSettingsIpc,
@@ -39,6 +38,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   logcat: {
     autoStart: true,
     autoScrollToEnd: true,
+    outputFontSize: 11,
     maxUiLines: 20_000,
     ringMaxEntries: 50_000,
   },
@@ -123,6 +123,10 @@ export function getDefaults(): AppSettings {
   return DEFAULT_SETTINGS;
 }
 
+export function logcatRowHeightForFontSize(fontSize: number): number {
+  return Math.max(20, fontSize + 9);
+}
+
 // Listen for settings corruption detected by the Rust backend on startup.
 // Guard with typeof window to avoid running in test environments.
 if (typeof window !== "undefined") {
@@ -136,9 +140,23 @@ if (typeof window !== "undefined") {
   });
 }
 
-// Apply CSS variable effects when appearance settings change
-if (typeof document !== "undefined") {
-  createEffect(() => {
-    document.documentElement.style.setProperty("--font-size-ui", `${settingsState.appearance.uiFontSize}px`);
-  });
+export function applyAppearanceSettings(): void {
+  if (typeof document === "undefined") return;
+  const uiFontSize = settingsState.appearance.uiFontSize;
+  const logcatFontSize = settingsState.logcat.outputFontSize;
+  document.documentElement.style.setProperty("--font-size-ui", `${uiFontSize}px`);
+  document.documentElement.style.setProperty(
+    "--font-size-ui-xs",
+    `${Math.max(8, uiFontSize - 2)}px`
+  );
+  document.documentElement.style.setProperty(
+    "--font-size-ui-sm",
+    `${Math.max(9, uiFontSize - 1)}px`
+  );
+  document.documentElement.style.setProperty("--font-size-ui-lg", `${uiFontSize + 2}px`);
+  document.documentElement.style.setProperty("--font-size-logcat-output", `${logcatFontSize}px`);
+  document.documentElement.style.setProperty(
+    "--logcat-row-height",
+    `${logcatRowHeightForFontSize(logcatFontSize)}px`
+  );
 }

--- a/src/stores/variant.store.ts
+++ b/src/stores/variant.store.ts
@@ -1,5 +1,4 @@
 import { createStore } from "solid-js/store";
-import { createMemo } from "solid-js";
 import type { BuildVariant, VariantList } from "@/bindings";
 import { getVariantsPreview, getVariantsFromGradle, setActiveVariant } from "@/lib/tauri-api";
 import { projectState } from "@/stores/project.store";
@@ -56,11 +55,13 @@ export { variantState };
 
 // ── Derived ───────────────────────────────────────────────────────────────────
 
-export const activeVariantObj = createMemo(() =>
-  variantState.variants.find((v) => v.name === variantState.activeVariant) ?? null
-);
+export function activeVariantObj(): BuildVariant | null {
+  return variantState.variants.find((v) => v.name === variantState.activeVariant) ?? null;
+}
 
-export const hasVariants = createMemo(() => variantState.variants.length > 0);
+export function hasVariants(): boolean {
+  return variantState.variants.length > 0;
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -75,10 +76,7 @@ function resolveActive(list: VariantList, currentActive: string | null): string 
     return currentActive;
   }
   // Android Studio–aligned default from Gradle (`isDefault`, `.idea`, heuristics).
-  if (
-    list.defaultVariant &&
-    list.variants.some((v) => v.name === list.defaultVariant)
-  ) {
+  if (list.defaultVariant && list.variants.some((v) => v.name === list.defaultVariant)) {
     return list.defaultVariant;
   }
   // Fall back to the first variant.
@@ -119,7 +117,13 @@ export function loadVariants(opts?: { force?: boolean }): Promise<void> {
 }
 
 async function runLoadVariants(): Promise<void> {
-  setVariantState({ loading: true, gradleLoading: true, error: null, gradleError: null, fromGradle: false });
+  setVariantState({
+    loading: true,
+    gradleLoading: true,
+    error: null,
+    gradleError: null,
+    fromGradle: false,
+  });
 
   // ── Phase 1: instant preview from static parse ─────────────────────────────
   try {
@@ -151,7 +155,7 @@ async function runLoadVariants(): Promise<void> {
           active: null,
           defaultVariant: cached.defaultVariant,
         },
-        variantState.activeVariant,
+        variantState.activeVariant
       ),
       fromGradle: true,
       gradleLoading: false,
@@ -178,7 +182,7 @@ async function runLoadVariants(): Promise<void> {
       error: null,
     });
   } catch (e) {
-    const msg = typeof e === "string" ? e : (e as Error).message ?? String(e);
+    const msg = typeof e === "string" ? e : ((e as Error).message ?? String(e));
     setVariantState({
       gradleLoading: false,
       gradleError: msg,

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -56,6 +56,11 @@
 
   /* Sizes */
   --font-size-ui: 12px;
+  --font-size-ui-xs: 10px;
+  --font-size-ui-sm: 11px;
+  --font-size-ui-lg: 14px;
+  --font-size-logcat-output: 11px;
+  --logcat-row-height: 20px;
   --titlebar-height: 38px;
   --statusbar-height: 24px;
   --sidebar-icon-width: 48px;

--- a/src/test/factories/settings.ts
+++ b/src/test/factories/settings.ts
@@ -28,6 +28,7 @@ export function makeSettings(overrides: Partial<AppSettings> = {}): AppSettings 
     logcat: {
       autoStart: false,
       autoScrollToEnd: true,
+      outputFontSize: 11,
       maxUiLines: 5000,
       ringMaxEntries: 50000,
     },

--- a/src/test/mock-backend/logcat.ts
+++ b/src/test/mock-backend/logcat.ts
@@ -56,6 +56,7 @@ export const sampleEntries: ProcessedEntry[] = [
     jsonBody: null,
   },
 ];
+let storedEntries: ProcessedEntry[] = [...sampleEntries];
 
 type LogcatEntriesArgs = {
   minLevel?: string | null;
@@ -128,7 +129,7 @@ export function logcatHandlers(): Record<string, (args: unknown) => unknown> {
   return {
     start_logcat: () => {
       logcatRunning = true;
-      triggerEvent("logcat:entries", filterEntries(sampleEntries, activeFilter));
+      triggerEvent("logcat:entries", filterEntries(storedEntries, activeFilter));
       streamInterval = setInterval(() => {
         const entry = {
           id: nextId++,
@@ -157,23 +158,30 @@ export function logcatHandlers(): Record<string, (args: unknown) => unknown> {
       }
     },
     clear_logcat: () => {
+      storedEntries = [];
       triggerEvent("logcat:cleared", undefined);
     },
-    get_logcat_entries: (args: unknown) => filterEntries(sampleEntries, argsToFilter(args)),
+    get_logcat_entries: (args: unknown) => filterEntries(storedEntries, argsToFilter(args)),
     get_logcat_status: () => logcatRunning,
     list_logcat_packages: () => ["com.example.mockapp"],
     set_logcat_filter: (args: unknown) => {
       const { filterSpec } = args as { filterSpec?: LogcatFilterSpec };
       activeFilter = filterSpec ?? emptyFilter();
     },
+    __e2e_append_logcat_entries: (args: unknown) => {
+      const { entries } = args as { entries?: ProcessedEntry[] };
+      const nextEntries = entries ?? [];
+      storedEntries = [...storedEntries, ...nextEntries];
+      triggerEvent("logcat:entries", filterEntries(nextEntries, activeFilter));
+    },
     get_logcat_stats: (): LogStats => ({
-      totalIngested: BigInt(3),
+      totalIngested: BigInt(storedEntries.length),
       countsByLevel: [BigInt(0), BigInt(1), BigInt(1), BigInt(0), BigInt(1), BigInt(0), BigInt(0)],
       crashCount: BigInt(0),
       jsonCount: BigInt(0),
       packagesSeen: 1,
       bufferUsagePct: 0.006,
-      bufferEntryCount: BigInt(3),
+      bufferEntryCount: BigInt(storedEntries.length),
     }),
   };
 }

--- a/src/test/mock-backend/settings.ts
+++ b/src/test/mock-backend/settings.ts
@@ -27,6 +27,7 @@ export const defaultSettings: AppSettings = {
   logcat: {
     autoStart: false,
     autoScrollToEnd: true,
+    outputFontSize: 11,
     maxUiLines: 5000,
     ringMaxEntries: 50000,
   },


### PR DESCRIPTION
## Summary

improvements and fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Logcat UX and stability: adds an adjustable Logcat output font size, fixes follow‑tail behavior and click‑to‑filter detail opening, and closes dropdowns on window blur. Also removes Solid owner warnings and adds tests to prevent regressions.

- **New Features**
  - Added “Logcat Output Font Size” setting (9–16px, default 11) with dynamic row height; persisted in backend and exposed via IPC.
  - Renamed “UI Font Size” to “System Font Size” and apply UI/Logcat font CSS variables on app load for consistent sizing.

- **Bug Fixes**
  - Follow‑tail stays paused after scrolling or selection until “Scroll to end”; virtual list no longer re‑enables auto‑scroll when manually returning to bottom.
  - Clicking a filtered row reliably opens its detail panel; package and preset menus close on window blur or tab hide.
  - Eliminated SolidJS owner warnings by avoiding module‑scope computations; added smoke/regression tests and doc guidance to prevent recurrence.

<sup>Written for commit ad7d698f4e5377156e9cf85cebd590095654ff13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

