### PR TITLE
log improvements

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -117,7 +117,7 @@ Use **Log Mode** from the title bar when logs are the main task. It hides the pr
 
 - **Start / Stop**: begin or end streaming.
 - **Pause / Resume**: pause display updates without losing buffered data.
-- **Jump to end**: resume follow-tail and clear row/detail selection.
+- **Jump to end**: resume follow-tail, apply any logs that arrived while you were reading, and clear row/detail selection.
 - **Clear**: clear displayed entries and the in-memory buffer.
 - **Export**: save filtered entries to a `.log` file.
 - **Filters**: use quick filters or saved filters.
@@ -148,7 +148,8 @@ Press **Enter** to commit a typed condition as a filter pill. Use **+ AND** and 
 - ANRs get an ANR badge.
 - JSON messages show a `{}` badge; open it to view formatted JSON.
 - Arrow keys move the selected row when focus is not in the query bar.
-- Scrolling away from the end or selecting a row pauses follow-tail until you use **Jump to end**.
+- Scrolling away from the end or selecting a row enters read mode: the visible list is frozen so the row you are reading cannot be pushed out by new logs or UI-buffer overflow.
+- While in read mode, new logs continue to be captured in the background. The **Jump to end** button shows how many matching logs arrived; use it to apply them and resume follow-tail.
 - In **Entry Detail**, click a tag, package, level, PID, TID, time, or message value to add it to the query bar as an **AND** or **OR** filter. Select part of the message before clicking to filter by only that selected text.
 
 Logcat keeps a bounded ring buffer. Configure the ring size, max visible lines, and Logcat output font size under **Settings -> Logcat**.

--- a/e2e/smoke/logcat-regressions.spec.ts
+++ b/e2e/smoke/logcat-regressions.spec.ts
@@ -95,9 +95,10 @@ test("logcat follow-tail stays paused after manual scrolling until Jump to end",
   await page.waitForTimeout(100);
   const pausedAfterManualBottom = await scrollState(scroller);
   expect(pausedAfterManualBottom.scrollTop).toBe(manualBottomTop);
-  expect(pausedAfterManualBottom.maxScrollTop).toBeGreaterThan(manualBottomTop);
+  expect(pausedAfterManualBottom.maxScrollTop).toBe(manualBottomTop);
+  await expect(page.getByText("2 new")).toBeVisible({ timeout: 5_000 });
 
-  await page.getByTitle("Scroll to end").click();
+  await page.getByTitle("2 new logs available - Jump to end").click();
   await page.waitForFunction(() => {
     const element = document.querySelector('[data-testid="logcat-virtual-list"]');
     if (!(element instanceof HTMLElement)) return false;
@@ -135,6 +136,31 @@ test("logcat detail panel opens for the clicked filtered row", async ({ page }) 
   await page.getByText("Beta target message").click();
 
   await expect(page.getByTitle("Filter by message")).toHaveText("Beta target message");
+});
+
+test("logcat selected row stays frozen while the live buffer overflows", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, makeScrollEntries(0, 5000));
+
+  const scroller = page.getByTestId("logcat-virtual-list");
+  await expect(scroller).toBeVisible({ timeout: 5_000 });
+  await scroller.evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+
+  await expect(page.getByText("Auto row 000")).toBeVisible({ timeout: 5_000 });
+  await page.getByText("Auto row 000").click();
+
+  await pushLogcatEntries(page, makeScrollEntries(5000, 120));
+
+  await expect(scroller.getByText("Auto row 000")).toBeVisible({ timeout: 5_000 });
+  await expect(scroller.getByText("Auto row 5000")).not.toBeVisible();
+  await expect(page.getByText("120 new")).toBeVisible({ timeout: 5_000 });
+
+  await page.getByTitle("120 new logs available - Jump to end").click();
+  await expect(scroller.getByText("Auto row 5119")).toBeVisible({ timeout: 5_000 });
+  await expect(scroller.getByText("Auto row 000")).not.toBeVisible();
 });
 
 test("logcat package filter dropdown closes when the window loses focus", async ({ page }) => {

--- a/e2e/smoke/logcat-regressions.spec.ts
+++ b/e2e/smoke/logcat-regressions.spec.ts
@@ -95,6 +95,8 @@ test("logcat follow-tail stays paused after manual scrolling until Jump to end",
   await page.waitForTimeout(100);
   const pausedAfterManualBottom = await scrollState(scroller);
   expect(pausedAfterManualBottom.scrollTop).toBe(manualBottomTop);
+  // Read mode freezes the rendered list, so incoming logs do not increase scrollHeight
+  // until Jump to end applies them.
   expect(pausedAfterManualBottom.maxScrollTop).toBe(manualBottomTop);
   await expect(page.getByText("2 new")).toBeVisible({ timeout: 5_000 });
 
@@ -139,6 +141,19 @@ test("logcat detail panel opens for the clicked filtered row", async ({ page }) 
 });
 
 test("logcat selected row stays frozen while the live buffer overflows", async ({ page }) => {
+  await page.evaluate(() => {
+    window.__keynobi_e2e_settings_overrides = {
+      logcat: {
+        autoStart: false,
+        autoScrollToEnd: true,
+        outputFontSize: 11,
+        maxUiLines: 5000,
+        ringMaxEntries: 50000,
+      },
+    };
+  });
+  await page.reload();
+  await page.waitForFunction(() => typeof window.__e2e__ !== "undefined", { timeout: 10_000 });
   await openLogcatWithEmptyEntries(page);
   await pushLogcatEntries(page, makeScrollEntries(0, 5000));
 
@@ -161,6 +176,13 @@ test("logcat selected row stays frozen while the live buffer overflows", async (
   await page.getByTitle("120 new logs available - Jump to end").click();
   await expect(scroller.getByText("Auto row 5119")).toBeVisible({ timeout: 5_000 });
   await expect(scroller.getByText("Auto row 000")).not.toBeVisible();
+
+  await scroller.evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+  await expect(scroller.getByText("Auto row 120")).toBeVisible({ timeout: 5_000 });
+  await expect(scroller.getByText("Auto row 119")).not.toBeVisible();
 });
 
 test("logcat package filter dropdown closes when the window loses focus", async ({ page }) => {

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -238,7 +238,9 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
 
     emitLogcatEntries([incomingEntry]);
 
-    expect(screen.getAllByText("Selected row should stay visible").length).toBeGreaterThan(0);
+    const virtualList = screen.getByTestId("logcat-virtual-list");
+    expect(virtualList.textContent).toContain("Selected row should stay visible");
+    expect(virtualList.textContent).not.toContain("Incoming row should wait");
     expect(screen.queryByText("Incoming row should wait")).toBeNull();
     expect(await screen.findByText("1 new")).not.toBeNull();
 

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -74,8 +74,11 @@ function filterEntries(entries: ProcessedEntry[], spec: LogcatFilterSpec): Proce
   });
 }
 
-function installLogcatPanelMocks(entries: ProcessedEntry[]): void {
+function installLogcatPanelMocks(entries: ProcessedEntry[]): {
+  emitLogcatEntries: (entries: ProcessedEntry[]) => void;
+} {
   let activeFilter = emptyFilter();
+  const listeners = new Map<string, (event: { payload: unknown }) => void>();
 
   vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
     switch (command) {
@@ -103,7 +106,18 @@ function installLogcatPanelMocks(entries: ProcessedEntry[]): void {
     }
   });
 
-  vi.mocked(listen).mockResolvedValue(() => {});
+  vi.mocked(listen).mockImplementation(async (event, callback) => {
+    listeners.set(String(event), callback as (event: { payload: unknown }) => void);
+    return () => {
+      listeners.delete(String(event));
+    };
+  });
+
+  return {
+    emitLogcatEntries(nextEntries: ProcessedEntry[]) {
+      listeners.get("logcat:entries")?.({ payload: filterEntries(nextEntries, activeFilter) });
+    },
+  };
 }
 
 describe("LogcatPanel Entry Detail click-to-filter integration", () => {
@@ -199,5 +213,37 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
     fireEvent.click(screen.getByText("Beta target message"));
 
     expect(screen.getByTitle("Filter by message").textContent).toBe("Beta target message");
+  });
+
+  it("freezes the visible log list after selecting a row until jumping to the end", async () => {
+    const selectedEntry = {
+      ...BASE_ENTRY,
+      id: 20n,
+      tag: "SelectedTag",
+      message: "Selected row should stay visible",
+    } satisfies ProcessedEntry;
+    const incomingEntry = {
+      ...BASE_ENTRY,
+      id: 21n,
+      tag: "IncomingTag",
+      message: "Incoming row should wait",
+    } satisfies ProcessedEntry;
+    const { emitLogcatEntries } = installLogcatPanelMocks([selectedEntry]);
+    render(() => <LogcatPanel />);
+
+    await waitFor(() =>
+      expect(vi.mocked(listen)).toHaveBeenCalledWith("logcat:entries", expect.any(Function))
+    );
+    fireEvent.click(await screen.findByText("Selected row should stay visible"));
+
+    emitLogcatEntries([incomingEntry]);
+
+    expect(screen.getAllByText("Selected row should stay visible").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Incoming row should wait")).toBeNull();
+    expect(await screen.findByText("1 new")).not.toBeNull();
+
+    fireEvent.click(screen.getByTitle("1 new log available - Jump to end"));
+
+    expect(await screen.findByText("Incoming row should wait")).not.toBeNull();
   });
 });

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -45,7 +45,11 @@ import { buildState } from "@/stores/build.store";
 import { LogEntryDetailPanel } from "./LogEntryDetailPanel";
 import { getLastActiveQuery, setLastActiveQuery } from "@/lib/logcat-filter-storage";
 import { uiState } from "@/stores/ui.store";
-import { clampSelectionIndices, nextSelectableIndex } from "./logcat-selection-nav";
+import {
+  clampSelectionIndices,
+  nextSelectableIndex,
+  shiftSelectionAfterFrontDrop,
+} from "./logcat-selection-nav";
 import { formatLogcatToolbarCount } from "./logcat-toolbar-count";
 import { clampLogcatMaxUiLines, clampLogcatRingMaxEntries } from "@/lib/logcat-ui-lines";
 import { effectiveLogcatFollowTail } from "@/lib/logcat-follow-tail";
@@ -96,6 +100,11 @@ export function LogcatPanel(): JSX.Element {
   let _queryDebounce: ReturnType<typeof setTimeout> | undefined;
 
   function updateQuery(q: string) {
+    exitReadMode();
+    setSelectionAnchor(null);
+    setSelectionEnd(null);
+    setSelectedJsonEntry(null);
+    setSelectedDetailEntry(null);
     setQuery(q);
     clearTimeout(_queryDebounce);
     _queryDebounce = setTimeout(() => setDebouncedQuery(q), 150);
@@ -106,6 +115,10 @@ export function LogcatPanel(): JSX.Element {
   const rowHeight = createMemo(() =>
     logcatRowHeightForFontSize(settingsState.logcat.outputFontSize)
   );
+  const [frozenEntries, setFrozenEntries] = createSignal<LogcatEntry[] | null>(null, {
+    equals: false,
+  });
+  const [pendingNewEntries, setPendingNewEntries] = createSignal(0);
   let virtualListRef: VirtualListHandle | undefined;
   const [paused, setPaused] = createSignal(false);
   const [restarting, setRestarting] = createSignal(false);
@@ -126,6 +139,7 @@ export function LogcatPanel(): JSX.Element {
       autoScroll: autoScroll(),
       selectionAnchor: selectionAnchor(),
       selectedJsonEntry: selectedJsonEntry(),
+      selectedDetailEntry: selectedDetailEntry(),
     })
   );
 
@@ -175,9 +189,33 @@ export function LogcatPanel(): JSX.Element {
     { equals: false }
   );
 
+  const displayedEntries = createMemo(() => frozenEntries() ?? filteredEntries());
+  const readMode = createMemo(() => frozenEntries() !== null);
+
+  function enterReadMode(): void {
+    if (frozenEntries() === null) {
+      setFrozenEntries(filteredEntries().slice());
+      setPendingNewEntries(0);
+    }
+    setAutoScroll(false);
+  }
+
+  function exitReadMode(): void {
+    setFrozenEntries(null);
+    setPendingNewEntries(0);
+  }
+
+  function countVisibleIncoming(entries: LogcatEntry[]): number {
+    if (entries.length === 0) return 0;
+    if (!needsFrontendFilter()) return entries.length;
+    const groups = parsedGroups();
+    const currentNow = hasAgeFilter() ? now() : Date.now();
+    return entries.filter((entry) => matchesFilterGroups(entry, groups, currentNow)).length;
+  }
+
   const filteredEntryIndexById = createMemo(() => {
     const indexById = new Map<LogcatEntry["id"], number>();
-    filteredEntries().forEach((entry, index) => {
+    displayedEntries().forEach((entry, index) => {
       indexById.set(entry.id, index);
     });
     return indexById;
@@ -195,6 +233,14 @@ export function LogcatPanel(): JSX.Element {
   // When frontend tokens are active filteredEntries may differ from the store,
   // so we fall back to scanning filteredEntries() (the set is already small).
   const crashIndices = createMemo(() => {
+    const frozen = frozenEntries();
+    if (frozen !== null) {
+      const indices: number[] = [];
+      frozen.forEach((entry, index) => {
+        if (entry.isCrash) indices.push(index);
+      });
+      return indices;
+    }
     if (!needsFrontendFilter()) {
       // Fast path: no frontend filtering, use the incremental index.
       return logcatState.crashIndicesFull;
@@ -346,7 +392,7 @@ export function LogcatPanel(): JSX.Element {
         const excess = len - cap;
         if (excess > 0) {
           replaceLogcatEntries(cap === 0 ? [] : logcatState.entries.slice(-cap));
-          if (!followTailForList()) {
+          if (!readMode() && !followTailForList()) {
             setScrollCompensate((c) => c + excess * rowHeight());
           }
         }
@@ -410,7 +456,13 @@ export function LogcatPanel(): JSX.Element {
     unlistenEntries = await listenLogcatEntries((newEntries) => {
       if (paused()) return;
       const dropped = appendLogcatEntries(newEntries, maxUiLinesCap());
-      if (dropped > 0 && !followTailForList()) {
+      if (readMode()) {
+        const visibleNew = countVisibleIncoming(newEntries);
+        if (visibleNew > 0) setPendingNewEntries((count) => count + visibleNew);
+      } else if (dropped > 0 && !followTailForList()) {
+        const shifted = shiftSelectionAfterFrontDrop(selectionAnchor(), selectionEnd(), dropped);
+        setSelectionAnchor(shifted.anchor);
+        setSelectionEnd(shifted.end);
         setScrollCompensate((c) => c + dropped * rowHeight());
       }
 
@@ -419,6 +471,7 @@ export function LogcatPanel(): JSX.Element {
     });
 
     unlistenCleared = await listenLogcatCleared(() => {
+      exitReadMode();
       clearLogcatEntries();
       suggestions.clear();
       setAutoScroll(true);
@@ -536,7 +589,7 @@ export function LogcatPanel(): JSX.Element {
     const next = Math.max(0, Math.min(indices.length - 1, crashCursor() + direction));
     setCrashCursor(next);
     setJumpTarget(indices[next]);
-    setAutoScroll(false);
+    enterReadMode();
   }
 
   function jumpToLastCrash() {
@@ -545,11 +598,11 @@ export function LogcatPanel(): JSX.Element {
     const last = indices.length - 1;
     setCrashCursor(last);
     setJumpTarget(indices[last]);
-    setAutoScroll(false);
+    enterReadMode();
   }
 
   createEffect(() => {
-    filteredEntries();
+    displayedEntries();
     setCrashCursor((c) => Math.min(c, Math.max(0, crashIndices().length - 1)));
   });
 
@@ -572,6 +625,7 @@ export function LogcatPanel(): JSX.Element {
     } else {
       setSelectionAnchor(idx);
       setSelectionEnd(null);
+      enterReadMode();
       // Plain click (no shift) — toggle detail panel
       setSelectedDetailEntry((prev) => (prev?.id === entry.id ? null : entry));
     }
@@ -589,7 +643,7 @@ export function LogcatPanel(): JSX.Element {
     const range = getSelectionRange();
     if (!range) return;
     const [lo, hi] = range;
-    const text = filteredEntries()
+    const text = displayedEntries()
       .slice(lo, hi + 1)
       .map(formatEntry)
       .join("\n");
@@ -608,9 +662,9 @@ export function LogcatPanel(): JSX.Element {
         defaultPath: "logcat.log",
       });
       if (!path) return;
-      const text = filteredEntries().map(formatEntry).join("\n");
+      const text = displayedEntries().map(formatEntry).join("\n");
       await writeTextFile(path, text);
-      showToast(`Exported ${filteredEntries().length} entries`, "success");
+      showToast(`Exported ${displayedEntries().length} entries`, "success");
     } catch (e) {
       showToast(`Export failed: ${formatError(e)}`, "error");
     }
@@ -623,9 +677,9 @@ export function LogcatPanel(): JSX.Element {
     updateQuery(q.trimEnd() ? q.trimEnd() + " " : "");
   }
 
-  // Clamp row selection when the filtered list shrinks or clears; drop detail if the entry vanished.
+  // Clamp row selection when the displayed list shrinks or clears; drop detail if the entry vanished.
   createEffect(() => {
-    const entries = filteredEntries();
+    const entries = displayedEntries();
     const n = entries.length;
     const anchor = selectionAnchor();
     const end = selectionEnd();
@@ -655,7 +709,7 @@ export function LogcatPanel(): JSX.Element {
       if (isPaletteOpen()) return;
       if (isLogcatTypingTarget(e.target)) return;
 
-      const entries = filteredEntries();
+      const entries = displayedEntries();
       if (entries.length === 0) return;
 
       const direction: 1 | -1 = e.key === "ArrowDown" ? 1 : -1;
@@ -666,7 +720,7 @@ export function LogcatPanel(): JSX.Element {
       setSelectionEnd(null);
       setSelectionAnchor(nextIdx);
       setSelectedDetailEntry(entries[nextIdx]);
-      setAutoScroll(false);
+      enterReadMode();
       virtualListRef?.scrollToIndex(nextIdx);
     }
 
@@ -677,10 +731,11 @@ export function LogcatPanel(): JSX.Element {
   function handleJsonBadgeClick(e: MouseEvent, entry: LogcatEntry) {
     e.stopPropagation();
     setSelectedJsonEntry((prev: LogcatEntry | null) => (prev?.id === entry.id ? null : entry));
-    setAutoScroll(false);
+    enterReadMode();
   }
 
   function handleScrollToEnd() {
+    exitReadMode();
     setSelectionAnchor(null);
     setSelectionEnd(null);
     setSelectedJsonEntry(null);
@@ -695,7 +750,7 @@ export function LogcatPanel(): JSX.Element {
   const toolbarCount = createMemo(() =>
     formatLogcatToolbarCount({
       queryActive: isFiltered(),
-      visible: filteredEntries().length,
+      visible: displayedEntries().length,
       ringTotal: logcatState.ringBufferTotal,
     })
   );
@@ -725,6 +780,7 @@ export function LogcatPanel(): JSX.Element {
         crashes={crashes()}
         selectedCount={selCount()}
         autoScroll={autoScroll()}
+        newEntriesCount={pendingNewEntries()}
         toolbarCount={toolbarCount()}
         onStart={handleStart}
         onStop={handleStop}
@@ -791,13 +847,13 @@ export function LogcatPanel(): JSX.Element {
       {/* ── Virtualised log list ──────────────────────────────────────────── */}
       <Show when={logcatState.entries.length > 0}>
         <VirtualList
-          items={filteredEntries()}
+          items={displayedEntries()}
           rowHeight={rowHeight()}
           autoScroll={followTailForList()}
           data-testid="logcat-virtual-list"
           scrollCompensate={scrollCompensate()}
           jumpTo={jumpTarget()}
-          onScrolledUp={() => setAutoScroll(false)}
+          onScrolledUp={enterReadMode}
           handle={(api) => {
             virtualListRef = api;
           }}

--- a/src/components/logcat/LogcatToolbar.test.tsx
+++ b/src/components/logcat/LogcatToolbar.test.tsx
@@ -10,6 +10,7 @@ function renderToolbar(overrides: Partial<Parameters<typeof LogcatToolbar>[0]> =
     crashes: 0,
     selectedCount: 0,
     autoScroll: true,
+    newEntriesCount: 0,
     toolbarCount: { text: "0 rows", title: "No rows" },
     onStart: vi.fn(),
     onStop: vi.fn(),

--- a/src/components/logcat/LogcatToolbar.tsx
+++ b/src/components/logcat/LogcatToolbar.tsx
@@ -9,6 +9,7 @@ export function LogcatToolbar(props: {
   crashes: number;
   selectedCount: number;
   autoScroll: boolean;
+  newEntriesCount: number;
   toolbarCount: { text: string; title: string };
   onStart: () => void;
   onStop: () => void;
@@ -127,10 +128,19 @@ export function LogcatToolbar(props: {
 
       <button
         onClick={() => props.onScrollToEnd()}
-        title="Scroll to end"
+        title={
+          props.newEntriesCount > 0
+            ? `${props.newEntriesCount.toLocaleString()} new ${
+                props.newEntriesCount === 1 ? "log" : "logs"
+              } available - Jump to end`
+            : "Scroll to end"
+        }
         style={btnStyle(props.autoScroll ? "var(--text-muted)" : "var(--accent)")}
       >
         ↓
+        <Show when={props.newEntriesCount > 0}>
+          <span>{props.newEntriesCount.toLocaleString()} new</span>
+        </Show>
       </button>
 
       <button

--- a/src/components/logcat/logcat-selection-nav.test.ts
+++ b/src/components/logcat/logcat-selection-nav.test.ts
@@ -3,6 +3,7 @@ import {
   isLogcatEntrySelectable,
   nextSelectableIndex,
   clampSelectionIndices,
+  shiftSelectionAfterFrontDrop,
 } from "./logcat-selection-nav";
 
 describe("isLogcatEntrySelectable", () => {
@@ -74,5 +75,20 @@ describe("clampSelectionIndices", () => {
 
   it("preserves null end", () => {
     expect(clampSelectionIndices(8, null, 10)).toEqual({ anchor: 8, end: null });
+  });
+});
+
+describe("shiftSelectionAfterFrontDrop", () => {
+  it("moves a single selected row upward by the dropped count", () => {
+    expect(shiftSelectionAfterFrontDrop(10, null, 3)).toEqual({ anchor: 7, end: null });
+  });
+
+  it("clears a single selected row when that row was dropped", () => {
+    expect(shiftSelectionAfterFrontDrop(2, null, 3)).toEqual({ anchor: null, end: null });
+  });
+
+  it("preserves the remaining part of a range after a partial front drop", () => {
+    expect(shiftSelectionAfterFrontDrop(2, 6, 4)).toEqual({ anchor: null, end: 2 });
+    expect(shiftSelectionAfterFrontDrop(8, 3, 5)).toEqual({ anchor: 3, end: null });
   });
 });

--- a/src/components/logcat/logcat-selection-nav.test.ts
+++ b/src/components/logcat/logcat-selection-nav.test.ts
@@ -88,7 +88,7 @@ describe("shiftSelectionAfterFrontDrop", () => {
   });
 
   it("preserves the remaining part of a range after a partial front drop", () => {
-    expect(shiftSelectionAfterFrontDrop(2, 6, 4)).toEqual({ anchor: null, end: 2 });
-    expect(shiftSelectionAfterFrontDrop(8, 3, 5)).toEqual({ anchor: 3, end: null });
+    expect(shiftSelectionAfterFrontDrop(2, 6, 4)).toEqual({ anchor: 0, end: 2 });
+    expect(shiftSelectionAfterFrontDrop(8, 3, 5)).toEqual({ anchor: 3, end: 0 });
   });
 });

--- a/src/components/logcat/logcat-selection-nav.ts
+++ b/src/components/logcat/logcat-selection-nav.ts
@@ -65,6 +65,18 @@ export function shiftSelectionAfterFrontDrop(
     return shifted >= 0 ? shifted : null;
   };
 
+  if (end !== null) {
+    const low = Math.min(anchor, end);
+    const high = Math.max(anchor, end);
+    if (high < dropped) return { anchor: null, end: null };
+
+    const shiftedLow = Math.max(0, low - dropped);
+    const shiftedHigh = high - dropped;
+    return anchor <= end
+      ? { anchor: shiftedLow, end: shiftedHigh }
+      : { anchor: shiftedHigh, end: shiftedLow };
+  }
+
   return {
     anchor: shift(anchor),
     end: shift(end),

--- a/src/components/logcat/logcat-selection-nav.ts
+++ b/src/components/logcat/logcat-selection-nav.ts
@@ -50,3 +50,23 @@ export function clampSelectionIndices(
   const nb = end === null ? null : Math.min(Math.max(0, end), max);
   return { anchor: na, end: nb };
 }
+
+/** Shift row selection after `dropped` rows were removed from the front. */
+export function shiftSelectionAfterFrontDrop(
+  anchor: number | null,
+  end: number | null,
+  dropped: number
+): { anchor: number | null; end: number | null } {
+  if (anchor === null || dropped <= 0) return { anchor, end: anchor === null ? null : end };
+
+  const shift = (index: number | null): number | null => {
+    if (index === null) return null;
+    const shifted = index - dropped;
+    return shifted >= 0 ? shifted : null;
+  };
+
+  return {
+    anchor: shift(anchor),
+    end: shift(end),
+  };
+}

--- a/src/components/ui/VirtualList/VirtualList.test.tsx
+++ b/src/components/ui/VirtualList/VirtualList.test.tsx
@@ -19,10 +19,17 @@ describe("VirtualList", () => {
   it("renders visible items", () => {
     const items = Array.from({ length: 10 }, (_, i) => `item-${i}`);
     const { container } = render(() => (
-      <VirtualList items={items} rowHeight={30} renderRow={(item) => <div>{item}</div>} />
+      <VirtualList
+        items={items}
+        rowHeight={30}
+        renderRow={(item) => <div>{item}</div>}
+        class="virtual-list-test"
+      />
     ));
     // At least some items rendered (jsdom has no real scroll height, so all items may render)
     expect(container.textContent).toContain("item-0");
+    const scroller = container.querySelector(".virtual-list-test") as HTMLElement;
+    expect(scroller.style.overflowAnchor).toBe("none");
   });
 
   it("does not re-enable auto-scroll when manually scrolling back to the bottom", () => {
@@ -65,5 +72,71 @@ describe("VirtualList", () => {
     Object.defineProperty(scroller, "scrollTop", { value: 1000, writable: true });
     scroller.dispatchEvent(new Event("scroll"));
     expect(state.textContent).toBe("off");
+  });
+
+  it("does not run a queued auto-scroll after follow-tail is disabled", async () => {
+    let setItems!: (items: string[]) => void;
+    let setAutoScroll!: (enabled: boolean) => void;
+
+    function Harness() {
+      const [items, _setItems] = createSignal(["item-0"]);
+      const [autoScroll, _setAutoScroll] = createSignal(true);
+      setItems = _setItems;
+      setAutoScroll = _setAutoScroll;
+
+      return (
+        <VirtualList
+          items={items()}
+          rowHeight={30}
+          renderRow={(item) => <div>{item}</div>}
+          autoScroll={autoScroll()}
+          class="virtual-list-test"
+        />
+      );
+    }
+
+    const { container } = render(() => <Harness />);
+    const scroller = container.querySelector(".virtual-list-test") as HTMLElement;
+    Object.defineProperty(scroller, "clientHeight", { value: 200, writable: true });
+    Object.defineProperty(scroller, "scrollHeight", { value: 1200, writable: true });
+    Object.defineProperty(scroller, "scrollTop", { value: 0, writable: true });
+
+    await Promise.resolve();
+    scroller.scrollTop = 125;
+
+    setItems(["item-0", "item-1"]);
+    setAutoScroll(false);
+    await Promise.resolve();
+
+    expect(scroller.scrollTop).toBe(125);
+  });
+
+  it("keeps the viewport stable when rows are evicted from the front", async () => {
+    let compensate!: (px: number) => void;
+
+    function Harness() {
+      const [scrollCompensate, setScrollCompensate] = createSignal(0);
+      compensate = (px: number) => setScrollCompensate((current) => current + px);
+
+      return (
+        <VirtualList
+          items={Array.from({ length: 100 }, (_, i) => `item-${i}`)}
+          rowHeight={30}
+          renderRow={(item) => <div>{item}</div>}
+          autoScroll={false}
+          scrollCompensate={scrollCompensate()}
+          class="virtual-list-test"
+        />
+      );
+    }
+
+    const { container } = render(() => <Harness />);
+    const scroller = container.querySelector(".virtual-list-test") as HTMLElement;
+    Object.defineProperty(scroller, "scrollTop", { value: 300, writable: true });
+
+    compensate(90);
+    await Promise.resolve();
+
+    expect(scroller.scrollTop).toBe(210);
   });
 });

--- a/src/components/ui/VirtualList/VirtualList.tsx
+++ b/src/components/ui/VirtualList/VirtualList.tsx
@@ -28,6 +28,7 @@ import {
   createSignal,
   onCleanup,
   onMount,
+  untrack,
 } from "solid-js";
 
 export interface VirtualListHandle {
@@ -155,7 +156,7 @@ export function VirtualList<T>(props: VirtualListProps<T>): JSX.Element {
   const scheduleAutoScroll = () => {
     if (props.autoScroll && wasAtBottom) {
       queueMicrotask(() => {
-        if (outerRef) {
+        if (outerRef && untrack(() => props.autoScroll) && wasAtBottom) {
           outerRef.scrollTop = outerRef.scrollHeight;
         }
       });
@@ -190,7 +191,7 @@ export function VirtualList<T>(props: VirtualListProps<T>): JSX.Element {
     const delta = current - prevCompensate;
     prevCompensate = current;
     if (delta !== 0 && outerRef) {
-      outerRef.scrollTop += delta;
+      outerRef.scrollTop = Math.max(0, outerRef.scrollTop - delta);
     }
   });
 
@@ -223,6 +224,7 @@ export function VirtualList<T>(props: VirtualListProps<T>): JSX.Element {
       style={{
         "overflow-y": "auto",
         "overflow-x": "hidden",
+        "overflow-anchor": "none",
         position: "relative",
         ...(props.style ?? {}),
       }}

--- a/src/lib/logcat-follow-tail.test.ts
+++ b/src/lib/logcat-follow-tail.test.ts
@@ -38,6 +38,18 @@ describe("effectiveLogcatFollowTail", () => {
         autoScroll: true,
         selectionAnchor: null,
         selectedJsonEntry: { id: "x" },
+        selectedDetailEntry: null,
+      })
+    ).toBe(false);
+  });
+
+  it("is false when entry detail is open", () => {
+    expect(
+      effectiveLogcatFollowTail({
+        autoScroll: true,
+        selectionAnchor: null,
+        selectedJsonEntry: null,
+        selectedDetailEntry: { id: "x" },
       })
     ).toBe(false);
   });

--- a/src/lib/logcat-follow-tail.ts
+++ b/src/lib/logcat-follow-tail.ts
@@ -1,15 +1,17 @@
 /**
  * Whether the Logcat virtual list should auto-scroll on new entries.
- * User follow-tail preference is suppressed while a row or JSON detail is active.
+ * User follow-tail preference is suppressed while a row, entry detail, or JSON detail is active.
  */
 export function effectiveLogcatFollowTail(params: {
   autoScroll: boolean;
   selectionAnchor: number | null;
   selectedJsonEntry: unknown | null;
+  selectedDetailEntry?: unknown | null;
 }): boolean {
   return (
     params.autoScroll &&
     params.selectionAnchor === null &&
+    (params.selectedDetailEntry === null || params.selectedDetailEntry === undefined) &&
     params.selectedJsonEntry === null
   );
 }


### PR DESCRIPTION
## Summary

log improvements on scrolling when selected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes the Logcat list when you scroll away from the end or select a row, queues incoming logs with an “N new” counter on the Jump button, and applies them when you Jump to end (which also clears row/detail selection). Improves follow‑tail and viewport stability, especially during buffer evictions.

- New Features
  - Read mode: freeze visible rows on scroll/selection; keep capturing logs; show “N new” on the Jump button with a tooltip like “120 new logs available - Jump to end”; Jump applies them, resumes follow‑tail, and clears selection.
  - Arrow/crash navigation enters read mode; export/copy uses the currently displayed (frozen) list; docs updated to explain read mode.

- Bug Fixes
  - Stable viewport when the ring buffer evicts from the front; preserve/shift selection after front drops.
  - Prevent queued auto‑scroll after follow‑tail is turned off; entry detail and JSON views suppress follow‑tail.
  - `VirtualList`: disable overflow anchoring and correct scroll compensation to avoid jumpiness.

<sup>Written for commit 2158460590babb24a4110c31550fc44be44af368. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

