### PR TITLE
feat(logcat): add lifecycle visibility filter

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -121,6 +121,7 @@ Use **Log Mode** from the title bar when logs are the main task. It hides the pr
 - **Clear**: clear displayed entries and the in-memory buffer.
 - **Export**: save filtered entries to a `.log` file.
 - **Filters**: use quick filters or saved filters.
+- **Lifecycle**: show or hide lifecycle/process entries such as ActivityManager rows and process separators. Hidden entries remain captured and can be shown again.
 - **Package dropdown**: show all packages, only your app, or a package seen in this session.
 
 ### Filters

--- a/src/components/logcat/LogcatFilterControls.test.tsx
+++ b/src/components/logcat/LogcatFilterControls.test.tsx
@@ -11,9 +11,11 @@ function renderFilterControls(overrides: Partial<Parameters<typeof LogcatFilterC
     activeAge: null,
     activePackage: null,
     isFiltered: false,
+    showLifecycle: true,
     onQueryChange: vi.fn(),
     onAgeSelect: vi.fn(),
     onPackageSelect: vi.fn(),
+    onToggleLifecycle: vi.fn(),
     onClear: vi.fn(),
     renderSavedFilterMenu: () => <div data-testid="saved-filter-menu">Filters</div>,
     ...overrides,
@@ -52,6 +54,26 @@ describe("LogcatFilterControls", () => {
 
     fireEvent.click(screen.getByText("All"));
     expect(onAgeSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("shows lifecycle quick filter as active by default", () => {
+    renderFilterControls();
+
+    const button = screen.getByRole("button", { name: "Lifecycle" });
+
+    expect(button.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("toggles lifecycle quick filter", () => {
+    const onToggleLifecycle = vi.fn();
+    renderFilterControls({ showLifecycle: false, onToggleLifecycle });
+
+    const button = screen.getByRole("button", { name: "Lifecycle" });
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(button);
+
+    expect(onToggleLifecycle).toHaveBeenCalledOnce();
   });
 
   it("selects package filters from the package dropdown", () => {

--- a/src/components/logcat/LogcatFilterControls.tsx
+++ b/src/components/logcat/LogcatFilterControls.tsx
@@ -22,9 +22,11 @@ export function LogcatFilterControls(props: {
   activeAge: string | null;
   activePackage: string | null;
   isFiltered: boolean;
+  showLifecycle: boolean;
   onQueryChange: (query: string) => void;
   onAgeSelect: (value: LogcatAgePillValue) => void;
   onPackageSelect: (pkg: string | null) => void;
+  onToggleLifecycle: () => void;
   onClear: () => void;
   renderSavedFilterMenu: () => JSX.Element;
 }): JSX.Element {
@@ -111,6 +113,29 @@ export function LogcatFilterControls(props: {
             );
           }}
         </For>
+
+        <button
+          onClick={() => props.onToggleLifecycle()}
+          aria-pressed={props.showLifecycle}
+          title={
+            props.showLifecycle
+              ? "Hide lifecycle and process logs"
+              : "Show lifecycle and process logs"
+          }
+          style={{
+            padding: "1px 7px",
+            "font-size": "10px",
+            background: props.showLifecycle ? "var(--accent)" : "var(--bg-primary)",
+            color: props.showLifecycle ? "#fff" : "var(--text-muted)",
+            border: `1px solid ${props.showLifecycle ? "var(--accent)" : "var(--border)"}`,
+            "border-radius": "10px",
+            cursor: "pointer",
+            "flex-shrink": "0",
+            transition: "all 0.1s",
+          }}
+        >
+          Lifecycle
+        </button>
 
         <div
           style={{

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -248,4 +248,49 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
 
     expect(await screen.findByText("Incoming row should wait")).not.toBeNull();
   });
+
+  it("hides and restores buffered lifecycle and process entries from the quick filter", async () => {
+    const appEntry = {
+      ...BASE_ENTRY,
+      id: 30n,
+      tag: "App",
+      message: "visible app row",
+      category: "general",
+      kind: "normal",
+    } satisfies ProcessedEntry;
+    const lifecycleEntry = {
+      ...BASE_ENTRY,
+      id: 31n,
+      tag: "ActivityManager",
+      message: "lifecycle row",
+      category: "lifecycle",
+      kind: "normal",
+    } satisfies ProcessedEntry;
+    const processEntry = {
+      ...BASE_ENTRY,
+      id: 32n,
+      tag: "---",
+      message: "com.example.app process died",
+      category: "lifecycle",
+      kind: "processDied",
+    } satisfies ProcessedEntry;
+
+    installLogcatPanelMocks([appEntry, lifecycleEntry, processEntry]);
+    render(() => <LogcatPanel />);
+
+    expect(await screen.findByText("visible app row")).not.toBeNull();
+    expect(screen.getByText("lifecycle row")).not.toBeNull();
+    expect(screen.getByText(/PROCESS DIED/)).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Lifecycle" }));
+
+    expect(screen.getByText("visible app row")).not.toBeNull();
+    expect(screen.queryByText("lifecycle row")).toBeNull();
+    expect(screen.queryByText(/PROCESS DIED/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Lifecycle" }));
+
+    expect(screen.getByText("lifecycle row")).not.toBeNull();
+    expect(screen.getByText(/PROCESS DIED/)).not.toBeNull();
+  });
 });

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -293,4 +293,37 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
     expect(screen.getByText("lifecycle row")).not.toBeNull();
     expect(screen.getByText(/PROCESS DIED/)).not.toBeNull();
   });
+
+  it("excludes hidden lifecycle crash rows from the read-mode crash count", async () => {
+    const appCrashEntry = {
+      ...BASE_ENTRY,
+      id: 40n,
+      tag: "AppCrash",
+      message: "visible app crash",
+      category: "general",
+      kind: "normal",
+      isCrash: true,
+    } satisfies ProcessedEntry;
+    const lifecycleCrashEntry = {
+      ...BASE_ENTRY,
+      id: 41n,
+      tag: "ActivityManager",
+      message: "hidden lifecycle crash",
+      category: "lifecycle",
+      kind: "normal",
+      isCrash: true,
+    } satisfies ProcessedEntry;
+
+    installLogcatPanelMocks([appCrashEntry, lifecycleCrashEntry]);
+    render(() => <LogcatPanel />);
+
+    fireEvent.click(await screen.findByText("visible app crash"));
+    expect(screen.getByTitle("2 crashes — click to jump")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Lifecycle" }));
+
+    expect(screen.getAllByText("visible app crash").length).toBeGreaterThan(0);
+    expect(screen.queryByText("hidden lifecycle crash")).toBeNull();
+    expect(screen.getByTitle("1 crash — click to jump")).not.toBeNull();
+  });
 });

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -53,6 +53,7 @@ import {
 import { formatLogcatToolbarCount } from "./logcat-toolbar-count";
 import { clampLogcatMaxUiLines, clampLogcatRingMaxEntries } from "@/lib/logcat-ui-lines";
 import { effectiveLogcatFollowTail } from "@/lib/logcat-follow-tail";
+import { isLifecycleLogcatEntry } from "@/lib/logcat-lifecycle";
 import {
   emptyLogcatFilterSpec,
   groupsToFilterSpec,
@@ -122,6 +123,7 @@ export function LogcatPanel(): JSX.Element {
   let virtualListRef: VirtualListHandle | undefined;
   const [paused, setPaused] = createSignal(false);
   const [restarting, setRestarting] = createSignal(false);
+  const [showLifecycle, setShowLifecycle] = createSignal(true);
 
   // Crash navigation
   const [jumpTarget, setJumpTarget] = createSignal<number | null>(null);
@@ -189,7 +191,10 @@ export function LogcatPanel(): JSX.Element {
     { equals: false }
   );
 
-  const displayedEntries = createMemo(() => frozenEntries() ?? filteredEntries());
+  const displayedEntries = createMemo(() => {
+    const entries = frozenEntries() ?? filteredEntries();
+    return showLifecycle() ? entries : entries.filter((entry) => !isLifecycleLogcatEntry(entry));
+  });
   const readMode = createMemo(() => frozenEntries() !== null);
 
   function enterReadMode(): void {
@@ -207,10 +212,14 @@ export function LogcatPanel(): JSX.Element {
 
   function countVisibleIncoming(entries: LogcatEntry[]): number {
     if (entries.length === 0) return 0;
-    if (!needsFrontendFilter()) return entries.length;
+    const lifecycleFiltered = showLifecycle()
+      ? entries
+      : entries.filter((entry) => !isLifecycleLogcatEntry(entry));
+    if (!needsFrontendFilter()) return lifecycleFiltered.length;
     const groups = parsedGroups();
     const currentNow = hasAgeFilter() ? now() : Date.now();
-    return entries.filter((entry) => matchesFilterGroups(entry, groups, currentNow)).length;
+    return lifecycleFiltered.filter((entry) => matchesFilterGroups(entry, groups, currentNow))
+      .length;
   }
 
   const filteredEntryIndexById = createMemo(() => {
@@ -241,13 +250,13 @@ export function LogcatPanel(): JSX.Element {
       });
       return indices;
     }
-    if (!needsFrontendFilter()) {
+    if (!needsFrontendFilter() && showLifecycle()) {
       // Fast path: no frontend filtering, use the incremental index.
       return logcatState.crashIndicesFull;
     }
-    // Slow path: frontend tokens active, rescan the (small) filtered set.
+    // Slow path: frontend tokens or lifecycle display filter active, rescan the visible set.
     const indices: number[] = [];
-    filteredEntries().forEach((e, i) => {
+    displayedEntries().forEach((e, i) => {
       if (e.isCrash) indices.push(i);
     });
     return indices;
@@ -803,9 +812,11 @@ export function LogcatPanel(): JSX.Element {
         activeAge={activeAge()}
         activePackage={activePackage()}
         isFiltered={isFiltered()}
+        showLifecycle={showLifecycle()}
         onQueryChange={updateQuery}
         onAgeSelect={handleAgePill}
         onPackageSelect={handlePackageSelect}
+        onToggleLifecycle={() => setShowLifecycle((v) => !v)}
         onClear={() => updateQuery("")}
         renderSavedFilterMenu={() => (
           <SavedFilterMenu query={query()} isFiltered={isFiltered()} onApplyQuery={updateQuery} />

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -245,7 +245,7 @@ export function LogcatPanel(): JSX.Element {
     const frozen = frozenEntries();
     if (frozen !== null) {
       const indices: number[] = [];
-      frozen.forEach((entry, index) => {
+      displayedEntries().forEach((entry, index) => {
         if (entry.isCrash) indices.push(index);
       });
       return indices;

--- a/src/lib/logcat-lifecycle.test.ts
+++ b/src/lib/logcat-lifecycle.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { LogcatEntry } from "@/lib/tauri-api";
+import { isLifecycleLogcatEntry } from "./logcat-lifecycle";
+
+function entry(overrides: Partial<LogcatEntry>): LogcatEntry {
+  return {
+    id: 1n,
+    timestamp: "05-08 12:00:00.000",
+    pid: 100,
+    tid: 100,
+    level: "info",
+    tag: "App",
+    message: "hello",
+    package: "com.example.app",
+    kind: "normal",
+    isCrash: false,
+    flags: 0,
+    category: "general",
+    crashGroupId: null,
+    jsonBody: null,
+    ...overrides,
+  };
+}
+
+describe("isLifecycleLogcatEntry", () => {
+  it("matches normal entries classified as lifecycle", () => {
+    expect(isLifecycleLogcatEntry(entry({ category: "lifecycle", kind: "normal" }))).toBe(true);
+  });
+
+  it("matches special process separator kinds", () => {
+    expect(isLifecycleLogcatEntry(entry({ category: "general", kind: "processDied" }))).toBe(true);
+    expect(isLifecycleLogcatEntry(entry({ category: "general", kind: "processStarted" }))).toBe(
+      true
+    );
+  });
+
+  it("does not match normal non-lifecycle entries", () => {
+    expect(isLifecycleLogcatEntry(entry({ category: "general", kind: "normal" }))).toBe(false);
+    expect(isLifecycleLogcatEntry(entry({ category: "network", kind: "normal" }))).toBe(false);
+  });
+});

--- a/src/lib/logcat-lifecycle.ts
+++ b/src/lib/logcat-lifecycle.ts
@@ -1,0 +1,5 @@
+import type { LogcatEntry } from "@/lib/tauri-api";
+
+export function isLifecycleLogcatEntry(entry: LogcatEntry): boolean {
+  return entry.category === "lifecycle" || entry.kind !== "normal";
+}


### PR DESCRIPTION
## Summary

toggle for lifecycle logs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Lifecycle" quick filter to Logcat to show/hide lifecycle and process entries, reducing noise while you debug. The toggle is on by default, and hidden entries remain buffered and can be restored.

- **New Features**
  - Added "Lifecycle" button in quick filters to toggle `ActivityManager` rows and process start/stop separators.
  - Applies to live and buffered logs; incoming counts and crash navigation respect visibility, including read-mode crash counts excluding hidden lifecycle crashes.
  - Updated user manual and added tests for the toggle, filtering behavior, and `isLifecycleLogcatEntry`.

<sup>Written for commit 6931111d8a41f3c4b0e6ee277d121b2c847bc63b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

