### PR TITLE
switch condition and package mine fix

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -142,6 +142,7 @@ Use the query bar for targeted searches:
 | `level:error | is:crash` | OR search |
 
 Press **Enter** to commit a typed condition as a filter pill. Use **+ AND** and **+ OR** for compound filters. Saved filters are capped at 50.
+Click an `AND` or `OR` connector badge between filter pills to toggle only that connector while keeping the surrounding filters in place.
 
 ### Reading logs
 

--- a/e2e/smoke/logcat-regressions.spec.ts
+++ b/e2e/smoke/logcat-regressions.spec.ts
@@ -166,7 +166,8 @@ test("logcat query connector badges toggle only the clicked condition", async ({
   await expect(page.getByText("Beta only row")).toBeVisible();
   await expect(page.getByText("Gamma only row")).toBeVisible();
 
-  await page.getByRole("button", { name: "Change OR to AND" }).first().click();
+  await page.getByRole("button", { name: "Change OR to AND" }).first().focus();
+  await page.keyboard.press("Enter");
 
   await expect(page.getByText("Alpha beta row")).toBeVisible({ timeout: 5_000 });
   await expect(page.getByText("Gamma only row")).toBeVisible();

--- a/e2e/smoke/logcat-regressions.spec.ts
+++ b/e2e/smoke/logcat-regressions.spec.ts
@@ -140,6 +140,40 @@ test("logcat detail panel opens for the clicked filtered row", async ({ page }) 
   await expect(page.getByTitle("Filter by message")).toHaveText("Beta target message");
 });
 
+test("logcat query connector badges toggle only the clicked condition", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 110, tag: "AlphaOnly", message: "Alpha only row" },
+    { id: 111, tag: "AlphaBeta", message: "Alpha beta row" },
+    { id: 112, tag: "BetaOnly", message: "Beta only row" },
+    { id: 113, tag: "GammaOnly", message: "Gamma only row" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(4, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("tag:Alpha tag:Beta | tag:Gamma ");
+
+  await expect(page.getByText("Alpha beta row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Gamma only row")).toBeVisible();
+  await expect(page.getByText("Alpha only row")).not.toBeVisible();
+  await expect(page.getByText("Beta only row")).not.toBeVisible();
+
+  await page.getByRole("button", { name: "Change AND to OR" }).click();
+
+  await expect(page.getByText("Alpha only row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Alpha beta row")).toBeVisible();
+  await expect(page.getByText("Beta only row")).toBeVisible();
+  await expect(page.getByText("Gamma only row")).toBeVisible();
+
+  await page.getByRole("button", { name: "Change OR to AND" }).first().click();
+
+  await expect(page.getByText("Alpha beta row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Gamma only row")).toBeVisible();
+  await expect(page.getByText("Alpha only row")).not.toBeVisible();
+  await expect(page.getByText("Beta only row")).not.toBeVisible();
+});
+
 test("logcat selected row stays frozen while the live buffer overflows", async ({ page }) => {
   await page.evaluate(() => {
     window.__keynobi_e2e_settings_overrides = {

--- a/src/components/logcat/LogcatPanel.auto-filter.test.ts
+++ b/src/components/logcat/LogcatPanel.auto-filter.test.ts
@@ -17,10 +17,11 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { createRoot, createSignal, createEffect } from "solid-js";
 import { buildState, setLastLaunchedAt, resetBuildState } from "@/stores/build.store";
-import { setPackageInQuery } from "@/lib/logcat-query";
+import { getMinePackage, setMinePackage, setPackageInQuery } from "@/lib/logcat-query";
 
 function resetState() {
   resetBuildState();
+  setMinePackage(null);
 }
 
 /**
@@ -42,6 +43,9 @@ function mountAutoFilterEffect(initialQuery: string): [() => string, () => void]
       if (launchedAt === _prevLaunchedAt) return;
       _prevLaunchedAt = launchedAt;
       if (launchedAt === null) return;
+      if (buildState.lastLaunchedPackage) {
+        setMinePackage(buildState.lastLaunchedPackage);
+      }
       const q = query();
       if (q.includes("package:mine") || q.includes("pkg:mine")) return;
       const next = setPackageInQuery(q, "mine");
@@ -97,6 +101,20 @@ describe("auto-apply package:mine on deploy", () => {
 
     // query unchanged — no duplicate package token
     expect(query()).toBe(initial);
+    dispose();
+  });
+
+  it("updates the mine resolver to the exact launched package when package:mine already exists", async () => {
+    setMinePackage("com.example.base");
+    const initial = "package:mine level:error ";
+    const [query, dispose] = mountAutoFilterEffect(initial);
+    await Promise.resolve();
+
+    setLastLaunchedAt(1_000_000, "com.example.flavor.debug");
+    await Promise.resolve();
+
+    expect(query()).toBe(initial);
+    expect(getMinePackage()).toBe("com.example.flavor.debug");
     dispose();
   });
 

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -373,8 +373,14 @@ export function LogcatPanel(): JSX.Element {
     if (launchedAt === _prevLaunchedAt) return;
     _prevLaunchedAt = launchedAt;
     if (launchedAt === null) return; // initial mount — skip
+    if (buildState.lastLaunchedPackage) {
+      setMinePackage(buildState.lastLaunchedPackage);
+    }
     const q = query();
-    if (q.includes("package:mine") || q.includes("pkg:mine")) return;
+    if (q.includes("package:mine") || q.includes("pkg:mine")) {
+      void syncBackendFilter(parseFilterGroups(q));
+      return;
+    }
     const next = setPackageInQuery(q, "mine");
     updateQuery(next.trimEnd() ? next.trimEnd() + " " : "");
   });

--- a/src/components/logcat/QueryBar.test.ts
+++ b/src/components/logcat/QueryBar.test.ts
@@ -82,6 +82,40 @@ describe("QueryBar — Enter keyboard commit", () => {
   });
 });
 
+describe("QueryBar — clickable connectors", () => {
+  it("toggles only the clicked AND connector to OR", () => {
+    const changes: string[] = [];
+    const { getByRole } = render(() =>
+      QueryBar({
+        value: "level:error tag:App | is:crash ",
+        onChange: (q) => changes.push(q),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+
+    fireEvent.mouseDown(getByRole("button", { name: "Change AND to OR" }));
+
+    expect(changes[changes.length - 1]).toBe("level:error | tag:App | is:crash ");
+  });
+
+  it("toggles only the clicked OR connector to AND", () => {
+    const changes: string[] = [];
+    const { getAllByRole } = render(() =>
+      QueryBar({
+        value: "level:error | tag:App | is:crash ",
+        onChange: (q) => changes.push(q),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+
+    fireEvent.mouseDown(getAllByRole("button", { name: "Change OR to AND" })[0]!);
+
+    expect(changes[changes.length - 1]).toBe("level:error tag:App | is:crash ");
+  });
+});
+
 // ── parseQueryState — trailing-space convention ───────────────────────────────
 
 describe("parseQueryState — trailing-space convention", () => {

--- a/src/components/logcat/QueryBar.test.ts
+++ b/src/components/logcat/QueryBar.test.ts
@@ -94,7 +94,7 @@ describe("QueryBar — clickable connectors", () => {
       })
     );
 
-    fireEvent.mouseDown(getByRole("button", { name: "Change AND to OR" }));
+    fireEvent.click(getByRole("button", { name: "Change AND to OR" }));
 
     expect(changes[changes.length - 1]).toBe("level:error | tag:App | is:crash ");
   });
@@ -110,7 +110,7 @@ describe("QueryBar — clickable connectors", () => {
       })
     );
 
-    fireEvent.mouseDown(getAllByRole("button", { name: "Change OR to AND" })[0]!);
+    fireEvent.click(getAllByRole("button", { name: "Change OR to AND" })[0]!);
 
     expect(changes[changes.length - 1]).toBe("level:error tag:App | is:crash ");
   });

--- a/src/components/logcat/QueryBar.tsx
+++ b/src/components/logcat/QueryBar.tsx
@@ -37,6 +37,8 @@ import {
   insertPillAtGroupPosition,
   applyInlineEditCommit,
   commitQueryBarDraft,
+  toggleQueryBarAndConnector,
+  toggleQueryBarOrConnector,
 } from "@/lib/logcat-query";
 import {
   QueryBarAndBadge,
@@ -423,6 +425,25 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
     queueMicrotask(() => draftRef?.focus());
   }
 
+  function toggleAndConnector(groupIdx: number, tokenIdxAfterConnector: number) {
+    if (inlineEdit()) commitInlineEdit();
+    const next = toggleQueryBarAndConnector(
+      committed(),
+      groupIdx,
+      tokenIdxAfterConnector,
+      draftInNewGroup()
+    );
+    props.onChange(buildQuery(next, draft()));
+    queueMicrotask(() => draftRef?.focus());
+  }
+
+  function toggleOrConnector(groupIdxAfterConnector: number) {
+    if (inlineEdit()) commitInlineEdit();
+    const next = toggleQueryBarOrConnector(committed(), groupIdxAfterConnector, draftInNewGroup());
+    props.onChange(buildQuery(next, draft()));
+    queueMicrotask(() => draftRef?.focus());
+  }
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
@@ -447,7 +468,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
               <>
                 {/* OR badge between groups */}
                 <Show when={gi() > 0}>
-                  <QueryBarOrBadge />
+                  <QueryBarOrBadge onToggle={() => toggleOrConnector(gi())} />
                 </Show>
 
                 {/* Group container: visible box only when 2+ groups exist */}
@@ -472,7 +493,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
                         </Show>
                         {/* AND badge between pills in the same group */}
                         <Show when={ti() > 0}>
-                          <QueryBarAndBadge />
+                          <QueryBarAndBadge onToggle={() => toggleAndConnector(gi(), ti())} />
                         </Show>
 
                         <QueryBarPill

--- a/src/components/logcat/QueryBarParts.tsx
+++ b/src/components/logcat/QueryBarParts.tsx
@@ -14,12 +14,52 @@ import {
   suggestionMenuStyle,
 } from "./querybar-styles";
 
-export function QueryBarOrBadge(): JSX.Element {
-  return <span style={queryBarOrBadgeStyle()}>OR</span>;
+export function QueryBarOrBadge(props: { onToggle?: () => void } = {}): JSX.Element {
+  return (
+    <>
+      {props.onToggle ? (
+        <button
+          type="button"
+          aria-label="Change OR to AND"
+          title="Change OR to AND"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            props.onToggle?.();
+          }}
+          style={queryBarOrBadgeStyle(true)}
+        >
+          OR
+        </button>
+      ) : (
+        <span style={queryBarOrBadgeStyle()}>OR</span>
+      )}
+    </>
+  );
 }
 
-export function QueryBarAndBadge(): JSX.Element {
-  return <span style={queryBarAndBadgeStyle()}>AND</span>;
+export function QueryBarAndBadge(props: { onToggle?: () => void } = {}): JSX.Element {
+  return (
+    <>
+      {props.onToggle ? (
+        <button
+          type="button"
+          aria-label="Change AND to OR"
+          title="Change AND to OR"
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            props.onToggle?.();
+          }}
+          style={queryBarAndBadgeStyle(true)}
+        >
+          AND
+        </button>
+      ) : (
+        <span style={queryBarAndBadgeStyle()}>AND</span>
+      )}
+    </>
+  );
 }
 
 export function QueryBarInlineEditInput(props: {

--- a/src/components/logcat/QueryBarParts.tsx
+++ b/src/components/logcat/QueryBarParts.tsx
@@ -25,6 +25,9 @@ export function QueryBarOrBadge(props: { onToggle?: () => void } = {}): JSX.Elem
           onMouseDown={(e) => {
             e.preventDefault();
             e.stopPropagation();
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
             props.onToggle?.();
           }}
           style={queryBarOrBadgeStyle(true)}
@@ -48,6 +51,9 @@ export function QueryBarAndBadge(props: { onToggle?: () => void } = {}): JSX.Ele
           title="Change AND to OR"
           onMouseDown={(e) => {
             e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
             e.stopPropagation();
             props.onToggle?.();
           }}

--- a/src/components/logcat/querybar-styles.ts
+++ b/src/components/logcat/querybar-styles.ts
@@ -100,8 +100,9 @@ export function queryBarGroupBoxStyle(): Record<string, string> {
   };
 }
 
-export function queryBarOrBadgeStyle(): Record<string, string> {
+export function queryBarOrBadgeStyle(clickable = false): Record<string, string> {
   return {
+    appearance: "none",
     "font-size": "9px",
     "font-weight": "700",
     "letter-spacing": "0.05em",
@@ -112,11 +113,15 @@ export function queryBarOrBadgeStyle(): Record<string, string> {
     padding: "1px 5px",
     "flex-shrink": "0",
     "user-select": "none",
+    cursor: clickable ? "pointer" : "default",
+    "line-height": "1.2",
   };
 }
 
-export function queryBarAndBadgeStyle(): Record<string, string> {
+export function queryBarAndBadgeStyle(clickable = false): Record<string, string> {
   return {
+    appearance: "none",
+    background: "transparent",
     "font-size": "9px",
     "font-weight": "600",
     "letter-spacing": "0.04em",
@@ -126,6 +131,8 @@ export function queryBarAndBadgeStyle(): Record<string, string> {
     padding: "1px 5px",
     "flex-shrink": "0",
     "user-select": "none",
+    cursor: clickable ? "pointer" : "default",
+    "line-height": "1.2",
   };
 }
 

--- a/src/lib/logcat-query.test.ts
+++ b/src/lib/logcat-query.test.ts
@@ -28,6 +28,8 @@ import {
   committedEndsWithOrSeparator,
   quoteMessageTokenForEditDraft,
   serializeQueryBarCommittedPart,
+  toggleQueryBarAndConnector,
+  toggleQueryBarOrConnector,
   splitRawQueryParts,
   commitQueryBarDraft,
   getQueryBarSuggestions,
@@ -934,6 +936,36 @@ describe("insertPillAtGroupPosition", () => {
 
   it("inserts into an empty query", () => {
     expect(insertPillAtGroupPosition([], 0, 0, "level:error", false)).toEqual(["level:error"]);
+  });
+});
+
+describe("toggleQueryBarAndConnector", () => {
+  it("splits a single group at the clicked AND connector", () => {
+    expect(toggleQueryBarAndConnector(["level:error", "tag:App", "is:crash"], 0, 1, false)).toEqual(
+      ["level:error", "|", "tag:App", "is:crash"]
+    );
+  });
+
+  it("preserves other OR groups when splitting one AND connector", () => {
+    expect(
+      toggleQueryBarAndConnector(["level:error", "tag:App", "|", "is:crash"], 0, 1, false)
+    ).toEqual(["level:error", "|", "tag:App", "|", "is:crash"]);
+  });
+});
+
+describe("toggleQueryBarOrConnector", () => {
+  it("merges only the adjacent groups at the clicked OR connector", () => {
+    expect(
+      toggleQueryBarOrConnector(["level:error", "|", "tag:App", "|", "is:crash"], 1, false)
+    ).toEqual(["level:error", "tag:App", "|", "is:crash"]);
+  });
+
+  it("preserves trailing draft OR state when present", () => {
+    expect(toggleQueryBarOrConnector(["level:error", "|", "tag:App"], 1, true)).toEqual([
+      "level:error",
+      "tag:App",
+      "|",
+    ]);
   });
 });
 

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -1077,6 +1077,54 @@ export function insertPillAtGroupPosition(
   );
 }
 
+/** Toggle the displayed AND connector before `tokenIdxAfterConnector` into an OR boundary. */
+export function toggleQueryBarAndConnector(
+  committed: string[],
+  groupIdx: number,
+  tokenIdxAfterConnector: number,
+  draftInNewGroup: boolean
+): string[] {
+  const groups = buildQueryBarPillGroups(committed).map((g) => [...g]);
+  const group = groups[groupIdx];
+  if (!group || tokenIdxAfterConnector <= 0 || tokenIdxAfterConnector >= group.length) {
+    return committed;
+  }
+
+  const before = group.slice(0, tokenIdxAfterConnector);
+  const after = group.slice(tokenIdxAfterConnector);
+  const nextGroups = [...groups.slice(0, groupIdx), before, after, ...groups.slice(groupIdx + 1)];
+  return flattenPillGroupsToCommitted(
+    nextGroups.filter((g) => g.length > 0),
+    draftInNewGroup
+  );
+}
+
+/** Toggle the displayed OR connector before `groupIdxAfterConnector` into an AND relationship. */
+export function toggleQueryBarOrConnector(
+  committed: string[],
+  groupIdxAfterConnector: number,
+  draftInNewGroup: boolean
+): string[] {
+  const groups = buildQueryBarPillGroups(committed).map((g) => [...g]);
+  if (groupIdxAfterConnector <= 0 || groupIdxAfterConnector >= groups.length) {
+    return committed;
+  }
+
+  const previous = groups[groupIdxAfterConnector - 1];
+  const current = groups[groupIdxAfterConnector];
+  if (!previous || !current) return committed;
+
+  const nextGroups = [
+    ...groups.slice(0, groupIdxAfterConnector - 1),
+    [...previous, ...current],
+    ...groups.slice(groupIdxAfterConnector + 1),
+  ];
+  return flattenPillGroupsToCommitted(
+    nextGroups.filter((g) => g.length > 0),
+    draftInNewGroup
+  );
+}
+
 /**
  * Compute the new committed array when an inline pill edit is confirmed.
  *

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -67,7 +67,8 @@ export async function initBuildService(): Promise<void> {
 }
 
 // One-shot resolver for the current build. Set before a build starts, cleared on completion.
-let _resolveBuildComplete: ((result: { success: boolean; durationMs: number }) => void) | null = null;
+let _resolveBuildComplete: ((result: { success: boolean; durationMs: number }) => void) | null =
+  null;
 
 // ── Build actions ─────────────────────────────────────────────────────────────
 
@@ -104,12 +105,15 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
   // something goes wrong in the Rust on_exit callback.
   const buildComplete = new Promise<{ success: boolean; durationMs: number }>((resolve, reject) => {
     _resolveBuildComplete = resolve;
-    setTimeout(() => {
-      if (_resolveBuildComplete === resolve) {
-        _resolveBuildComplete = null;
-        reject(new Error("Build timed out waiting for build:complete event after 5 minutes."));
-      }
-    }, 5 * 60 * 1000);
+    setTimeout(
+      () => {
+        if (_resolveBuildComplete === resolve) {
+          _resolveBuildComplete = null;
+          reject(new Error("Build timed out waiting for build:complete event after 5 minutes."));
+        }
+      },
+      5 * 60 * 1000
+    );
   });
 
   try {
@@ -130,7 +134,13 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
     // Process-level spawn failure (e.g. gradlew not found).
     _resolveBuildComplete = null;
     const msg = formatError(e);
-    addBuildLine({ kind: "error", content: `Failed to start Gradle: ${msg}`, file: null, line: null, col: null });
+    addBuildLine({
+      kind: "error",
+      content: `Failed to start Gradle: ${msg}`,
+      file: null,
+      line: null,
+      col: null,
+    });
     setBuildResult({ success: false, durationMs: 0, errorCount: 1, warningCount: 0 });
     throw e;
   }
@@ -142,7 +152,13 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
   } catch (e) {
     // Timeout or unexpected rejection.
     const msg = formatError(e);
-    addBuildLine({ kind: "error", content: `Build event error: ${msg}`, file: null, line: null, col: null });
+    addBuildLine({
+      kind: "error",
+      content: `Build event error: ${msg}`,
+      file: null,
+      line: null,
+      col: null,
+    });
     setBuildResult({ success: false, durationMs: 0, errorCount: 1, warningCount: 0 });
     throw e;
   }
@@ -198,9 +214,7 @@ export async function runAndDeploy(): Promise<void> {
     //    context header as the very first callback line from the Gradle channel.
     setDeployPhase("building");
     await runBuild(`assemble${capitalize(variant)}`, {
-      headerLines: [
-        `── Deploy: ${variant} → ${serial} ──`,
-      ],
+      headerLines: [`── Deploy: ${variant} → ${serial} ──`],
     });
 
     const phase = buildState.phase;
@@ -216,7 +230,7 @@ export async function runAndDeploy(): Promise<void> {
     if (!apkPath) {
       logError(
         `APK not found for variant "${variant}". ` +
-        "Expected: app/build/outputs/apk/. Make sure the build produced an APK."
+          "Expected: app/build/outputs/apk/. Make sure the build produced an APK."
       );
       throw new Error("APK not found.");
     }
@@ -250,11 +264,11 @@ export async function runAndDeploy(): Promise<void> {
       logStep(`adb shell am start (package: ${packageName})`);
       const launchOutput = await launchAppOnDevice(serial, packageName);
       logStep(`Launch: ${launchOutput.trim()}`);
-      setLastLaunchedAt(Date.now());
+      setLastLaunchedAt(Date.now(), packageName);
     } else {
       logStep(
         "APK installed. Could not determine package name — cannot auto-launch. " +
-        "Ensure aapt2 is available in your Android SDK or set applicationId in Project App Info."
+          "Ensure aapt2 is available in your Android SDK or set applicationId in Project App Info."
       );
     }
   } catch (e) {
@@ -339,9 +353,13 @@ export async function jumpToBuildError(error: BuildError): Promise<void> {
       const filename = parts[parts.length - 1] ?? error.file;
       // Build a dotted class path from the path relative to java/ or kotlin/.
       const srcIdx = parts.findIndex((p) => p === "java" || p === "kotlin");
-      const classPath = srcIdx >= 0
-        ? parts.slice(srcIdx + 1).join(".").replace(/\.(kt|java)$/, "")
-        : filename.replace(/\.(kt|java)$/, "");
+      const classPath =
+        srcIdx >= 0
+          ? parts
+              .slice(srcIdx + 1)
+              .join(".")
+              .replace(/\.(kt|java)$/, "")
+          : filename.replace(/\.(kt|java)$/, "");
       await openInStudio(classPath, filename, error.line ?? 1);
       return;
     } catch (e) {

--- a/src/stores/build.store.test.ts
+++ b/src/stores/build.store.test.ts
@@ -95,7 +95,13 @@ describe("build.store", () => {
       {
         id: 1,
         task: "assembleDebug",
-        status: { state: "Success", success: true, durationMs: 1000, errorCount: 0, warningCount: 0 } as any,
+        status: {
+          state: "Success",
+          success: true,
+          durationMs: 1000,
+          errorCount: 0,
+          warningCount: 0,
+        } as any,
         errors: [],
         startedAt: new Date().toISOString(),
         projectRoot: "/home/user/my-app",
@@ -112,9 +118,12 @@ describe("build.store", () => {
   it("resetBuildState clears history along with build state", () => {
     setBuildHistory([
       {
-        id: 1, task: "assembleDebug",
-        status: { state: "success" } as any, errors: [],
-        startedAt: new Date().toISOString(), projectRoot: "/home/user/my-app",
+        id: 1,
+        task: "assembleDebug",
+        status: { state: "success" } as any,
+        errors: [],
+        startedAt: new Date().toISOString(),
+        projectRoot: "/home/user/my-app",
       },
     ]);
     startBuild("assembleDebug");
@@ -127,9 +136,12 @@ describe("build.store", () => {
   it("clearBuild does NOT clear history — only resetBuildState does", () => {
     setBuildHistory([
       {
-        id: 1, task: "assembleDebug",
-        status: { state: "success" } as any, errors: [],
-        startedAt: new Date().toISOString(), projectRoot: "/home/user/my-app",
+        id: 1,
+        task: "assembleDebug",
+        status: { state: "success" } as any,
+        errors: [],
+        startedAt: new Date().toISOString(),
+        projectRoot: "/home/user/my-app",
       },
     ]);
     startBuild("assembleDebug");
@@ -285,7 +297,9 @@ describe("build.store batching", () => {
 // ── lastLaunchedAt ────────────────────────────────────────────────────────────
 
 describe("lastLaunchedAt", () => {
-  beforeEach(() => { resetBuildState(); });
+  beforeEach(() => {
+    resetBuildState();
+  });
 
   it("is null on initial state", () => {
     expect(buildState.lastLaunchedAt).toBeNull();
@@ -296,16 +310,24 @@ describe("lastLaunchedAt", () => {
     expect(buildState.lastLaunchedAt).toBe(1_000_000);
   });
 
+  it("setLastLaunchedAt stores the exact launched package when provided", () => {
+    setLastLaunchedAt(1_000_000, "com.example.flavor.debug");
+    expect(buildState.lastLaunchedAt).toBe(1_000_000);
+    expect(buildState.lastLaunchedPackage).toBe("com.example.flavor.debug");
+  });
+
   it("clearBuild resets lastLaunchedAt to null", () => {
     setLastLaunchedAt(1_000_000);
     clearBuild();
     expect(buildState.lastLaunchedAt).toBeNull();
+    expect(buildState.lastLaunchedPackage).toBeNull();
   });
 
   it("resetBuildState resets lastLaunchedAt to null", () => {
     setLastLaunchedAt(1_000_000);
     resetBuildState();
     expect(buildState.lastLaunchedAt).toBeNull();
+    expect(buildState.lastLaunchedPackage).toBeNull();
   });
 
   it("successive deploys each update the timestamp", () => {

--- a/src/stores/build.store.ts
+++ b/src/stores/build.store.ts
@@ -19,6 +19,7 @@ export interface BuildStoreState {
   history: BuildRecord[];
   deployPhase: DeployPhase;
   lastLaunchedAt: number | null;
+  lastLaunchedPackage: string | null;
 }
 
 // ── Tick (1-second reactive heartbeat while a build is running) ───────────────
@@ -50,6 +51,7 @@ const [buildState, setBuildState] = createStore<BuildStoreState>({
   history: [],
   deployPhase: null,
   lastLaunchedAt: null,
+  lastLaunchedPackage: null,
 });
 
 export { buildState };
@@ -185,8 +187,11 @@ export function setDeployPhase(phase: DeployPhase): void {
   setBuildState("deployPhase", phase);
 }
 
-export function setLastLaunchedAt(ts: number): void {
-  setBuildState("lastLaunchedAt", ts);
+export function setLastLaunchedAt(ts: number, packageName: string | null = null): void {
+  setBuildState({
+    lastLaunchedAt: ts,
+    lastLaunchedPackage: packageName,
+  });
 }
 
 export function setBuildResult(opts: {
@@ -224,6 +229,7 @@ export function clearBuild(): void {
     warnings: [],
     deployPhase: null,
     lastLaunchedAt: null,
+    lastLaunchedPackage: null,
   });
   buildLogStore.clearEntries();
 }


### PR DESCRIPTION
## Summary

Switch condition and package:mine fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make logcat query connectors clickable to toggle AND/OR in place. Also fix `package:mine` to resolve to the exact launched package and update without rewriting the user’s query.

- **New Features**
  - Clickable AND/OR badges in the query bar toggle only the clicked connector.
  - Added accessible buttons with clear labels and updated docs.

- **Bug Fixes**
  - `package:mine` now maps to the exact launched package and updates if it already exists in the query.
  - Persist `lastLaunchedPackage` in the build store and set it on deploy.
  - If `package:mine`/`pkg:mine` is present, sync backend filters without altering the query.

<sup>Written for commit 72d144b17cbfba4743769fe03ce400c27a9afff2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

