### PR TITLE
Feat/fix and improvements

### DIFF
--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -140,9 +140,12 @@ Use the query bar for targeted searches:
 | `-tag:system` | exclude matching tag |
 | `level:warn tag:MyApp` | AND search |
 | `level:error | is:crash` | OR search |
+| `message:action_${action_name}_done` | message contains a value supplied by the `action_name` variable |
 
-Press **Enter** to commit a typed condition as a filter pill. Use **+ AND** and **+ OR** for compound filters. Saved filters are capped at 50.
+Press **Enter** to commit a typed condition as a filter pill. Use **+ AND** and **+ OR** for compound filters. When a filter is active, click **Save** beside the query bar to name and reuse it later from **Filters**. Saved filters are capped at 50.
 Click an `AND` or `OR` connector badge between filter pills to toggle only that connector while keeping the surrounding filters in place.
+Click the power icon on a filter pill to temporarily disable or re-enable that condition without removing it. Disabled filters stay editable and reset when the app session restarts.
+Use `${name}` inside filter values to create a filter variable. Click **Variables** beside the query bar to create variables before they are used, edit their values, insert them into the query, or delete them. Variables also appear in a compact row under the query bar for quick edits. Variable values are session-local and reset when the app restarts; saved filters keep the `${name}` template.
 
 ### Reading logs
 

--- a/e2e/smoke/logcat-regressions.spec.ts
+++ b/e2e/smoke/logcat-regressions.spec.ts
@@ -165,6 +165,7 @@ test("logcat query connector badges toggle only the clicked condition", async ({
   await expect(page.getByText("Alpha beta row")).toBeVisible();
   await expect(page.getByText("Beta only row")).toBeVisible();
   await expect(page.getByText("Gamma only row")).toBeVisible();
+  await expect(page.getByText(/Tab\/Enter select/)).not.toBeVisible();
 
   await page.getByRole("button", { name: "Change OR to AND" }).first().focus();
   await page.keyboard.press("Enter");
@@ -173,6 +174,231 @@ test("logcat query connector badges toggle only the clicked condition", async ({
   await expect(page.getByText("Gamma only row")).toBeVisible();
   await expect(page.getByText("Alpha only row")).not.toBeVisible();
   await expect(page.getByText("Beta only row")).not.toBeVisible();
+  await expect(page.getByText(/Tab\/Enter select/)).not.toBeVisible();
+});
+
+test("logcat filter pill can be temporarily disabled and re-enabled", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 120, tag: "AlphaOnly", message: "Alpha only disable row" },
+    { id: 121, tag: "AlphaBeta", message: "Alpha beta disable row" },
+    { id: 122, tag: "BetaOnly", message: "Beta only disable row" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(3, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("tag:Alpha tag:Beta ");
+
+  await expect(page.getByText("Alpha beta disable row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Alpha only disable row")).not.toBeVisible();
+  await expect(page.getByText("Beta only disable row")).not.toBeVisible();
+  await expect(page.getByText("tag:Beta")).toBeVisible();
+
+  await page.getByRole("button", { name: "Disable filter tag:Beta" }).click();
+
+  await expect(page.getByText("Alpha only disable row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Alpha beta disable row")).toBeVisible();
+  await expect(page.getByText("Beta only disable row")).not.toBeVisible();
+  await expect(page.getByText("tag:Beta")).toBeVisible();
+
+  await page.getByRole("button", { name: "Re-enable filter tag:Beta" }).click();
+
+  await expect(page.getByText("Alpha beta disable row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Alpha only disable row")).not.toBeVisible();
+  await expect(page.getByText("Beta only disable row")).not.toBeVisible();
+});
+
+test("logcat active filter can be saved from the query row and reapplied", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 130, tag: "SaveAlpha", message: "Saved alpha row" },
+    { id: 131, tag: "SaveBeta", message: "Saved beta row" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(2, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("tag:SaveAlpha ");
+
+  await expect(page.getByText("Saved alpha row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Saved beta row")).not.toBeVisible();
+
+  await page.getByTitle("Save current filter").click();
+  await page.getByPlaceholder("Filter name…").fill("Saved Alpha E2E");
+  await page.getByRole("button", { name: "Save" }).last().click();
+
+  await page.getByTitle("Clear all filters").first().click();
+  await expect(page.getByText("Saved alpha row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Saved beta row")).toBeVisible();
+
+  await page.getByTitle("Filter presets").click();
+  await page.getByTestId("logcat-filter-quick-row").getByText("Saved Alpha E2E").click();
+
+  await expect(page.getByText("Saved alpha row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Saved beta row")).not.toBeVisible();
+});
+
+test("logcat saving with a disabled pill stores only the effective filter", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 140, tag: "SaveAlpha", message: "Saved disabled alpha row" },
+    { id: 141, tag: "SaveAlphaBeta", message: "Saved disabled alpha beta row" },
+    { id: 142, tag: "SaveBeta", message: "Saved disabled beta row" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(3, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("tag:SaveAlpha tag:Beta ");
+
+  await expect(page.getByText("Saved disabled alpha beta row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Saved disabled alpha row")).not.toBeVisible();
+  await expect(page.getByText("Saved disabled beta row")).not.toBeVisible();
+
+  await page.getByRole("button", { name: "Disable filter tag:Beta" }).click();
+  await expect(page.getByText("Saved disabled alpha row")).toBeVisible({ timeout: 5_000 });
+
+  await page.getByTitle("Save current filter").click();
+  await page.getByPlaceholder("Filter name…").fill("Effective Alpha E2E");
+  await page.getByRole("button", { name: "Save" }).last().click();
+
+  await page.getByTitle("Clear all filters").first().click();
+  await page.getByTitle("Filter presets").click();
+  await page.getByTestId("logcat-filter-quick-row").getByText("Effective Alpha E2E").click();
+
+  await expect(page.getByText("Saved disabled alpha row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Saved disabled alpha beta row")).toBeVisible();
+  await expect(page.getByText("Saved disabled beta row")).not.toBeVisible();
+});
+
+test("logcat filter variables resolve from the variable row", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 150, tag: "VariableAction", message: "action_checkout_done" },
+    { id: 151, tag: "VariableAction", message: "action_login_done" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(2, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("message:action_${action_name}_done ");
+
+  await expect(page.getByTestId("logcat-filter-variable-row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("action_checkout_done")).not.toBeVisible();
+  await expect(page.getByText("action_login_done")).not.toBeVisible();
+
+  await page.getByTitle("Variable action_name").fill("checkout");
+
+  await expect(page.getByText("action_checkout_done")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("action_login_done")).not.toBeVisible();
+
+  await page.getByTitle("Save current filter").click();
+  await page.getByPlaceholder("Filter name…").fill("Variable Action E2E");
+  await page.getByRole("button", { name: "Save" }).last().click();
+
+  await page.getByTitle("Clear all filters").first().click();
+  await expect(page.getByText("action_checkout_done")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("action_login_done")).toBeVisible();
+
+  await page.getByTitle("Filter presets").click();
+  await page.getByTestId("logcat-filter-quick-row").getByText("Variable Action E2E").click();
+
+  await expect(page.getByTestId("logcat-filter-variable-row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("action_checkout_done")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("action_login_done")).not.toBeVisible();
+
+  await page.getByTitle("Variable action_name").fill("login");
+
+  await expect(page.getByText("action_login_done")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("action_checkout_done")).not.toBeVisible();
+});
+
+test("logcat variables can be created before they are used in a filter", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 155, tag: "PrecreatedVariable", message: "action_checkout" },
+    { id: 156, tag: "PrecreatedVariable", message: "action_login" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(2, { timeout: 5_000 });
+
+  await page.getByTitle("Manage filter variables").click();
+  await page.getByPlaceholder("variable_name").fill("action_name");
+  await page.getByPlaceholder("Initial value").fill("checkout");
+  await page.getByRole("button", { name: "Add variable" }).click();
+  await expect(
+    page.getByTestId("logcat-filter-variable-row").getByTitle("Variable action_name")
+  ).toHaveValue("checkout");
+
+  await page.mouse.click(5, 5);
+  await expect(page.getByTestId("logcat-variable-manager")).not.toBeVisible();
+  await page.locator('input[type="text"][placeholder*="Filter"]').first().fill("message:action_");
+  await page.getByTitle("Manage filter variables").click();
+  await page.getByTitle("Insert variable action_name").click();
+
+  await expect(page.getByText("action_checkout")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("action_login")).not.toBeVisible();
+});
+
+test("logcat filter variables work inside quoted OR group filters", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 160, tag: "VariableAction", message: "User checkout button clicked" },
+    { id: 161, tag: "VariableAction", message: "User login button clicked" },
+    { id: 162, tag: "VariableFallback", message: "fallback variable row" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(3, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill('message:"User ${action_name} clicked" | tag:VariableFallback ');
+
+  await expect(page.getByTestId("logcat-filter-variable-row")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("fallback variable row")).toBeVisible();
+  await expect(page.getByText("User checkout button clicked")).not.toBeVisible();
+  await expect(page.getByText("User login button clicked")).not.toBeVisible();
+
+  await page.getByTitle("Variable action_name").fill("checkout button");
+
+  await expect(page.getByText("User checkout button clicked")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("fallback variable row")).toBeVisible();
+  await expect(page.getByText("User login button clicked")).not.toBeVisible();
+});
+
+test("logcat disabled variable pills stay editable and stop affecting filtering", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 170, tag: "VariableAlpha", message: "alpha_checkout_done" },
+    { id: 171, tag: "VariableAlpha", message: "alpha_login_done" },
+    { id: 172, tag: "VariableBeta", message: "beta_checkout_done" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(3, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("tag:VariableAlpha message:${action_name}_checkout_done ");
+  await page.getByTitle("Variable action_name").fill("alpha");
+
+  await expect(page.getByText("alpha_checkout_done")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("alpha_login_done")).not.toBeVisible();
+  await expect(page.getByText("beta_checkout_done")).not.toBeVisible();
+
+  await page
+    .getByRole("button", { name: "Disable filter message:${action_name}_checkout_done" })
+    .click();
+
+  await expect(page.getByTestId("logcat-filter-variable-row")).toBeVisible();
+  await expect(page.getByText("message:${action_name}_checkout_done")).toBeVisible();
+  await expect(page.getByText("alpha_checkout_done")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("alpha_login_done")).toBeVisible();
+  await expect(page.getByText("beta_checkout_done")).not.toBeVisible();
+
+  await page.getByTitle("Variable action_name").fill("beta");
+
+  await expect(page.getByText("alpha_checkout_done")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("alpha_login_done")).toBeVisible();
+  await expect(page.getByText("beta_checkout_done")).not.toBeVisible();
 });
 
 test("logcat selected row stays frozen while the live buffer overflows", async ({ page }) => {

--- a/src/components/logcat/LogcatFilterControls.test.tsx
+++ b/src/components/logcat/LogcatFilterControls.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@solidjs/testing-library";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LogcatFilterControls } from "./LogcatFilterControls";
+import { buildQueryBarPillRefs } from "@/lib/logcat-query";
 
 function renderFilterControls(overrides: Partial<Parameters<typeof LogcatFilterControls>[0]> = {}) {
   const props: Parameters<typeof LogcatFilterControls>[0] = {
@@ -17,7 +18,6 @@ function renderFilterControls(overrides: Partial<Parameters<typeof LogcatFilterC
     onPackageSelect: vi.fn(),
     onToggleLifecycle: vi.fn(),
     onClear: vi.fn(),
-    renderSavedFilterMenu: () => <div data-testid="saved-filter-menu">Filters</div>,
     ...overrides,
   };
 
@@ -28,6 +28,10 @@ function renderFilterControls(overrides: Partial<Parameters<typeof LogcatFilterC
 }
 
 describe("LogcatFilterControls", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("renders the query row before the quick-filter row", () => {
     renderFilterControls();
 
@@ -38,11 +42,11 @@ describe("LogcatFilterControls", () => {
     expect(siblings.indexOf(queryRow)).toBeLessThan(siblings.indexOf(quickRow));
   });
 
-  it("renders saved filters in the quick-filter row", () => {
+  it("renders filter presets in the quick-filter row", () => {
     renderFilterControls();
 
     const quickRow = screen.getByTestId("logcat-filter-quick-row");
-    expect(quickRow.contains(screen.getByTestId("saved-filter-menu"))).toBe(true);
+    expect(quickRow.contains(screen.getByTitle("Filter presets"))).toBe(true);
   });
 
   it("selects age quick filters", () => {
@@ -93,5 +97,173 @@ describe("LogcatFilterControls", () => {
     fireEvent.click(screen.getByTitle("Clear all filters"));
 
     expect(onClear).toHaveBeenCalledOnce();
+  });
+
+  it("shows variable inputs between the query row and quick filters", () => {
+    renderFilterControls({
+      isFiltered: true,
+      query: "message:${action_name} tag:${screen} ",
+      variableValues: { action_name: "tap" },
+    });
+
+    const queryRow = screen.getByTestId("logcat-filter-query-row");
+    const variableRow = screen.getByTestId("logcat-filter-variable-row");
+    const quickRow = screen.getByTestId("logcat-filter-quick-row");
+    const siblings = Array.from(queryRow.parentElement?.children ?? []);
+
+    expect(siblings.indexOf(queryRow)).toBeLessThan(siblings.indexOf(variableRow));
+    expect(siblings.indexOf(variableRow)).toBeLessThan(siblings.indexOf(quickRow));
+    expect((screen.getByTitle("Variable action_name") as HTMLInputElement).value).toBe("tap");
+    expect((screen.getByTitle("Variable screen") as HTMLInputElement).value).toBe("");
+  });
+
+  it("updates variable values from the variable row", () => {
+    const onVariableValueChange = vi.fn();
+    renderFilterControls({
+      isFiltered: true,
+      query: "message:some_prefix_${action_name} ",
+      variableValues: { action_name: "" },
+      onVariableValueChange,
+    });
+
+    fireEvent.input(screen.getByTitle("Variable action_name"), {
+      target: { value: "checkout" },
+    });
+
+    expect(onVariableValueChange).toHaveBeenCalledWith("action_name", "checkout");
+  });
+
+  it("shows predefined variables even before the query references them", () => {
+    renderFilterControls({
+      isFiltered: false,
+      query: "",
+      variableValues: { action_name: "checkout" },
+    });
+
+    expect(screen.getByTestId("logcat-filter-variable-row")).not.toBeNull();
+    expect((screen.getByTitle("Variable action_name") as HTMLInputElement).value).toBe("checkout");
+  });
+
+  it("creates variables from the manager before they are used in the query", () => {
+    const onVariableValueChange = vi.fn();
+    renderFilterControls({
+      variableValues: {},
+      onVariableValueChange,
+    });
+
+    fireEvent.click(screen.getByTitle("Manage filter variables"));
+    fireEvent.input(screen.getByPlaceholderText("variable_name"), {
+      target: { value: "action_name" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("Initial value"), {
+      target: { value: "checkout" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add variable" }));
+
+    expect(onVariableValueChange).toHaveBeenCalledWith("action_name", "checkout");
+  });
+
+  it("inserts an existing variable token from the manager", () => {
+    const onVariableInsert = vi.fn();
+    renderFilterControls({
+      variableValues: { action_name: "checkout" },
+      onVariableInsert,
+    });
+
+    fireEvent.click(screen.getByTitle("Manage filter variables"));
+    fireEvent.click(screen.getByTitle("Insert variable action_name"));
+
+    expect(onVariableInsert).toHaveBeenCalledWith("action_name");
+  });
+
+  it("deletes variables from the manager", () => {
+    const onVariableDelete = vi.fn();
+    renderFilterControls({
+      variableValues: { action_name: "checkout" },
+      onVariableDelete,
+    });
+
+    fireEvent.click(screen.getByTitle("Manage filter variables"));
+    fireEvent.click(screen.getByTitle("Delete variable action_name"));
+
+    expect(onVariableDelete).toHaveBeenCalledWith("action_name");
+  });
+
+  it("hides the direct save button until a filter is active", () => {
+    renderFilterControls({ isFiltered: false, query: "" });
+
+    expect(screen.queryByTitle("Save current filter")).toBeNull();
+  });
+
+  it("saves the active query from the query row and shows it in the filters menu", () => {
+    renderFilterControls({
+      isFiltered: true,
+      query: "level:error ",
+    });
+
+    fireEvent.click(screen.getByTitle("Save current filter"));
+    fireEvent.input(screen.getByPlaceholderText("Filter name…"), {
+      target: { value: "Errors" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[1]!);
+    fireEvent.click(screen.getByTitle("Filter presets"));
+
+    expect(screen.getByText("Errors")).not.toBeNull();
+  });
+
+  it("opens the direct save name box with an opaque panel background", () => {
+    renderFilterControls({
+      isFiltered: true,
+      query: "level:error ",
+    });
+
+    fireEvent.click(screen.getByTitle("Save current filter"));
+
+    const box = screen.getByPlaceholderText("Filter name…").parentElement;
+    expect(box?.getAttribute("style")).toContain("background:var(--bg-secondary)");
+  });
+
+  it("saves the effective active query when a pill is temporarily disabled", () => {
+    const onQueryChange = vi.fn();
+    const refs = buildQueryBarPillRefs(["tag:Alpha", "tag:Beta"]);
+    const beta = refs.find((ref) => ref.token === "tag:Beta")!;
+
+    renderFilterControls({
+      isFiltered: true,
+      query: "tag:Alpha tag:Beta ",
+      disabledPillIds: new Set([beta.id]),
+      onQueryChange,
+    });
+
+    fireEvent.click(screen.getByTitle("Save current filter"));
+    fireEvent.input(screen.getByPlaceholderText("Filter name…"), {
+      target: { value: "Alpha only" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[1]!);
+    fireEvent.click(screen.getByTitle("Filter presets"));
+    fireEvent.click(screen.getByText("Alpha only"));
+
+    expect(onQueryChange).toHaveBeenCalledWith("tag:Alpha ");
+  });
+
+  it("saves variable filters as reusable templates instead of resolved values", () => {
+    const onQueryChange = vi.fn();
+
+    renderFilterControls({
+      isFiltered: true,
+      query: "message:action_${action_name}_done ",
+      variableValues: { action_name: "checkout" },
+      onQueryChange,
+    });
+
+    fireEvent.click(screen.getByTitle("Save current filter"));
+    fireEvent.input(screen.getByPlaceholderText("Filter name…"), {
+      target: { value: "Action template" },
+    });
+    fireEvent.click(screen.getAllByRole("button", { name: "Save" })[1]!);
+    fireEvent.click(screen.getByTitle("Filter presets"));
+    fireEvent.click(screen.getByText("Action template"));
+
+    expect(onQueryChange).toHaveBeenCalledWith("message:action_${action_name}_done ");
   });
 });

--- a/src/components/logcat/LogcatFilterControls.tsx
+++ b/src/components/logcat/LogcatFilterControls.tsx
@@ -1,7 +1,21 @@
-import { For, Show, type JSX } from "solid-js";
+import { For, Show, createMemo, createSignal, type JSX } from "solid-js";
+import { showToast } from "@/components/ui";
 import { QueryBar } from "@/components/logcat/QueryBar";
 import { PackageDropdown } from "@/components/logcat/PackageDropdown";
+import {
+  addSavedFilter,
+  deleteSavedFilter,
+  loadFilterStorage,
+  renameSavedFilter,
+} from "@/lib/logcat-filter-storage";
+import {
+  buildEffectiveQueryWithDisabledPills,
+  extractQueryVariables,
+  isValidQueryVariableName,
+  type QueryVariableValues,
+} from "@/lib/logcat-query";
 import { btnStyle } from "./logcat-styles";
+import { SavedFilterMenu } from "./SavedFilterMenu";
 
 export const LOGCAT_AGE_PILLS = [
   { label: "30s", value: "30s" },
@@ -22,14 +36,50 @@ export function LogcatFilterControls(props: {
   activeAge: string | null;
   activePackage: string | null;
   isFiltered: boolean;
+  disabledPillIds?: ReadonlySet<string>;
+  variableValues?: QueryVariableValues;
   showLifecycle: boolean;
   onQueryChange: (query: string) => void;
+  onTogglePillDisabled?: (id: string) => void;
+  onVariableValueChange?: (name: string, value: string) => void;
+  onVariableDelete?: (name: string) => void;
+  onVariableInsert?: (name: string) => void;
   onAgeSelect: (value: LogcatAgePillValue) => void;
   onPackageSelect: (pkg: string | null) => void;
   onToggleLifecycle: () => void;
+  onApplySavedQuery?: (query: string) => void;
   onClear: () => void;
-  renderSavedFilterMenu: () => JSX.Element;
 }): JSX.Element {
+  const [savedFilters, setSavedFilters] = createSignal(loadFilterStorage().filters);
+
+  function refreshSavedFilters(): void {
+    setSavedFilters(loadFilterStorage().filters);
+  }
+
+  function saveCurrentFilter(name: string): void {
+    try {
+      const effectiveQuery = buildEffectiveQueryWithDisabledPills(
+        props.query,
+        props.disabledPillIds ?? new Set<string>()
+      );
+      const saved = addSavedFilter(name, effectiveQuery);
+      refreshSavedFilters();
+      showToast(`Saved filter "${saved.name}"`, "success");
+    } catch (e) {
+      showToast(String(e), "error");
+    }
+  }
+
+  function handleDeleteSavedFilter(id: string): void {
+    deleteSavedFilter(id);
+    refreshSavedFilters();
+  }
+
+  function handleRenameSavedFilter(id: string, name: string): void {
+    renameSavedFilter(id, name);
+    refreshSavedFilters();
+  }
+
   return (
     <div
       style={{
@@ -46,6 +96,8 @@ export function LogcatFilterControls(props: {
         data-testid="logcat-filter-query-row"
         style={{
           display: "flex",
+          "align-items": "flex-start",
+          gap: "6px",
           width: "100%",
           "min-width": "0",
         }}
@@ -55,8 +107,28 @@ export function LogcatFilterControls(props: {
           onChange={props.onQueryChange}
           knownTags={props.knownTags}
           knownPackages={props.knownPackages}
+          disabledPillIds={props.disabledPillIds}
+          onTogglePillDisabled={props.onTogglePillDisabled}
+        />
+        <DirectSaveFilterButton
+          query={props.query}
+          isFiltered={props.isFiltered}
+          onSave={saveCurrentFilter}
+        />
+        <VariableManagerButton
+          query={props.query}
+          values={props.variableValues ?? {}}
+          onChange={props.onVariableValueChange}
+          onDelete={props.onVariableDelete}
+          onInsert={props.onVariableInsert}
         />
       </div>
+
+      <QueryVariableControls
+        query={props.query}
+        values={props.variableValues ?? {}}
+        onChange={props.onVariableValueChange}
+      />
 
       <div
         data-testid="logcat-filter-quick-row"
@@ -68,7 +140,12 @@ export function LogcatFilterControls(props: {
           "min-width": "0",
         }}
       >
-        {props.renderSavedFilterMenu()}
+        <SavedFilterMenu
+          savedFilters={savedFilters()}
+          onApplyQuery={props.onApplySavedQuery ?? props.onQueryChange}
+          onDeleteSavedFilter={handleDeleteSavedFilter}
+          onRenameSavedFilter={handleRenameSavedFilter}
+        />
 
         <div
           style={{
@@ -168,5 +245,446 @@ export function LogcatFilterControls(props: {
         </Show>
       </div>
     </div>
+  );
+}
+
+function getVariableNames(query: string, values: QueryVariableValues): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+
+  for (const name of Object.keys(values)) {
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+
+  for (const name of extractQueryVariables(query)) {
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+
+  return names;
+}
+
+function QueryVariableControls(props: {
+  query: string;
+  values: QueryVariableValues;
+  onChange?: (name: string, value: string) => void;
+}): JSX.Element {
+  const variables = createMemo(() => getVariableNames(props.query, props.values));
+
+  return (
+    <Show when={variables().length > 0}>
+      <div
+        data-testid="logcat-filter-variable-row"
+        style={{
+          display: "flex",
+          "align-items": "center",
+          gap: "6px",
+          "flex-wrap": "wrap",
+          "min-width": "0",
+          padding: "1px 0",
+        }}
+      >
+        <span
+          style={{
+            "font-size": "10px",
+            color: "var(--text-muted)",
+            "flex-shrink": "0",
+          }}
+        >
+          Variables
+        </span>
+        <For each={variables()}>
+          {(name) => (
+            <label
+              style={{
+                display: "inline-flex",
+                "align-items": "center",
+                gap: "4px",
+                "min-width": "0",
+                "flex-shrink": "0",
+                background: "var(--bg-primary)",
+                border: "1px solid var(--border)",
+                "border-radius": "4px",
+                padding: "2px 5px",
+              }}
+            >
+              <span
+                style={{
+                  "font-size": "10px",
+                  "font-family": "var(--font-mono)",
+                  color: "var(--accent)",
+                  "white-space": "nowrap",
+                }}
+              >
+                {name}
+              </span>
+              <input
+                title={`Variable ${name}`}
+                type="text"
+                value={props.values[name] ?? ""}
+                placeholder="value"
+                spellcheck={false}
+                onInput={(e) => props.onChange?.(name, e.currentTarget.value)}
+                style={{
+                  width: "120px",
+                  "min-width": "72px",
+                  background: "transparent",
+                  border: "0",
+                  color: "var(--text-primary)",
+                  "font-size": "10px",
+                  "font-family": "var(--font-mono)",
+                  outline: "none",
+                  padding: "0",
+                }}
+              />
+            </label>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+}
+
+function VariableManagerButton(props: {
+  query: string;
+  values: QueryVariableValues;
+  onChange?: (name: string, value: string) => void;
+  onDelete?: (name: string) => void;
+  onInsert?: (name: string) => void;
+}): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const [draftName, setDraftName] = createSignal("");
+  const [draftValue, setDraftValue] = createSignal("");
+  const variables = createMemo(() => getVariableNames(props.query, props.values));
+  const queryVariables = createMemo(() => new Set(extractQueryVariables(props.query)));
+  const normalizedName = createMemo(() => draftName().trim());
+  const canAdd = createMemo(() => isValidQueryVariableName(normalizedName()));
+
+  function close(): void {
+    setOpen(false);
+    setDraftName("");
+    setDraftValue("");
+  }
+
+  function addVariable(): void {
+    const name = normalizedName();
+    if (!isValidQueryVariableName(name)) return;
+    props.onChange?.(name, draftValue());
+    setDraftName("");
+    setDraftValue("");
+  }
+
+  return (
+    <div style={{ position: "relative", "flex-shrink": "0" }}>
+      <button
+        type="button"
+        title="Manage filter variables"
+        onClick={() => setOpen((value) => !value)}
+        style={{
+          ...btnStyle("var(--text-muted)"),
+          height: "28px",
+          padding: "0 10px",
+          "font-size": "11px",
+          "font-weight": "600",
+        }}
+      >
+        Variables
+      </button>
+
+      <Show when={open()}>
+        <>
+          <div
+            data-testid="logcat-variable-manager"
+            style={{
+              position: "absolute",
+              top: "32px",
+              right: "0",
+              "z-index": "1000",
+              display: "flex",
+              "flex-direction": "column",
+              gap: "8px",
+              padding: "8px",
+              background: "var(--bg-secondary)",
+              border: "1px solid var(--border)",
+              "border-radius": "6px",
+              "box-shadow": "0 8px 24px rgba(0,0,0,0.35)",
+              width: "360px",
+            }}
+          >
+            <div
+              style={{
+                display: "grid",
+                "grid-template-columns": "minmax(0, 1fr) minmax(0, 1fr) auto",
+                gap: "6px",
+                "align-items": "center",
+              }}
+            >
+              <input
+                type="text"
+                placeholder="variable_name"
+                value={draftName()}
+                onInput={(e) => setDraftName(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") addVariable();
+                  if (e.key === "Escape") close();
+                }}
+                style={variableManagerInputStyle()}
+              />
+              <input
+                type="text"
+                placeholder="Initial value"
+                value={draftValue()}
+                onInput={(e) => setDraftValue(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") addVariable();
+                  if (e.key === "Escape") close();
+                }}
+                style={variableManagerInputStyle()}
+              />
+              <button
+                type="button"
+                disabled={!canAdd()}
+                onClick={addVariable}
+                style={{
+                  ...btnStyle(canAdd() ? "var(--accent)" : "var(--text-muted)"),
+                  opacity: canAdd() ? "1" : "0.45",
+                  cursor: canAdd() ? "pointer" : "not-allowed",
+                }}
+              >
+                Add variable
+              </button>
+            </div>
+
+            <Show
+              when={variables().length > 0}
+              fallback={
+                <div
+                  style={{
+                    color: "var(--text-muted)",
+                    "font-size": "11px",
+                    padding: "4px 2px",
+                  }}
+                >
+                  No variables
+                </div>
+              }
+            >
+              <div
+                style={{
+                  display: "flex",
+                  "flex-direction": "column",
+                  gap: "5px",
+                  "max-height": "220px",
+                  overflow: "auto",
+                }}
+              >
+                <For each={variables()}>
+                  {(name) => (
+                    <div
+                      style={{
+                        display: "grid",
+                        "grid-template-columns": "minmax(80px, 0.8fr) minmax(0, 1fr) auto auto",
+                        gap: "6px",
+                        "align-items": "center",
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          "align-items": "center",
+                          gap: "4px",
+                          "min-width": "0",
+                        }}
+                      >
+                        <span
+                          style={{
+                            "font-size": "11px",
+                            "font-family": "var(--font-mono)",
+                            color: "var(--accent)",
+                            overflow: "hidden",
+                            "text-overflow": "ellipsis",
+                            "white-space": "nowrap",
+                          }}
+                          title={`\${${name}}`}
+                        >
+                          {name}
+                        </span>
+                        <Show when={queryVariables().has(name)}>
+                          <span
+                            style={{
+                              "font-size": "9px",
+                              color: "var(--text-muted)",
+                              border: "1px solid var(--border)",
+                              "border-radius": "8px",
+                              padding: "0 4px",
+                              "flex-shrink": "0",
+                            }}
+                          >
+                            used
+                          </span>
+                        </Show>
+                      </div>
+                      <input
+                        type="text"
+                        title={`Variable ${name}`}
+                        value={props.values[name] ?? ""}
+                        placeholder="value"
+                        onInput={(e) => props.onChange?.(name, e.currentTarget.value)}
+                        style={variableManagerInputStyle()}
+                      />
+                      <button
+                        type="button"
+                        title={`Insert variable ${name}`}
+                        onClick={() => props.onInsert?.(name)}
+                        style={btnStyle("var(--accent)")}
+                      >
+                        Insert
+                      </button>
+                      <button
+                        type="button"
+                        title={`Delete variable ${name}`}
+                        onClick={() => props.onDelete?.(name)}
+                        style={btnStyle("var(--text-muted)")}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </Show>
+          </div>
+          <div
+            onClick={close}
+            style={{
+              position: "fixed",
+              inset: "0",
+              "z-index": "999",
+            }}
+          />
+        </>
+      </Show>
+    </div>
+  );
+}
+
+function variableManagerInputStyle(): JSX.CSSProperties {
+  return {
+    background: "var(--bg-primary)",
+    border: "1px solid var(--border)",
+    color: "var(--text-primary)",
+    "border-radius": "4px",
+    padding: "4px 7px",
+    "font-size": "11px",
+    "font-family": "var(--font-mono)",
+    outline: "none",
+    "min-width": "0",
+  };
+}
+
+function DirectSaveFilterButton(props: {
+  query: string;
+  isFiltered: boolean;
+  onSave: (name: string) => void;
+}): JSX.Element {
+  const [open, setOpen] = createSignal(false);
+  const [draft, setDraft] = createSignal("");
+
+  function close(): void {
+    setOpen(false);
+    setDraft("");
+  }
+
+  function save(): void {
+    const name = draft().trim();
+    if (!name) return;
+    props.onSave(name);
+    close();
+  }
+
+  return (
+    <Show when={props.isFiltered}>
+      <div style={{ position: "relative", "flex-shrink": "0" }}>
+        <button
+          type="button"
+          title="Save current filter"
+          onClick={() => {
+            setOpen((v) => !v);
+            setDraft("");
+          }}
+          style={{
+            ...btnStyle("var(--accent)"),
+            height: "28px",
+            padding: "0 10px",
+            "font-size": "11px",
+            "font-weight": "600",
+          }}
+        >
+          Save
+        </button>
+
+        <Show when={open()}>
+          <>
+            <div
+              style={{
+                position: "absolute",
+                top: "32px",
+                right: "0",
+                "z-index": "1000",
+                display: "flex",
+                gap: "6px",
+                padding: "8px",
+                background: "var(--bg-secondary)",
+                border: "1px solid var(--border)",
+                "border-radius": "6px",
+                "box-shadow": "0 8px 24px rgba(0,0,0,0.35)",
+                "min-width": "260px",
+              }}
+            >
+              <input
+                type="text"
+                placeholder="Filter name…"
+                value={draft()}
+                onInput={(e) => setDraft(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") save();
+                  if (e.key === "Escape") close();
+                }}
+                autofocus
+                style={{
+                  flex: "1",
+                  background: "var(--bg-primary)",
+                  border: "1px solid var(--border)",
+                  color: "var(--text-primary)",
+                  "border-radius": "4px",
+                  padding: "4px 7px",
+                  "font-size": "11px",
+                  outline: "none",
+                }}
+              />
+              <button type="button" onClick={save} style={btnStyle("var(--accent)")}>
+                Save
+              </button>
+              <button type="button" onClick={close} style={btnStyle("var(--text-muted)")}>
+                Cancel
+              </button>
+            </div>
+            <div
+              onClick={close}
+              style={{
+                position: "fixed",
+                inset: "0",
+                "z-index": "999",
+              }}
+            />
+          </>
+        </Show>
+      </div>
+    </Show>
   );
 }

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { LogcatFilterSpec, LogStats, ProcessedEntry } from "@/bindings";
+import { addSavedFilter } from "@/lib/logcat-filter-storage";
 import {
   replaceLogcatEntries,
   setLogcatRingBufferTotal,
@@ -76,8 +77,10 @@ function filterEntries(entries: ProcessedEntry[], spec: LogcatFilterSpec): Proce
 
 function installLogcatPanelMocks(entries: ProcessedEntry[]): {
   emitLogcatEntries: (entries: ProcessedEntry[]) => void;
+  setFilterCalls: () => LogcatFilterSpec[];
 } {
   let activeFilter = emptyFilter();
+  const setFilterCalls: LogcatFilterSpec[] = [];
   const listeners = new Map<string, (event: { payload: unknown }) => void>();
 
   vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
@@ -99,6 +102,7 @@ function installLogcatPanelMocks(entries: ProcessedEntry[]): {
       case "set_logcat_filter": {
         const payload = args as { filterSpec?: LogcatFilterSpec };
         activeFilter = payload.filterSpec ?? emptyFilter();
+        setFilterCalls.push(activeFilter);
         return undefined;
       }
       default:
@@ -116,6 +120,9 @@ function installLogcatPanelMocks(entries: ProcessedEntry[]): {
   return {
     emitLogcatEntries(nextEntries: ProcessedEntry[]) {
       listeners.get("logcat:entries")?.({ payload: filterEntries(nextEntries, activeFilter) });
+    },
+    setFilterCalls() {
+      return [...setFilterCalls];
     },
   };
 }
@@ -139,6 +146,7 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     replaceLogcatEntries([]);
     setLogcatStreaming(false);
     setLogcatRingBufferTotal(null);
@@ -325,5 +333,83 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
     expect(screen.getAllByText("visible app crash").length).toBeGreaterThan(0);
     expect(screen.queryByText("hidden lifecycle crash")).toBeNull();
     expect(screen.getByTitle("1 crash — click to jump")).not.toBeNull();
+  });
+
+  it("clears disabled pill state when applying a saved filter", async () => {
+    addSavedFilter("Beta only", "tag:Beta");
+    installLogcatPanelMocks([
+      {
+        ...BASE_ENTRY,
+        id: 50n,
+        tag: "AlphaOnly",
+        message: "Alpha only saved-filter row",
+      },
+      {
+        ...BASE_ENTRY,
+        id: 51n,
+        tag: "AlphaBeta",
+        message: "Alpha beta saved-filter row",
+      },
+      {
+        ...BASE_ENTRY,
+        id: 52n,
+        tag: "BetaOnly",
+        message: "Beta only saved-filter row",
+      },
+    ]);
+    render(() => <LogcatPanel />);
+
+    await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(3));
+
+    const input = screen.getByRole("textbox");
+    fireEvent.input(input, { target: { value: "tag:Alpha tag:Beta " } });
+
+    await waitFor(() => expect(screen.getByText("Alpha beta saved-filter row")).not.toBeNull());
+    await waitFor(() => expect(screen.queryByText("Alpha only saved-filter row")).toBeNull());
+
+    fireEvent.click(screen.getByRole("button", { name: "Disable filter tag:Beta" }));
+
+    await waitFor(() => expect(screen.getByText("Alpha only saved-filter row")).not.toBeNull());
+
+    fireEvent.click(screen.getByTitle("Filter presets"));
+    fireEvent.click(screen.getByText("Beta only"));
+
+    await waitFor(() => expect(screen.getByText("Beta only saved-filter row")).not.toBeNull());
+    expect(screen.getByText("Alpha beta saved-filter row")).not.toBeNull();
+    expect(screen.queryByText("Alpha only saved-filter row")).toBeNull();
+  });
+
+  it("debounces backend filter sync while editing variable values", async () => {
+    vi.useFakeTimers();
+    const mocks = installLogcatPanelMocks([BASE_ENTRY]);
+    render(() => <LogcatPanel />);
+
+    await vi.runOnlyPendingTimersAsync();
+    await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(1));
+
+    const input = screen.getByRole("textbox");
+    fireEvent.input(input, { target: { value: "message:action_${action_name}_done " } });
+    await vi.advanceTimersByTimeAsync(150);
+    await Promise.resolve();
+
+    const afterQueryCommit = mocks.setFilterCalls().length;
+    const variableInput = screen.getByTitle("Variable action_name");
+
+    fireEvent.input(variableInput, { target: { value: "c" } });
+    fireEvent.input(variableInput, { target: { value: "ch" } });
+    fireEvent.input(variableInput, { target: { value: "checkout" } });
+    await Promise.resolve();
+
+    expect(mocks.setFilterCalls()).toHaveLength(afterQueryCommit);
+
+    await vi.advanceTimersByTimeAsync(149);
+    await Promise.resolve();
+
+    expect(mocks.setFilterCalls()).toHaveLength(afterQueryCommit);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+
+    expect(mocks.setFilterCalls()).toHaveLength(afterQueryCommit + 1);
   });
 });

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -32,6 +32,10 @@ import {
   parseAge,
   parseFilterGroups,
   matchesFilterGroups,
+  buildEffectiveQueryWithDisabledPills,
+  reconcileDisabledQueryPillIds,
+  ensureQueryVariableValues,
+  resolveQueryVariables,
   setAgeInQuery,
   setPackageInQuery,
   getPackageFromQuery,
@@ -39,6 +43,7 @@ import {
   appendLogEntryDetailFilterToken,
   type LogEntryDetailFilterMode,
   type FilterGroup,
+  type QueryVariableValues,
 } from "@/lib/logcat-query";
 import { projectState } from "@/stores/project.store";
 import { buildState } from "@/stores/build.store";
@@ -70,7 +75,6 @@ import {
 import { createLatestOnlyGuard } from "@/services/logcat.service";
 import { JsonDetailPanel } from "./LogcatJsonDetailPanel";
 import { LogcatVirtualRow, SeparatorRow } from "./LogcatRows";
-import { SavedFilterMenu } from "./SavedFilterMenu";
 import {
   LogcatFilterControls,
   LOGCAT_AGE_PILLS,
@@ -98,7 +102,14 @@ function isLogcatTypingTarget(target: unknown): boolean {
 export function LogcatPanel(): JSX.Element {
   const [query, setQuery] = createSignal("");
   const [debouncedQuery, setDebouncedQuery] = createSignal("");
+  const [disabledPillIds, setDisabledPillIds] = createSignal<Set<string>>(new Set(), {
+    equals: false,
+  });
+  const [queryVariableValues, setQueryVariableValues] = createSignal<QueryVariableValues>({});
+  const [debouncedQueryVariableValues, setDebouncedQueryVariableValues] =
+    createSignal<QueryVariableValues>({});
   let _queryDebounce: ReturnType<typeof setTimeout> | undefined;
+  let _variableDebounce: ReturnType<typeof setTimeout> | undefined;
 
   function updateQuery(q: string) {
     exitReadMode();
@@ -107,8 +118,66 @@ export function LogcatPanel(): JSX.Element {
     setSelectedJsonEntry(null);
     setSelectedDetailEntry(null);
     setQuery(q);
+    setQueryVariableValues((values) => ensureQueryVariableValues(q, values));
+    setDebouncedQueryVariableValues((values) => ensureQueryVariableValues(q, values));
+    setDisabledPillIds((ids) => reconcileDisabledQueryPillIds(q, ids));
     clearTimeout(_queryDebounce);
     _queryDebounce = setTimeout(() => setDebouncedQuery(q), 150);
+  }
+
+  function scheduleDebouncedQueryVariableValues(values: QueryVariableValues): void {
+    clearTimeout(_variableDebounce);
+    _variableDebounce = setTimeout(() => {
+      setDebouncedQueryVariableValues(ensureQueryVariableValues(query(), values));
+    }, 150);
+  }
+
+  function updateQueryVariableValue(name: string, value: string): void {
+    exitReadMode();
+    setSelectionAnchor(null);
+    setSelectionEnd(null);
+    setSelectedJsonEntry(null);
+    setSelectedDetailEntry(null);
+    const nextValues = ensureQueryVariableValues(query(), {
+      ...queryVariableValues(),
+      [name]: value,
+    });
+    setQueryVariableValues(nextValues);
+    scheduleDebouncedQueryVariableValues(nextValues);
+  }
+
+  function deleteQueryVariable(name: string): void {
+    const next = { ...queryVariableValues() };
+    delete next[name];
+    const nextValues = ensureQueryVariableValues(query(), next);
+    setQueryVariableValues(nextValues);
+    scheduleDebouncedQueryVariableValues(nextValues);
+  }
+
+  function insertQueryVariable(name: string): void {
+    updateQuery(`${query()}\${${name}}`);
+  }
+
+  function applyPresetQuery(q: string): void {
+    setDisabledPillIds(new Set<string>());
+    updateQuery(q);
+  }
+
+  function togglePillDisabled(id: string): void {
+    exitReadMode();
+    setSelectionAnchor(null);
+    setSelectionEnd(null);
+    setSelectedJsonEntry(null);
+    setSelectedDetailEntry(null);
+    setDisabledPillIds((ids) => {
+      const next = new Set(ids);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return reconcileDisabledQueryPillIds(query(), next);
+    });
   }
 
   const [autoScroll, setAutoScroll] = createSignal(settingsState.logcat.autoScrollToEnd !== false);
@@ -158,7 +227,13 @@ export function LogcatPanel(): JSX.Element {
   let nowTimer: ReturnType<typeof setInterval> | undefined;
 
   // ── Parsed query (debounced — avoids re-parsing on every keystroke)
-  const parsedGroups = createMemo(() => parseFilterGroups(debouncedQuery()));
+  const effectiveDebouncedQueryTemplate = createMemo(() =>
+    buildEffectiveQueryWithDisabledPills(debouncedQuery(), disabledPillIds())
+  );
+  const effectiveDebouncedQuery = createMemo(() =>
+    resolveQueryVariables(effectiveDebouncedQueryTemplate(), debouncedQueryVariableValues())
+  );
+  const parsedGroups = createMemo(() => parseFilterGroups(effectiveDebouncedQuery()));
   // Flat token list for single-group utilities (age detection, etc.)
   const parsedTokens = createMemo(() => parsedGroups().flat());
   const hasAgeFilter = createMemo(() => parsedTokens().some((t) => t.type === "age"));
@@ -273,7 +348,7 @@ export function LogcatPanel(): JSX.Element {
     return null;
   });
 
-  const activePackage = createMemo(() => getPackageFromQuery(debouncedQuery()));
+  const activePackage = createMemo(() => getPackageFromQuery(effectiveDebouncedQuery()));
 
   function handlePackageSelect(pkg: string | null) {
     const q = setPackageInQuery(query(), pkg);
@@ -337,12 +412,17 @@ export function LogcatPanel(): JSX.Element {
   // memos must be pure. The comparison guard prevents running on the initial
   // mount since onMount already fetches the unfiltered backfill.
   let _prevDebouncedQuery = "";
+  let _prevEffectiveDebouncedQuery = "";
   createEffect(() => {
     const q = debouncedQuery();
-    if (q === _prevDebouncedQuery) return;
-    _prevDebouncedQuery = q;
-    setLastActiveQuery(q);
-    syncBackendFilter(parseFilterGroups(q));
+    const effectiveQuery = effectiveDebouncedQuery();
+    if (q !== _prevDebouncedQuery) {
+      _prevDebouncedQuery = q;
+      setLastActiveQuery(q);
+    }
+    if (effectiveQuery === _prevEffectiveDebouncedQuery) return;
+    _prevEffectiveDebouncedQuery = effectiveQuery;
+    syncBackendFilter(parseFilterGroups(effectiveQuery));
   });
 
   // Re-sync the backend filter when the project's applicationId becomes available
@@ -357,7 +437,7 @@ export function LogcatPanel(): JSX.Element {
     _prevAppId = appId;
     setMinePackage(appId);
     // Re-evaluate the backend filter only if the current query references "mine".
-    const q = debouncedQuery();
+    const q = effectiveDebouncedQuery();
     if (q.includes("package:mine") || q.includes("pkg:mine")) {
       syncBackendFilter(parseFilterGroups(q));
     }
@@ -378,7 +458,7 @@ export function LogcatPanel(): JSX.Element {
     }
     const q = query();
     if (q.includes("package:mine") || q.includes("pkg:mine")) {
-      void syncBackendFilter(parseFilterGroups(q));
+      void syncBackendFilter(parseFilterGroups(effectiveDebouncedQuery()));
       return;
     }
     const next = setPackageInQuery(q, "mine");
@@ -390,7 +470,7 @@ export function LogcatPanel(): JSX.Element {
   createEffect(() => {
     const ring = clampLogcatRingMaxEntries(settingsState.logcat.ringMaxEntries);
     if (prevRingCap !== undefined && ring !== prevRingCap) {
-      void syncBackendFilter(parseFilterGroups(debouncedQuery()));
+      void syncBackendFilter(parseFilterGroups(effectiveDebouncedQuery()));
       void refreshLogcatRingStats();
     }
     prevRingCap = ring;
@@ -412,7 +492,7 @@ export function LogcatPanel(): JSX.Element {
           }
         }
       } else if (cap > prevLogcatMaxUi) {
-        void syncBackendFilter(parseFilterGroups(debouncedQuery()));
+        void syncBackendFilter(parseFilterGroups(effectiveDebouncedQuery()));
       }
     }
     prevLogcatMaxUi = cap;
@@ -426,8 +506,11 @@ export function LogcatPanel(): JSX.Element {
     const savedQuery = getLastActiveQuery();
     if (savedQuery) {
       setQuery(savedQuery);
+      setQueryVariableValues((values) => ensureQueryVariableValues(savedQuery, values));
+      setDebouncedQueryVariableValues((values) => ensureQueryVariableValues(savedQuery, values));
       setDebouncedQuery(savedQuery);
       _prevDebouncedQuery = savedQuery;
+      _prevEffectiveDebouncedQuery = savedQuery;
     }
 
     // Build the filter spec for the initial backfill.
@@ -542,6 +625,7 @@ export function LogcatPanel(): JSX.Element {
     unlistenReconnecting?.();
     clearInterval(nowTimer);
     clearTimeout(_queryDebounce);
+    clearTimeout(_variableDebounce);
     filterSyncGuard.invalidate();
     // Clear backend filter on unmount so it doesn't persist
     setLogcatFilter(emptyLogcatFilterSpec()).catch(() => {});
@@ -818,15 +902,22 @@ export function LogcatPanel(): JSX.Element {
         activeAge={activeAge()}
         activePackage={activePackage()}
         isFiltered={isFiltered()}
+        disabledPillIds={disabledPillIds()}
+        variableValues={queryVariableValues()}
         showLifecycle={showLifecycle()}
         onQueryChange={updateQuery}
+        onTogglePillDisabled={togglePillDisabled}
+        onVariableValueChange={updateQueryVariableValue}
+        onVariableDelete={deleteQueryVariable}
+        onVariableInsert={insertQueryVariable}
         onAgeSelect={handleAgePill}
         onPackageSelect={handlePackageSelect}
         onToggleLifecycle={() => setShowLifecycle((v) => !v)}
-        onClear={() => updateQuery("")}
-        renderSavedFilterMenu={() => (
-          <SavedFilterMenu query={query()} isFiltered={isFiltered()} onApplyQuery={updateQuery} />
-        )}
+        onApplySavedQuery={applyPresetQuery}
+        onClear={() => {
+          setDisabledPillIds(new Set<string>());
+          updateQuery("");
+        }}
       />
 
       {/* ── Empty state ───────────────────────────────────────────────────── */}

--- a/src/components/logcat/QueryBar.test.ts
+++ b/src/components/logcat/QueryBar.test.ts
@@ -14,10 +14,11 @@
  * of becoming a pill until the user presses Space.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { fireEvent, render } from "@solidjs/testing-library";
 import { QueryBar, parseQueryState, buildQuery } from "./QueryBar";
 import {
+  buildQueryBarPillRefs,
   rebuildCommittedAfterRemovingPill,
   quoteMessageTokenForEditDraft,
   setPackageInQuery,
@@ -83,9 +84,9 @@ describe("QueryBar — Enter keyboard commit", () => {
 });
 
 describe("QueryBar — clickable connectors", () => {
-  it("toggles only the clicked AND connector to OR", () => {
+  it("toggles only the clicked AND connector to OR", async () => {
     const changes: string[] = [];
-    const { getByRole } = render(() =>
+    const { getByRole, queryByText } = render(() =>
       QueryBar({
         value: "level:error tag:App | is:crash ",
         onChange: (q) => changes.push(q),
@@ -95,13 +96,15 @@ describe("QueryBar — clickable connectors", () => {
     );
 
     fireEvent.click(getByRole("button", { name: "Change AND to OR" }));
+    await Promise.resolve();
 
     expect(changes[changes.length - 1]).toBe("level:error | tag:App | is:crash ");
+    expect(queryByText("level:")).toBeNull();
   });
 
-  it("toggles only the clicked OR connector to AND", () => {
+  it("toggles only the clicked OR connector to AND", async () => {
     const changes: string[] = [];
-    const { getAllByRole } = render(() =>
+    const { getAllByRole, queryByText } = render(() =>
       QueryBar({
         value: "level:error | tag:App | is:crash ",
         onChange: (q) => changes.push(q),
@@ -111,8 +114,73 @@ describe("QueryBar — clickable connectors", () => {
     );
 
     fireEvent.click(getAllByRole("button", { name: "Change OR to AND" })[0]!);
+    await Promise.resolve();
 
     expect(changes[changes.length - 1]).toBe("level:error tag:App | is:crash ");
+    expect(queryByText("level:")).toBeNull();
+  });
+
+  it("closes open suggestions when toggling an AND connector", async () => {
+    const { container, getByRole, getByText, queryByText } = render(() =>
+      QueryBar({
+        value: "level:error tag:App ",
+        onChange: vi.fn(),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+    const input = container.querySelector("input") as HTMLInputElement;
+
+    fireEvent.focus(input);
+    expect(getByText("level:")).not.toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Change AND to OR" }));
+    await Promise.resolve();
+
+    expect(queryByText("level:")).toBeNull();
+  });
+});
+
+describe("QueryBar — temporarily disabled pills", () => {
+  it("toggles a disabled pill without removing or editing it", () => {
+    const refs = buildQueryBarPillRefs(["level:error", "tag:App"]);
+    const tagRef = refs.find((ref) => ref.token === "tag:App")!;
+    const toggled: string[] = [];
+
+    const { getByRole } = render(() =>
+      QueryBar({
+        value: "level:error tag:App ",
+        onChange: vi.fn(),
+        knownTags: [],
+        knownPackages: [],
+        disabledPillIds: new Set([tagRef.id]),
+        onTogglePillDisabled: (id) => toggled.push(id),
+      })
+    );
+
+    fireEvent.click(getByRole("button", { name: "Re-enable filter tag:App" }));
+
+    expect(toggled).toEqual([tagRef.id]);
+  });
+
+  it("keeps disabled pills editable", () => {
+    const refs = buildQueryBarPillRefs(["level:error", "tag:App"]);
+    const tagRef = refs.find((ref) => ref.token === "tag:App")!;
+
+    const { getByText, getByDisplayValue } = render(() =>
+      QueryBar({
+        value: "level:error tag:App ",
+        onChange: vi.fn(),
+        knownTags: [],
+        knownPackages: [],
+        disabledPillIds: new Set([tagRef.id]),
+        onTogglePillDisabled: vi.fn(),
+      })
+    );
+
+    fireEvent.mouseDown(getByText("tag:App"));
+
+    expect(getByDisplayValue("tag:App")).not.toBeNull();
   });
 });
 

--- a/src/components/logcat/QueryBar.test.ts
+++ b/src/components/logcat/QueryBar.test.ts
@@ -139,6 +139,58 @@ describe("QueryBar — clickable connectors", () => {
 
     expect(queryByText("level:")).toBeNull();
   });
+
+  it("toggles an AND connector after an empty OR group", async () => {
+    const changes: string[] = [];
+    const { getByRole } = render(() =>
+      QueryBar({
+        value: "level:error | | tag:App is:crash ",
+        onChange: (q) => changes.push(q),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+
+    fireEvent.click(getByRole("button", { name: "Change AND to OR" }));
+    await Promise.resolve();
+
+    expect(changes[changes.length - 1]).toBe("level:error | tag:App | is:crash ");
+  });
+});
+
+describe("QueryBar — sparse OR groups", () => {
+  it("toggles a visible OR connector after an empty OR group", async () => {
+    const changes: string[] = [];
+    const { getByRole } = render(() =>
+      QueryBar({
+        value: "level:error | | tag:App ",
+        onChange: (q) => changes.push(q),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+
+    fireEvent.click(getByRole("button", { name: "Change OR to AND" }));
+    await Promise.resolve();
+
+    expect(changes[changes.length - 1]).toBe("level:error tag:App ");
+  });
+
+  it("removes a pill after an empty OR group", () => {
+    const changes: string[] = [];
+    const { getAllByTitle } = render(() =>
+      QueryBar({
+        value: "level:error | | tag:App ",
+        onChange: (q) => changes.push(q),
+        knownTags: [],
+        knownPackages: [],
+      })
+    );
+
+    fireEvent.mouseDown(getAllByTitle("Remove filter")[1]!);
+
+    expect(changes[changes.length - 1]).toBe("level:error ");
+  });
 });
 
 describe("QueryBar — temporarily disabled pills", () => {

--- a/src/components/logcat/QueryBar.tsx
+++ b/src/components/logcat/QueryBar.tsx
@@ -469,73 +469,86 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
 
         {/* ── Pill groups ─────────────────────────────────────────────── */}
         <For each={pillRefGroups()}>
-          {(group, gi) => (
-            <Show when={group.length > 0}>
-              <>
-                {/* OR badge between groups */}
-                <Show when={gi() > 0}>
-                  <QueryBarOrBadge onToggle={() => toggleOrConnector(gi())} />
-                </Show>
-
-                {/* Group container: visible box only when 2+ groups exist */}
-                <div style={multiGroup() ? queryBarGroupBoxStyle() : { display: "contents" }}>
-                  {/* Tokens in this group */}
-                  <For each={group}>
-                    {(tokenRef, ti) => (
-                      <>
-                        <Show
-                          when={inlineEdit()?.groupIdx === gi() && inlineEdit()?.tokenIdx === ti()}
-                        >
-                          <QueryBarInlineEditInput
-                            inputRef={(el) => {
-                              inlineEditRef = el;
-                            }}
-                            value={inlineEdit()?.text ?? ""}
-                            onInput={handleInlineInput}
-                            onKeyDown={handleInlineKeyDown}
-                            onBlur={handleInlineBlur}
-                            style={{ flex: "0 1 auto" }}
-                          />
-                        </Show>
-                        {/* AND badge between pills in the same group */}
-                        <Show when={ti() > 0}>
-                          <QueryBarAndBadge onToggle={() => toggleAndConnector(gi(), ti())} />
-                        </Show>
-
-                        <QueryBarPill
-                          token={tokenRef.token}
-                          disabled={props.disabledPillIds?.has(tokenRef.id) ?? false}
-                          onToggleDisabled={
-                            props.onTogglePillDisabled
-                              ? () => props.onTogglePillDisabled?.(tokenRef.id)
-                              : undefined
-                          }
-                          onEdit={() => editToken(gi(), ti(), tokenRef.token)}
-                          onRemove={() => removeToken(gi(), ti())}
-                        />
-                      </>
-                    )}
-                  </For>
-                  <Show
-                    when={
-                      inlineEdit()?.groupIdx === gi() && inlineEdit()?.tokenIdx === group.length
-                    }
-                  >
-                    <QueryBarInlineEditInput
-                      inputRef={(el) => {
-                        inlineEditRef = el;
-                      }}
-                      value={inlineEdit()?.text ?? ""}
-                      onInput={handleInlineInput}
-                      onKeyDown={handleInlineKeyDown}
-                      onBlur={handleInlineBlur}
-                      style={{ flex: "0 1 auto" }}
-                    />
+          {(group, gi) => {
+            const groupIdx = () => group[0]?.groupIdx ?? gi();
+            return (
+              <Show when={group.length > 0}>
+                <>
+                  {/* OR badge between groups */}
+                  <Show when={gi() > 0}>
+                    <QueryBarOrBadge onToggle={() => toggleOrConnector(groupIdx())} />
                   </Show>
-                </div>
-              </>
-            </Show>
-          )}
+
+                  {/* Group container: visible box only when 2+ groups exist */}
+                  <div style={multiGroup() ? queryBarGroupBoxStyle() : { display: "contents" }}>
+                    {/* Tokens in this group */}
+                    <For each={group}>
+                      {(tokenRef, ti) => (
+                        <>
+                          <Show
+                            when={
+                              inlineEdit()?.groupIdx === tokenRef.groupIdx &&
+                              inlineEdit()?.tokenIdx === tokenRef.tokenIdx
+                            }
+                          >
+                            <QueryBarInlineEditInput
+                              inputRef={(el) => {
+                                inlineEditRef = el;
+                              }}
+                              value={inlineEdit()?.text ?? ""}
+                              onInput={handleInlineInput}
+                              onKeyDown={handleInlineKeyDown}
+                              onBlur={handleInlineBlur}
+                              style={{ flex: "0 1 auto" }}
+                            />
+                          </Show>
+                          {/* AND badge between pills in the same group */}
+                          <Show when={ti() > 0}>
+                            <QueryBarAndBadge
+                              onToggle={() =>
+                                toggleAndConnector(tokenRef.groupIdx, tokenRef.tokenIdx)
+                              }
+                            />
+                          </Show>
+
+                          <QueryBarPill
+                            token={tokenRef.token}
+                            disabled={props.disabledPillIds?.has(tokenRef.id) ?? false}
+                            onToggleDisabled={
+                              props.onTogglePillDisabled
+                                ? () => props.onTogglePillDisabled?.(tokenRef.id)
+                                : undefined
+                            }
+                            onEdit={() =>
+                              editToken(tokenRef.groupIdx, tokenRef.tokenIdx, tokenRef.token)
+                            }
+                            onRemove={() => removeToken(tokenRef.groupIdx, tokenRef.tokenIdx)}
+                          />
+                        </>
+                      )}
+                    </For>
+                    <Show
+                      when={
+                        inlineEdit()?.groupIdx === groupIdx() &&
+                        inlineEdit()?.tokenIdx === group.length
+                      }
+                    >
+                      <QueryBarInlineEditInput
+                        inputRef={(el) => {
+                          inlineEditRef = el;
+                        }}
+                        value={inlineEdit()?.text ?? ""}
+                        onInput={handleInlineInput}
+                        onKeyDown={handleInlineKeyDown}
+                        onBlur={handleInlineBlur}
+                        style={{ flex: "0 1 auto" }}
+                      />
+                    </Show>
+                  </div>
+                </>
+              </Show>
+            );
+          }}
         </For>
 
         <Show when={inlineEditOrphanAfterOrBranch()}>

--- a/src/components/logcat/QueryBar.tsx
+++ b/src/components/logcat/QueryBar.tsx
@@ -29,6 +29,7 @@ import {
   parseQueryBarState,
   balanceMessageDraftQuotes,
   buildQueryBarPillGroups,
+  buildQueryBarPillRefGroups,
   applyMessageKeySpaceAutoQuote,
   pasteIntoMessageKeyDraft,
   rebuildCommittedAfterRemovingPill,
@@ -68,6 +69,8 @@ export interface QueryBarProps {
   knownTags: string[];
   knownPackages: string[];
   placeholder?: string;
+  disabledPillIds?: ReadonlySet<string>;
+  onTogglePillDisabled?: (id: string) => void;
 }
 
 // ── Query parsing helpers (local to this component) ───────────────────────────
@@ -119,6 +122,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
   const committed = createMemo(() => queryState().committed);
   const draft = createMemo(() => queryState().draft);
   const pillGroups = createMemo(() => buildQueryBarPillGroups(committed()));
+  const pillRefGroups = createMemo(() => buildQueryBarPillRefGroups(committed()));
   const multiGroup = createMemo(() => pillGroups().filter((g) => g.length > 0).length >= 2);
 
   function totalPillCount(): number {
@@ -427,6 +431,8 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
 
   function toggleAndConnector(groupIdx: number, tokenIdxAfterConnector: number) {
     if (inlineEdit()) commitInlineEdit();
+    setOpen(false);
+    setSelectedIdx(0);
     const next = toggleQueryBarAndConnector(
       committed(),
       groupIdx,
@@ -434,14 +440,14 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
       draftInNewGroup()
     );
     props.onChange(buildQuery(next, draft()));
-    queueMicrotask(() => draftRef?.focus());
   }
 
   function toggleOrConnector(groupIdxAfterConnector: number) {
     if (inlineEdit()) commitInlineEdit();
+    setOpen(false);
+    setSelectedIdx(0);
     const next = toggleQueryBarOrConnector(committed(), groupIdxAfterConnector, draftInNewGroup());
     props.onChange(buildQuery(next, draft()));
-    queueMicrotask(() => draftRef?.focus());
   }
 
   // ── Render ────────────────────────────────────────────────────────────────
@@ -462,7 +468,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
         <span style={searchIconStyle()}>⌕</span>
 
         {/* ── Pill groups ─────────────────────────────────────────────── */}
-        <For each={pillGroups()}>
+        <For each={pillRefGroups()}>
           {(group, gi) => (
             <Show when={group.length > 0}>
               <>
@@ -475,7 +481,7 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
                 <div style={multiGroup() ? queryBarGroupBoxStyle() : { display: "contents" }}>
                   {/* Tokens in this group */}
                   <For each={group}>
-                    {(token, ti) => (
+                    {(tokenRef, ti) => (
                       <>
                         <Show
                           when={inlineEdit()?.groupIdx === gi() && inlineEdit()?.tokenIdx === ti()}
@@ -497,8 +503,14 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
                         </Show>
 
                         <QueryBarPill
-                          token={token}
-                          onEdit={() => editToken(gi(), ti(), token)}
+                          token={tokenRef.token}
+                          disabled={props.disabledPillIds?.has(tokenRef.id) ?? false}
+                          onToggleDisabled={
+                            props.onTogglePillDisabled
+                              ? () => props.onTogglePillDisabled?.(tokenRef.id)
+                              : undefined
+                          }
+                          onEdit={() => editToken(gi(), ti(), tokenRef.token)}
                           onRemove={() => removeToken(gi(), ti())}
                         />
                       </>
@@ -613,8 +625,9 @@ export function QueryBar(props: QueryBarProps): JSX.Element {
               onMouseDown={(e) => {
                 e.preventDefault();
                 setInlineEdit(null);
+                setOpen(false);
+                setSelectedIdx(0);
                 props.onChange("");
-                draftRef?.focus();
               }}
               title="Clear all filters (Esc)"
               style={queryBarClearButtonStyle()}

--- a/src/components/logcat/QueryBarParts.tsx
+++ b/src/components/logcat/QueryBarParts.tsx
@@ -9,6 +9,7 @@ import {
   queryBarPillLabelStyle,
   queryBarPillRemoveButtonStyle,
   queryBarPillStyle,
+  queryBarPillToggleButtonStyle,
   suggestionFooterStyle,
   suggestionItemStyle,
   suggestionMenuStyle,
@@ -95,16 +96,42 @@ export function QueryBarInlineEditInput(props: {
 
 export function QueryBarPill(props: {
   token: string;
+  disabled?: boolean;
   onEdit: () => void;
   onRemove: () => void;
+  onToggleDisabled?: () => void;
 }): JSX.Element {
   const style = () => getQueryBarTokenStyle(props.token);
+  const disabled = () => props.disabled === true;
 
   return (
     <span
       onClick={(e) => e.stopPropagation()}
-      style={queryBarPillStyle(style(), props.token.startsWith("-"))}
+      style={queryBarPillStyle(style(), props.token.startsWith("-"), disabled())}
     >
+      {props.onToggleDisabled ? (
+        <button
+          onMouseDown={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onToggleDisabled?.();
+          }}
+          aria-label={`${disabled() ? "Re-enable" : "Disable"} filter ${props.token}`}
+          title={disabled() ? "Re-enable filter" : "Disable filter temporarily"}
+          style={queryBarPillToggleButtonStyle(style().color, disabled())}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLElement).style.opacity = "1";
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLElement).style.opacity = disabled() ? "0.9" : "0.45";
+          }}
+        >
+          ⏻
+        </button>
+      ) : null}
       <span
         onMouseDown={(e) => {
           e.preventDefault();
@@ -112,7 +139,7 @@ export function QueryBarPill(props: {
           props.onEdit();
         }}
         title="Edit filter"
-        style={queryBarPillLabelStyle()}
+        style={queryBarPillLabelStyle(disabled())}
       >
         {props.token}
       </span>

--- a/src/components/logcat/SavedFilterMenu.test.tsx
+++ b/src/components/logcat/SavedFilterMenu.test.tsx
@@ -4,7 +4,12 @@ import { SavedFilterMenu } from "./SavedFilterMenu";
 
 function renderSavedFilterMenu() {
   return render(() => (
-    <SavedFilterMenu query="level:error " isFiltered={true} onApplyQuery={vi.fn()} />
+    <SavedFilterMenu
+      savedFilters={[]}
+      onApplyQuery={vi.fn()}
+      onDeleteSavedFilter={vi.fn()}
+      onRenameSavedFilter={vi.fn()}
+    />
   ));
 }
 

--- a/src/components/logcat/SavedFilterMenu.tsx
+++ b/src/components/logcat/SavedFilterMenu.tsx
@@ -1,13 +1,5 @@
 import { For, Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
-import { showToast } from "@/components/ui";
-import {
-  addSavedFilter,
-  deleteSavedFilter,
-  loadFilterStorage,
-  MAX_SAVED_FILTERS,
-  renameSavedFilter,
-  type SavedFilter,
-} from "@/lib/logcat-filter-storage";
+import { MAX_SAVED_FILTERS, type SavedFilter } from "@/lib/logcat-filter-storage";
 import { btnStyle } from "./logcat-styles";
 import {
   logcatDropdownOverlayStyle,
@@ -32,39 +24,18 @@ const BUILTIN_PRESETS: LogcatPreset[] = [
 ];
 
 export function SavedFilterMenu(props: {
-  query: string;
-  isFiltered: boolean;
+  savedFilters: readonly SavedFilter[];
   onApplyQuery: (query: string) => void;
+  onDeleteSavedFilter: (id: string) => void;
+  onRenameSavedFilter: (id: string, name: string) => void;
 }): JSX.Element {
   const [open, setOpen] = createSignal(false);
-  const [savedFilters, setSavedFilters] = createSignal<SavedFilter[]>(loadFilterStorage().filters);
-  const [savingPreset, setSavingPreset] = createSignal(false);
-  const [presetNameDraft, setPresetNameDraft] = createSignal("");
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameDraft, setRenameDraft] = createSignal("");
 
   function applyPreset(q: string) {
     props.onApplyQuery(q.trimEnd() + " ");
     setOpen(false);
-  }
-
-  function saveCurrentFilter() {
-    const name = presetNameDraft().trim();
-    if (!name) return;
-    try {
-      const saved = addSavedFilter(name, props.query);
-      setSavedFilters(loadFilterStorage().filters);
-      setSavingPreset(false);
-      setPresetNameDraft("");
-      showToast(`Saved filter "${saved.name}"`, "success");
-    } catch (e) {
-      showToast(String(e), "error");
-    }
-  }
-
-  function deleteSavedFilterItem(id: string) {
-    deleteSavedFilter(id);
-    setSavedFilters(loadFilterStorage().filters);
   }
 
   function startRename(filter: SavedFilter) {
@@ -75,8 +46,7 @@ export function SavedFilterMenu(props: {
   function commitRename() {
     const id = renamingId();
     if (id) {
-      renameSavedFilter(id, renameDraft());
-      setSavedFilters(loadFilterStorage().filters);
+      props.onRenameSavedFilter(id, renameDraft());
     }
     setRenamingId(null);
     setRenameDraft("");
@@ -89,7 +59,6 @@ export function SavedFilterMenu(props: {
 
   function closeMenu() {
     setOpen(false);
-    setSavingPreset(false);
     cancelRename();
   }
 
@@ -112,7 +81,6 @@ export function SavedFilterMenu(props: {
       <button
         onClick={() => {
           setOpen((v) => !v);
-          setSavingPreset(false);
           setRenamingId(null);
         }}
         title="Filter presets"
@@ -180,11 +148,11 @@ export function SavedFilterMenu(props: {
                 Saved
               </span>
               <span style={{ "font-size": "10px", color: "var(--text-muted)" }}>
-                {savedFilters().length} / {MAX_SAVED_FILTERS}
+                {props.savedFilters.length} / {MAX_SAVED_FILTERS}
               </span>
             </div>
 
-            <Show when={savedFilters().length === 0}>
+            <Show when={props.savedFilters.length === 0}>
               <div
                 style={{
                   padding: "4px 10px 6px",
@@ -197,7 +165,7 @@ export function SavedFilterMenu(props: {
               </div>
             </Show>
 
-            <For each={savedFilters()}>
+            <For each={props.savedFilters}>
               {(f) => (
                 <div
                   style={{
@@ -251,7 +219,7 @@ export function SavedFilterMenu(props: {
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
-                            deleteSavedFilterItem(f.id);
+                            props.onDeleteSavedFilter(f.id);
                           }}
                           style={{
                             background: "none",
@@ -316,59 +284,6 @@ export function SavedFilterMenu(props: {
                 </div>
               )}
             </For>
-
-            <div style={logcatDropdownSeparatorStyle()} />
-            <Show
-              when={savingPreset()}
-              fallback={
-                <div
-                  onClick={() => {
-                    setSavingPreset(true);
-                    setPresetNameDraft("");
-                  }}
-                  style={{
-                    padding: "5px 10px",
-                    cursor: "pointer",
-                    color: props.isFiltered ? "var(--accent)" : "var(--text-muted)",
-                  }}
-                  onMouseEnter={(e) => {
-                    (e.currentTarget as HTMLElement).style.background = "rgba(255,255,255,0.06)";
-                  }}
-                  onMouseLeave={(e) => {
-                    (e.currentTarget as HTMLElement).style.background = "transparent";
-                  }}
-                >
-                  + Save current filter
-                </div>
-              }
-            >
-              <div style={{ display: "flex", gap: "4px", padding: "4px 8px" }}>
-                <input
-                  type="text"
-                  placeholder="Filter name…"
-                  value={presetNameDraft()}
-                  onInput={(e) => setPresetNameDraft(e.currentTarget.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") saveCurrentFilter();
-                    if (e.key === "Escape") setSavingPreset(false);
-                  }}
-                  autofocus
-                  style={{
-                    flex: "1",
-                    background: "var(--bg-primary)",
-                    border: "1px solid var(--border)",
-                    color: "var(--text-primary)",
-                    "border-radius": "3px",
-                    padding: "3px 6px",
-                    "font-size": "11px",
-                    outline: "none",
-                  }}
-                />
-                <button onClick={saveCurrentFilter} style={btnStyle("var(--accent)")}>
-                  Save
-                </button>
-              </div>
-            </Show>
           </div>
         </div>
         <div style={logcatDropdownOverlayStyle()} onClick={closeMenu} />

--- a/src/components/logcat/querybar-styles.ts
+++ b/src/components/logcat/querybar-styles.ts
@@ -138,7 +138,8 @@ export function queryBarAndBadgeStyle(clickable = false): Record<string, string>
 
 export function queryBarPillStyle(
   tokenStyle: QueryBarTokenStyle,
-  negated: boolean
+  negated: boolean,
+  disabled = false
 ): Record<string, string> {
   return {
     display: "inline-flex",
@@ -153,12 +154,34 @@ export function queryBarPillStyle(
     padding: "1px 4px 1px 6px",
     "flex-shrink": "0",
     "white-space": "nowrap",
-    opacity: negated ? "0.65" : "1",
+    opacity: disabled ? "0.45" : negated ? "0.65" : "1",
   };
 }
 
-export function queryBarPillLabelStyle(): Record<string, string> {
-  return { cursor: "text", "user-select": "none" };
+export function queryBarPillLabelStyle(disabled = false): Record<string, string> {
+  return {
+    cursor: "text",
+    "user-select": "none",
+    "text-decoration": disabled ? "line-through" : "none",
+  };
+}
+
+export function queryBarPillToggleButtonStyle(
+  color: string,
+  disabled = false
+): Record<string, string> {
+  return {
+    background: "none",
+    border: "none",
+    color,
+    cursor: "pointer",
+    padding: "0 1px",
+    "font-size": "9px",
+    "line-height": "1",
+    opacity: disabled ? "0.9" : "0.45",
+    display: "flex",
+    "align-items": "center",
+  };
 }
 
 export function queryBarPillRemoveButtonStyle(color: string): Record<string, string> {

--- a/src/lib/logcat-query.test.ts
+++ b/src/lib/logcat-query.test.ts
@@ -40,6 +40,14 @@ import {
   parseStackFrame,
   isProjectFrame,
   applyInlineEditCommit,
+  buildQueryBarPillRefs,
+  buildEffectiveQueryWithDisabledPills,
+  reconcileDisabledQueryPillIds,
+  extractQueryVariables,
+  resolveQueryVariables,
+  reconcileQueryVariableValues,
+  ensureQueryVariableValues,
+  isValidQueryVariableName,
 } from "./logcat-query";
 import type { LogcatEntry } from "@/lib/tauri-api";
 
@@ -966,6 +974,141 @@ describe("toggleQueryBarOrConnector", () => {
       "tag:App",
       "|",
     ]);
+  });
+});
+
+describe("buildEffectiveQueryWithDisabledPills", () => {
+  it("omits disabled pills while preserving the visible query text", () => {
+    const refs = buildQueryBarPillRefs(["level:error", "tag:App"]);
+    const disabled = new Set([refs.find((ref) => ref.token === "tag:App")!.id]);
+
+    expect(buildEffectiveQueryWithDisabledPills("level:error tag:App ", disabled)).toBe(
+      "level:error "
+    );
+  });
+
+  it("keeps OR semantics valid when a disabled pill removes one branch", () => {
+    const refs = buildQueryBarPillRefs(["level:error", "|", "tag:App", "|", "is:crash"]);
+    const disabled = new Set([refs.find((ref) => ref.token === "tag:App")!.id]);
+
+    expect(
+      buildEffectiveQueryWithDisabledPills("level:error | tag:App | is:crash ", disabled)
+    ).toBe("level:error | is:crash ");
+  });
+
+  it("keeps the draft active because drafts are not yet disable-able pills", () => {
+    const refs = buildQueryBarPillRefs(["level:error"]);
+    const disabled = new Set([refs[0]!.id]);
+
+    expect(buildEffectiveQueryWithDisabledPills("level:error tag:App", disabled)).toBe("tag:App");
+  });
+
+  it("removes disabled ids that no longer match the visible query", () => {
+    const refs = buildQueryBarPillRefs(["level:error"]);
+    const disabled = new Set([refs[0]!.id, "missing"]);
+
+    expect(reconcileDisabledQueryPillIds("tag:App ", disabled)).toEqual(new Set());
+  });
+});
+
+describe("query variables", () => {
+  it("extracts unique variables in first-seen order", () => {
+    expect(
+      extractQueryVariables("message:${action_name} tag:${screen} message:prefix_${action_name}")
+    ).toEqual(["action_name", "screen"]);
+  });
+
+  it("resolves variables inside filter values", () => {
+    expect(
+      resolveQueryVariables("message:some_prefix_${action_name} tag:${screen}", {
+        action_name: "tap",
+        screen: "Home",
+      })
+    ).toBe("message:some_prefix_tap tag:Home");
+  });
+
+  it("resolves variables inside quoted values with spaces", () => {
+    const resolved = resolveQueryVariables('message:"User ${action_name} clicked"', {
+      action_name: "checkout button",
+    });
+
+    expect(resolved).toBe('message:"User checkout button clicked"');
+    expect(parseQuery(resolved)[0]).toMatchObject({
+      type: "message",
+      value: "User checkout button clicked",
+    });
+  });
+
+  it("resolves variables before OR group matching", () => {
+    const groups = parseFilterGroups(
+      resolveQueryVariables("message:action_${action_name}_done | tag:Fallback", {
+        action_name: "checkout",
+      })
+    );
+
+    expect(
+      matchesFilterGroups(
+        makeEntry({ tag: "VariableAction", message: "action_checkout_done" }),
+        groups,
+        NOW
+      )
+    ).toBe(true);
+    expect(
+      matchesFilterGroups(makeEntry({ tag: "Fallback", message: "fallback path" }), groups, NOW)
+    ).toBe(true);
+    expect(
+      matchesFilterGroups(
+        makeEntry({ tag: "VariableAction", message: "action_login_done" }),
+        groups,
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it("can disable a variable pill before resolving active variables", () => {
+    const refs = buildQueryBarPillRefs(["tag:Alpha", "message:action_${action_name}_done"]);
+    const disabled = new Set([
+      refs.find((ref) => ref.token === "message:action_${action_name}_done")!.id,
+    ]);
+    const effectiveTemplate = buildEffectiveQueryWithDisabledPills(
+      "tag:Alpha message:action_${action_name}_done ",
+      disabled
+    );
+
+    expect(resolveQueryVariables(effectiveTemplate, { action_name: "checkout" })).toBe(
+      "tag:Alpha "
+    );
+  });
+
+  it("leaves empty or unset variables literal so they do not broaden filters", () => {
+    expect(resolveQueryVariables("message:${action_name}", {})).toBe("message:${action_name}");
+    expect(resolveQueryVariables("message:${action_name}", { action_name: "   " })).toBe(
+      "message:${action_name}"
+    );
+  });
+
+  it("reconciles variable values to variables still present in the query", () => {
+    expect(
+      reconcileQueryVariableValues("message:${next}", {
+        action_name: "tap",
+        next: "open",
+      })
+    ).toEqual({ next: "open" });
+  });
+
+  it("keeps predefined variable values while adding referenced variables", () => {
+    expect(
+      ensureQueryVariableValues("message:${screen}", {
+        action_name: "checkout",
+      })
+    ).toEqual({ action_name: "checkout", screen: "" });
+  });
+
+  it("validates user-created variable names", () => {
+    expect(isValidQueryVariableName("action_name")).toBe(true);
+    expect(isValidQueryVariableName("_screen2")).toBe(true);
+    expect(isValidQueryVariableName("2screen")).toBe(false);
+    expect(isValidQueryVariableName("screen-name")).toBe(false);
   });
 });
 

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -66,6 +66,59 @@ export interface QueryBarSuggestion {
   insert: string;
 }
 
+export type QueryVariableValues = Record<string, string>;
+
+const QUERY_VARIABLE_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const QUERY_VARIABLE_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+export function isValidQueryVariableName(name: string): boolean {
+  return QUERY_VARIABLE_NAME_RE.test(name);
+}
+
+export function extractQueryVariables(query: string): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+
+  for (const match of query.matchAll(QUERY_VARIABLE_RE)) {
+    const name = match[1];
+    if (!seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+
+  return names;
+}
+
+export function resolveQueryVariables(query: string, values: QueryVariableValues): string {
+  return query.replace(QUERY_VARIABLE_RE, (raw, name: string) => {
+    const value = values[name]?.trim();
+    return value ? value : raw;
+  });
+}
+
+export function reconcileQueryVariableValues(
+  query: string,
+  values: QueryVariableValues
+): QueryVariableValues {
+  const next: QueryVariableValues = {};
+  for (const name of extractQueryVariables(query)) {
+    if (values[name] !== undefined) next[name] = values[name];
+  }
+  return next;
+}
+
+export function ensureQueryVariableValues(
+  query: string,
+  values: QueryVariableValues
+): QueryVariableValues {
+  const next: QueryVariableValues = { ...values };
+  for (const name of extractQueryVariables(query)) {
+    if (next[name] === undefined) next[name] = "";
+  }
+  return next;
+}
+
 export function getQueryBarSuggestions(
   draft: string,
   knownTags: readonly string[],
@@ -952,6 +1005,88 @@ export function buildQueryBarPillGroups(committed: string[]): string[][] {
     }
   }
   return groups.map(normalizeGroupParenTokens);
+}
+
+export interface QueryBarPillRef {
+  id: string;
+  token: string;
+  groupIdx: number;
+  tokenIdx: number;
+}
+
+export function queryBarPillId(token: string, occurrence: number): string {
+  return JSON.stringify([token, occurrence]);
+}
+
+export function buildQueryBarPillRefs(committed: string[]): QueryBarPillRef[] {
+  const seen = new Map<string, number>();
+  const refs: QueryBarPillRef[] = [];
+
+  buildQueryBarPillGroups(committed).forEach((group, groupIdx) => {
+    group.forEach((token, tokenIdx) => {
+      const occurrence = seen.get(token) ?? 0;
+      seen.set(token, occurrence + 1);
+      refs.push({
+        id: queryBarPillId(token, occurrence),
+        token,
+        groupIdx,
+        tokenIdx,
+      });
+    });
+  });
+
+  return refs;
+}
+
+export function buildQueryBarPillRefGroups(committed: string[]): QueryBarPillRef[][] {
+  const refs = buildQueryBarPillRefs(committed);
+  const groups: QueryBarPillRef[][] = [];
+
+  for (const ref of refs) {
+    if (!groups[ref.groupIdx]) groups[ref.groupIdx] = [];
+    groups[ref.groupIdx]!.push(ref);
+  }
+
+  return groups.filter((group) => group.length > 0);
+}
+
+function buildQueryFromCommittedAndDraft(committed: string[], draft: string): string {
+  const base = committed.map(serializeQueryBarCommittedPart).join(" ");
+  if (!draft) return base ? `${base} ` : "";
+  return base ? `${base} ${draft}` : draft;
+}
+
+export function reconcileDisabledQueryPillIds(
+  query: string,
+  disabledIds: ReadonlySet<string>
+): Set<string> {
+  if (disabledIds.size === 0) return new Set();
+  const validIds = new Set(
+    buildQueryBarPillRefs(parseQueryBarState(query).committed).map((r) => r.id)
+  );
+  return new Set([...disabledIds].filter((id) => validIds.has(id)));
+}
+
+export function buildEffectiveQueryWithDisabledPills(
+  query: string,
+  disabledIds: ReadonlySet<string>
+): string {
+  if (disabledIds.size === 0) return query;
+
+  const { committed, draft } = parseQueryBarState(query);
+  const draftInNewGroup = committedEndsWithOrSeparator(committed);
+  const refGroups = buildQueryBarPillRefGroups(committed);
+  const activeGroups = refGroups
+    .map((group) => group.filter((ref) => !disabledIds.has(ref.id)).map((ref) => ref.token))
+    .filter((group) => group.length > 0);
+
+  const activeCommitted = flattenPillGroupsToCommitted(activeGroups, false);
+  if (draft.trim()) {
+    if (draftInNewGroup && activeCommitted.length > 0) activeCommitted.push("|");
+    return buildQueryFromCommittedAndDraft(activeCommitted, draft);
+  }
+
+  return buildQueryFromCommittedAndDraft(activeCommitted, "");
 }
 
 /** True when the last structural committed part is `|` (draft starts a new OR group). */

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -1245,12 +1245,15 @@ export function toggleQueryBarOrConnector(
     return committed;
   }
 
-  const previous = groups[groupIdxAfterConnector - 1];
+  let previousIdx = groupIdxAfterConnector - 1;
+  while (previousIdx >= 0 && groups[previousIdx]!.length === 0) previousIdx--;
+
+  const previous = previousIdx >= 0 ? groups[previousIdx] : undefined;
   const current = groups[groupIdxAfterConnector];
   if (!previous || !current) return committed;
 
   const nextGroups = [
-    ...groups.slice(0, groupIdxAfterConnector - 1),
+    ...groups.slice(0, previousIdx),
     [...previous, ...current],
     ...groups.slice(groupIdxAfterConnector + 1),
   ];


### PR DESCRIPTION
## Summary

fix and improvements

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds temporary disable for query pills, filter variables with a manager and quick-edit row, and a direct “Save” action. Backend syncing now uses the effective query with disabled pills removed and variables resolved.

- **New Features**
  - Temporarily disable/re-enable individual filter pills via the power icon; disabled pills stay editable, are not applied, and reset on clear/preset/app restart. Saving stores only the effective active filter.
  - Filter variables using `${name}` inside values; quick-edit variable row under the query; “Variables” manager to add/edit/insert/delete; values are session-local; resolving works in quoted values and OR groups; saving preserves the `${name}` template.
  - Direct “Save” button beside the query bar; `SavedFilterMenu` now receives saved filters and supports apply/rename/delete; applying a preset clears disabled pill state.
  - Backend filter sync uses the effective query (disabled pills removed, variables resolved) and debounces variable value changes by 150ms.
  - Docs: expanded query bar section with variable usage, save flow, and disabling pills.

- **Bug Fixes**
  - Toggling AND/OR badges now closes open suggestions and updates only the clicked connector, including cases with empty OR groups.

<sup>Written for commit d4cc77c9c5907b4fbcdc28e8c07f33c55776ae2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

