### PR TITLE
Feat/expand log

### DIFF
--- a/docs/DOMAIN_PATTERNS.md
+++ b/docs/DOMAIN_PATTERNS.md
@@ -84,6 +84,8 @@ Backend processing owns package resolution, crash detection, JSON detection, cat
 
 Handle high-volume and simple filters in Rust before crossing IPC. Frontend-only filters are limited to cases that require browser state or JS-only semantics, such as age filters, negation, and regex.
 
+Filtered Logcat context expansion should fetch adjacent raw rows from the backend ring buffer by anchor entry id. Do not clear the active filter or replace the filtered backfill just to show surrounding context; merge bounded context rows into the visible frontend list and mark them as expanded context.
+
 ### Frontend Boundaries
 
 Keep `LogcatPanel.tsx` as composition/orchestration. Domain logic lives in focused helpers:

--- a/docs/USER_MANUAL.md
+++ b/docs/USER_MANUAL.md
@@ -153,6 +153,7 @@ Use `${name}` inside filter values to create a filter variable. Click **Variable
 - ANRs get an ANR badge.
 - JSON messages show a `{}` badge; open it to view formatted JSON.
 - Arrow keys move the selected row when focus is not in the query bar.
+- When a filter is active, right-click a log row and choose **Expand 10 up** or **Expand 10 down** to reveal adjacent raw log rows without clearing the filter. You can repeat this from any visible row. Rows added this way use a green left marker so they are distinct from rows that matched the filter.
 - Scrolling away from the end or selecting a row enters read mode: the visible list is frozen so the row you are reading cannot be pushed out by new logs or UI-buffer overflow.
 - While in read mode, new logs continue to be captured in the background. The **Jump to end** button shows how many matching logs arrived; use it to apply them and resume follow-tail.
 - In **Entry Detail**, click a tag, package, level, PID, TID, time, or message value to add it to the query bar as an **AND** or **OR** filter. Select part of the message before clicking to filter by only that selected text.

--- a/e2e/smoke/logcat-regressions.spec.ts
+++ b/e2e/smoke/logcat-regressions.spec.ts
@@ -140,6 +140,73 @@ test("logcat detail panel opens for the clicked filtered row", async ({ page }) 
   await expect(page.getByTitle("Filter by message")).toHaveText("Beta target message");
 });
 
+test("logcat entry detail filter menu has an opaque surface", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 103, tag: "DetailMenuTag", message: "Detail menu surface row" },
+  ]);
+
+  await expect(page.getByText("Detail menu surface row")).toBeVisible({ timeout: 5_000 });
+  await page.getByText("Detail menu surface row").click();
+  await page.getByTitle("Filter by Tag").click();
+
+  await expect(page.getByRole("menu")).toBeVisible();
+  await expect(page.getByRole("menu")).toHaveCSS(
+    "background-color",
+    /^(?!rgba\(0, 0, 0, 0\))/
+  );
+});
+
+test("logcat filtered rows can expand adjacent raw context", async ({ page }) => {
+  await openLogcatWithEmptyEntries(page);
+  await pushLogcatEntries(page, [
+    { id: 104, tag: "ContextBefore", message: "Context before one" },
+    { id: 105, tag: "ContextBefore", message: "Context before two" },
+    { id: 106, tag: "ContextTarget", message: "Focused context match" },
+    { id: 107, tag: "ContextAfter", message: "Context after one" },
+    { id: 108, tag: "ContextAfter", message: "Context after two" },
+  ]);
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(5, { timeout: 5_000 });
+
+  const filterInput = page.locator('input[type="text"][placeholder*="Filter"]').first();
+  await filterInput.fill("message:Focused ");
+
+  await expect(page.getByTitle(ROW_TITLE)).toHaveCount(1, { timeout: 5_000 });
+  await expect(page.getByText("Focused context match")).toBeVisible();
+  await expect(page.getByText("Context before one")).not.toBeVisible();
+  await expect(page.getByText("Context after one")).not.toBeVisible();
+
+  await page.getByText("Focused context match").click({ button: "right" });
+  await expect(page.getByRole("menu")).toHaveCSS("background-color", /^(?!rgba\(0, 0, 0, 0\))/);
+  await page.getByRole("menuitem", { name: "Expand 10 up" }).click();
+
+  await expect(page.getByText("Context before one")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Context before two")).toBeVisible();
+  await expect(page.getByText("Context after one")).not.toBeVisible();
+  await expect(
+    page.locator(`div[title="${ROW_TITLE}"][data-expanded-context="true"]`).filter({
+      hasText: "Context before one",
+    })
+  ).toHaveCount(1);
+  await expect(
+    page.locator(`div[title="${ROW_TITLE}"][data-expanded-context="true"]`).filter({
+      hasText: "Focused context match",
+    })
+  ).toHaveCount(0);
+
+  await page.getByText("Context before one").click({ button: "right" });
+  await page.getByRole("menuitem", { name: "Expand 10 down" }).click();
+
+  await expect(page.getByText("Context after one")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText("Context after two")).toBeVisible();
+  await expect(
+    page.locator(`div[title="${ROW_TITLE}"][data-expanded-context="true"]`).filter({
+      hasText: "Context after one",
+    })
+  ).toHaveCount(1);
+});
+
 test("logcat query connector badges toggle only the clicked condition", async ({ page }) => {
   await openLogcatWithEmptyEntries(page);
   await pushLogcatEntries(page, [

--- a/src-tauri/src/commands/logcat.rs
+++ b/src-tauri/src/commands/logcat.rs
@@ -84,6 +84,23 @@ pub async fn get_logcat_entries(
     Ok(state.store.query(&filter, limit))
 }
 
+/// Return unfiltered entries adjacent to an anchor entry in the ring buffer.
+#[tauri::command]
+pub async fn get_logcat_context_entries(
+    anchor_id: u64,
+    direction: String,
+    count: Option<usize>,
+    logcat_state: State<'_, LogcatState>,
+) -> Result<Vec<ProcessedEntry>, String> {
+    let state = logcat_state.lock().await;
+    let limit = count.unwrap_or(10).min(state.store.capacity());
+    match direction.as_str() {
+        "before" => Ok(state.store.context_before(anchor_id, limit)),
+        "after" => Ok(state.store.context_after(anchor_id, limit)),
+        other => Err(format!("Invalid logcat context direction: {other}")),
+    }
+}
+
 /// Return whether logcat is currently streaming.
 #[tauri::command]
 pub async fn get_logcat_status(logcat_state: State<'_, LogcatState>) -> Result<bool, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,8 +22,9 @@ use commands::file_system::{
 };
 use commands::health::run_health_checks;
 use commands::logcat::{
-    clear_logcat, get_logcat_entries, get_logcat_stats, get_logcat_status, list_logcat_packages,
-    new_logcat_state, set_logcat_filter, start_logcat, stop_logcat,
+    clear_logcat, get_logcat_context_entries, get_logcat_entries, get_logcat_stats,
+    get_logcat_status, list_logcat_packages, new_logcat_state, set_logcat_filter, start_logcat,
+    stop_logcat,
 };
 use commands::mcp::{
     clear_mcp_activity, get_mcp_activity, get_mcp_server_status, get_mcp_setup_status,
@@ -354,6 +355,7 @@ pub fn run() {
             start_logcat,
             stop_logcat,
             clear_logcat,
+            get_logcat_context_entries,
             get_logcat_entries,
             get_logcat_status,
             list_logcat_packages,

--- a/src-tauri/src/services/log_store.rs
+++ b/src-tauri/src/services/log_store.rs
@@ -170,6 +170,33 @@ impl LogStore {
         result
     }
 
+    /// Return up to `limit` entries immediately before `anchor_id`, in chronological order.
+    pub fn context_before(&self, anchor_id: u64, limit: usize) -> Vec<ProcessedEntry> {
+        let Some(anchor_index) = self.entries.iter().position(|entry| entry.id == anchor_id) else {
+            return Vec::new();
+        };
+        let start = anchor_index.saturating_sub(limit);
+        self.entries
+            .iter()
+            .skip(start)
+            .take(anchor_index - start)
+            .cloned()
+            .collect()
+    }
+
+    /// Return up to `limit` entries immediately after `anchor_id`, in chronological order.
+    pub fn context_after(&self, anchor_id: u64, limit: usize) -> Vec<ProcessedEntry> {
+        let Some(anchor_index) = self.entries.iter().position(|entry| entry.id == anchor_id) else {
+            return Vec::new();
+        };
+        self.entries
+            .iter()
+            .skip(anchor_index + 1)
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
     /// Return all crash entry IDs in ascending order.
     pub fn crash_ids(&self) -> &VecDeque<u64> {
         &self.crash_ids
@@ -362,6 +389,49 @@ mod tests {
 
         let ids: Vec<u64> = store.query(&filter, 10).into_iter().map(|e| e.id).collect();
         assert_eq!(ids, vec![1]);
+    }
+
+    #[test]
+    fn context_before_returns_adjacent_older_entries_in_chronological_order() {
+        let mut store = LogStore::with_capacity(10_000);
+        for id in 1..=8 {
+            store.push(make_entry(id, 0));
+        }
+
+        let ids: Vec<u64> = store
+            .context_before(6, 3)
+            .into_iter()
+            .map(|entry| entry.id)
+            .collect();
+
+        assert_eq!(ids, vec![3, 4, 5]);
+    }
+
+    #[test]
+    fn context_after_returns_adjacent_newer_entries_in_chronological_order() {
+        let mut store = LogStore::with_capacity(10_000);
+        for id in 1..=8 {
+            store.push(make_entry(id, 0));
+        }
+
+        let ids: Vec<u64> = store
+            .context_after(4, 10)
+            .into_iter()
+            .map(|entry| entry.id)
+            .collect();
+
+        assert_eq!(ids, vec![5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn context_returns_empty_when_anchor_is_not_in_buffer() {
+        let mut store = LogStore::with_capacity(10_000);
+        for id in 1..=3 {
+            store.push(make_entry(id, 0));
+        }
+
+        assert!(store.context_before(99, 10).is_empty());
+        assert!(store.context_after(99, 10).is_empty());
     }
 
     #[test]

--- a/src/components/logcat/LogEntryDetailPanel.tsx
+++ b/src/components/logcat/LogEntryDetailPanel.tsx
@@ -234,6 +234,7 @@ export function LogEntryDetailPanel(props: LogEntryDetailPanelProps) {
             }}
             class={styles.filterMenu}
             role="menu"
+            surface="floating"
             style={{ left: `${menu().x}px`, top: `${menu().y}px` }}
           >
             <MenuListItem role="menuitem" onClick={() => addFilter("and")}>

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -75,6 +75,26 @@ function filterEntries(entries: ProcessedEntry[], spec: LogcatFilterSpec): Proce
   });
 }
 
+function contextEntries(entries: ProcessedEntry[], args: unknown): ProcessedEntry[] {
+  const opts = (args ?? {}) as {
+    anchorId?: bigint | number | string | null;
+    direction?: string | null;
+    count?: number | null;
+  };
+  if (opts.anchorId === null || opts.anchorId === undefined) return [];
+  const anchorId = BigInt(opts.anchorId);
+  const anchorIndex = entries.findIndex((entry) => entry.id === anchorId);
+  if (anchorIndex < 0) return [];
+  const count = Math.max(0, Math.floor(opts.count ?? 10));
+  if (opts.direction === "before") {
+    return entries.slice(Math.max(0, anchorIndex - count), anchorIndex);
+  }
+  if (opts.direction === "after") {
+    return entries.slice(anchorIndex + 1, anchorIndex + 1 + count);
+  }
+  return [];
+}
+
 function installLogcatPanelMocks(entries: ProcessedEntry[]): {
   emitLogcatEntries: (entries: ProcessedEntry[]) => void;
   setFilterCalls: () => LogcatFilterSpec[];
@@ -87,6 +107,8 @@ function installLogcatPanelMocks(entries: ProcessedEntry[]): {
     switch (command) {
       case "get_logcat_entries":
         return filterEntries(entries, activeFilter);
+      case "get_logcat_context_entries":
+        return contextEntries(entries, args);
       case "get_logcat_status":
         return false;
       case "get_logcat_stats":
@@ -377,6 +399,45 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
     await waitFor(() => expect(screen.getByText("Beta only saved-filter row")).not.toBeNull());
     expect(screen.getByText("Alpha beta saved-filter row")).not.toBeNull();
     expect(screen.queryByText("Alpha only saved-filter row")).toBeNull();
+  });
+
+  it("expands unfiltered context above a filtered row from the row context menu", async () => {
+    const beforeEntry = {
+      ...BASE_ENTRY,
+      id: 60n,
+      tag: "Before",
+      message: "Raw row before target",
+    } satisfies ProcessedEntry;
+    const targetEntry = {
+      ...BASE_ENTRY,
+      id: 61n,
+      tag: "Target",
+      message: "Filtered target row",
+    } satisfies ProcessedEntry;
+    const afterEntry = {
+      ...BASE_ENTRY,
+      id: 62n,
+      tag: "After",
+      message: "Raw row after target",
+    } satisfies ProcessedEntry;
+    installLogcatPanelMocks([beforeEntry, targetEntry, afterEntry]);
+    render(() => <LogcatPanel />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.input(input, { target: { value: "message:Filtered" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getAllByTitle(ROW_TITLE)).toHaveLength(1));
+    expect(screen.getByText("Filtered target row")).not.toBeNull();
+    expect(screen.queryByText("Raw row before target")).toBeNull();
+
+    fireEvent.contextMenu(screen.getByText("Filtered target row"));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Expand 10 up" }));
+
+    expect(await screen.findByText("Raw row before target")).not.toBeNull();
+    expect(screen.queryByText("Raw row after target")).toBeNull();
+    const row = screen.getByText("Raw row before target").closest(`div[title="${ROW_TITLE}"]`);
+    expect(row?.getAttribute("data-expanded-context")).toBe("true");
   });
 
   it("debounces backend filter sync while editing variable values", async () => {

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -12,6 +12,7 @@ import {
   stopLogcat,
   clearLogcat,
   getLogcatEntries,
+  getLogcatContextEntries,
   getLogcatStatus,
   getLogcatStats,
   setLogcatFilter,
@@ -26,7 +27,7 @@ import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { save } from "@tauri-apps/plugin-dialog";
 import { selectedDevice } from "@/stores/device.store";
 import { logcatRowHeightForFontSize, settingsState } from "@/stores/settings.store";
-import { EmptyState, showToast } from "@/components/ui";
+import { EmptyState, Icon, MenuList, MenuListItem, showToast } from "@/components/ui";
 import { VirtualList, type VirtualListHandle, isPaletteOpen } from "@/components/ui";
 import {
   parseAge,
@@ -82,6 +83,13 @@ import { createLogcatSuggestionRuntime } from "./logcat-suggestion-runtime";
 import { createLogcatQueryController } from "./logcat-query-controller";
 import { formatLogcatEntries } from "./logcat-entry-format";
 import { copyToClipboard } from "@/utils/clipboard";
+import {
+  LOGCAT_CONTEXT_EXPAND_COUNT,
+  LOGCAT_MAX_EXPANDED_CONTEXT_ENTRIES,
+  isExpandedContextRow,
+  mergeExpandedContextEntries,
+  mergeLogcatEntriesChronologically,
+} from "./logcat-context-expansion";
 
 function maxUiLinesCap(): number {
   return clampLogcatMaxUiLines(
@@ -98,6 +106,14 @@ function isLogcatTypingTarget(target: unknown): boolean {
   const tag = target.tagName;
   return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
 }
+
+type LogcatContextMenu = {
+  entry: LogcatEntry;
+  x: number;
+  y: number;
+};
+
+type LogcatContextDirection = "before" | "after";
 
 export function LogcatPanel(): JSX.Element {
   function resetQueryInteraction(): void {
@@ -127,6 +143,10 @@ export function LogcatPanel(): JSX.Element {
     restoreQuery,
   } = queryController;
 
+  function isFiltered() {
+    return query().trim() !== "";
+  }
+
   const [autoScroll, setAutoScroll] = createSignal(settingsState.logcat.autoScrollToEnd !== false);
   const [scrollCompensate, setScrollCompensate] = createSignal(0);
   const rowHeight = createMemo(() =>
@@ -140,6 +160,11 @@ export function LogcatPanel(): JSX.Element {
   const [paused, setPaused] = createSignal(false);
   const [restarting, setRestarting] = createSignal(false);
   const [showLifecycle, setShowLifecycle] = createSignal(true);
+  const [expandedContextEntries, setExpandedContextEntries] = createSignal<LogcatEntry[]>([], {
+    equals: false,
+  });
+  const [contextMenu, setContextMenu] = createSignal<LogcatContextMenu | null>(null);
+  let contextMenuRef: HTMLDivElement | undefined;
 
   // Crash navigation
   const [jumpTarget, setJumpTarget] = createSignal<number | null>(null);
@@ -213,18 +238,84 @@ export function LogcatPanel(): JSX.Element {
     { equals: false }
   );
 
+  const filteredEntryIds = createMemo(() => new Set(filteredEntries().map((entry) => entry.id)));
+  const expandedContextIds = createMemo(
+    () => new Set(expandedContextEntries().map((entry) => entry.id))
+  );
+  const mergedEntries = createMemo(() => {
+    if (!isFiltered()) return filteredEntries();
+    return mergeLogcatEntriesChronologically(filteredEntries(), expandedContextEntries());
+  });
+
   const displayedEntries = createMemo(() => {
-    const entries = frozenEntries() ?? filteredEntries();
+    const entries = frozenEntries() ?? mergedEntries();
     return showLifecycle() ? entries : entries.filter((entry) => !isLifecycleLogcatEntry(entry));
   });
   const readMode = createMemo(() => frozenEntries() !== null);
 
   function enterReadMode(): void {
     if (frozenEntries() === null) {
-      setFrozenEntries(filteredEntries().slice());
+      setFrozenEntries(mergedEntries().slice());
       setPendingNewEntries(0);
     }
     setAutoScroll(false);
+  }
+
+  function clearExpandedContext(): void {
+    setExpandedContextEntries([]);
+    setContextMenu(null);
+  }
+
+  function contextMenuPosition(x: number, y: number): { x: number; y: number } {
+    const menuWidth = 176;
+    const menuHeight = 80;
+    const maxX = Math.max(8, window.innerWidth - menuWidth - 8);
+    const maxY = Math.max(8, window.innerHeight - menuHeight - 8);
+    return {
+      x: Math.min(Math.max(8, x), maxX),
+      y: Math.min(Math.max(8, y), maxY),
+    };
+  }
+
+  function handleRowContextMenu(entry: LogcatEntry, e: MouseEvent): void {
+    if (!isFiltered()) return;
+    e.preventDefault();
+    enterReadMode();
+    setContextMenu({ entry, ...contextMenuPosition(e.clientX, e.clientY) });
+  }
+
+  function isExpandedRow(entry: LogcatEntry): boolean {
+    return isExpandedContextRow(entry.id, expandedContextIds(), filteredEntryIds());
+  }
+
+  async function expandLogContext(direction: LogcatContextDirection): Promise<void> {
+    const menu = contextMenu();
+    if (!menu) return;
+    setContextMenu(null);
+    try {
+      const entries = await getLogcatContextEntries({
+        anchorId: menu.entry.id,
+        direction,
+        count: LOGCAT_CONTEXT_EXPAND_COUNT,
+      });
+      if (entries.length === 0) {
+        showToast(
+          direction === "before" ? "No earlier logs in buffer" : "No later logs in buffer",
+          "info"
+        );
+        return;
+      }
+
+      setExpandedContextEntries((current) =>
+        mergeExpandedContextEntries(current, entries, LOGCAT_MAX_EXPANDED_CONTEXT_ENTRIES)
+      );
+      const frozen = frozenEntries();
+      if (frozen !== null) {
+        setFrozenEntries(mergeLogcatEntriesChronologically(frozen, entries));
+      }
+    } catch (err) {
+      showToast(`Failed to expand log context: ${formatError(err)}`, "error");
+    }
   }
 
   function exitReadMode(): void {
@@ -369,6 +460,7 @@ export function LogcatPanel(): JSX.Element {
     }
     if (effectiveQuery === _prevEffectiveDebouncedQuery) return;
     _prevEffectiveDebouncedQuery = effectiveQuery;
+    clearExpandedContext();
     syncBackendFilter(parseFilterGroups(effectiveQuery));
   });
 
@@ -514,6 +606,7 @@ export function LogcatPanel(): JSX.Element {
 
     unlistenCleared = await listenLogcatCleared(() => {
       exitReadMode();
+      clearExpandedContext();
       clearLogcatEntries();
       suggestions.clear();
       setAutoScroll(true);
@@ -573,6 +666,25 @@ export function LogcatPanel(): JSX.Element {
     setLogcatFilter(emptyLogcatFilterSpec()).catch(() => {});
   });
 
+  onMount(() => {
+    function closeContextMenu(e: MouseEvent): void {
+      const target = e.target as globalThis.Node | null;
+      if (target && contextMenuRef?.contains(target)) return;
+      setContextMenu(null);
+    }
+
+    function handleContextMenuEscape(e: KeyboardEvent): void {
+      if (e.key === "Escape") setContextMenu(null);
+    }
+
+    document.addEventListener("mousedown", closeContextMenu);
+    document.addEventListener("keydown", handleContextMenuEscape);
+    onCleanup(() => {
+      document.removeEventListener("mousedown", closeContextMenu);
+      document.removeEventListener("keydown", handleContextMenuEscape);
+    });
+  });
+
   // ── Controls ──────────────────────────────────────────────────────────────────
 
   async function handleStart() {
@@ -599,6 +711,7 @@ export function LogcatPanel(): JSX.Element {
   async function handleClear() {
     try {
       await clearLogcat();
+      clearExpandedContext();
       setSelectionAnchor(null);
       setSelectionEnd(null);
     } catch (e) {
@@ -773,13 +886,13 @@ export function LogcatPanel(): JSX.Element {
     setSelectionEnd(null);
     setSelectedJsonEntry(null);
     setSelectedDetailEntry(null);
+    clearExpandedContext();
     setAutoScroll(true);
     virtualListRef?.scrollToBottom();
   }
 
   // ── UI helpers ────────────────────────────────────────────────────────────────
 
-  const isFiltered = () => query().trim() !== "";
   const toolbarCount = createMemo(() =>
     formatLogcatToolbarCount({
       queryActive: isFiltered(),
@@ -898,7 +1011,13 @@ export function LogcatPanel(): JSX.Element {
           }}
           renderRow={(entry) => {
             if (entry.kind === "processDied" || entry.kind === "processStarted") {
-              return <SeparatorRow entry={entry} />;
+              return (
+                <SeparatorRow
+                  entry={entry}
+                  expandedContext={isExpandedRow(entry)}
+                  onContextMenu={(e) => handleRowContextMenu(entry, e)}
+                />
+              );
             }
             return (
               <LogcatVirtualRow
@@ -909,12 +1028,41 @@ export function LogcatPanel(): JSX.Element {
                 getEnd={() => selectionEnd()}
                 getDetailEntry={() => selectedDetailEntry()}
                 getJsonEntry={() => selectedJsonEntry()}
+                expandedContext={isExpandedRow(entry)}
                 onRowClick={(e) => handleRowClick(entry, e)}
+                onContextMenu={(e) => handleRowContextMenu(entry, e)}
                 onJsonClick={(e) => handleJsonBadgeClick(e, entry)}
               />
             );
           }}
         />
+      </Show>
+
+      <Show when={contextMenu()}>
+        {(menu) => (
+          <MenuList
+            role="menu"
+            surface="floating"
+            listRef={(el) => {
+              contextMenuRef = el;
+            }}
+            class="logcat-context-menu"
+            style={{
+              position: "fixed",
+              left: `${menu().x}px`,
+              top: `${menu().y}px`,
+              width: "176px",
+              "z-index": 1000,
+            }}
+          >
+            <MenuListItem role="menuitem" onClick={() => void expandLogContext("before")}>
+              <Icon name="arrow-up" size={12} /> Expand 10 up
+            </MenuListItem>
+            <MenuListItem role="menuitem" onClick={() => void expandLogContext("after")}>
+              <Icon name="arrow-down" size={12} /> Expand 10 down
+            </MenuListItem>
+          </MenuList>
+        )}
       </Show>
 
       {/* ── JSON Detail Panel ─────────────────────────────────────────────── */}

--- a/src/components/logcat/LogcatRows.module.css
+++ b/src/components/logcat/LogcatRows.module.css
@@ -47,6 +47,11 @@
   font-size: 10px;
 }
 
+.expandedContext {
+  border-left: 4px solid var(--success);
+  background: color-mix(in srgb, var(--success) 10%, transparent);
+}
+
 .row {
   display: flex;
   align-items: center;

--- a/src/components/logcat/LogcatRows.test.tsx
+++ b/src/components/logcat/LogcatRows.test.tsx
@@ -32,7 +32,9 @@ describe("LogcatRows", () => {
         getEnd={() => null}
         getDetailEntry={() => null}
         getJsonEntry={() => null}
+        expandedContext={false}
         onRowClick={() => {}}
+        onContextMenu={() => {}}
         onJsonClick={() => {}}
       />
     ));

--- a/src/components/logcat/LogcatRows.test.tsx
+++ b/src/components/logcat/LogcatRows.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { describe, expect, it } from "vitest";
 import type { LogcatEntry } from "@/lib/tauri-api";
 import { LogcatVirtualRow } from "./LogcatRows";
@@ -44,5 +44,31 @@ describe("LogcatRows", () => {
     expect(row.classList.contains(styles.row)).toBe(true);
     expect(row.style.background).not.toBe("");
     expect(row.style.borderLeft).toBe("2px solid transparent");
+  });
+
+  it("restores expanded context background after hovering crash rows", () => {
+    render(() => (
+      <LogcatVirtualRow
+        entry={{ ...ENTRY, isCrash: true }}
+        getIndex={() => 0}
+        getSelectionRange={() => null}
+        getAnchor={() => null}
+        getEnd={() => null}
+        getDetailEntry={() => null}
+        getJsonEntry={() => null}
+        expandedContext
+        onRowClick={() => {}}
+        onContextMenu={() => {}}
+        onJsonClick={() => {}}
+      />
+    ));
+
+    const row = screen.getByTitle("Click to copy · Shift+click to select range");
+    const initialBackground = row.style.background;
+
+    fireEvent.mouseEnter(row);
+    fireEvent.mouseLeave(row);
+
+    expect(row.style.background).toBe(initialBackground);
   });
 });

--- a/src/components/logcat/LogcatRows.tsx
+++ b/src/components/logcat/LogcatRows.tsx
@@ -23,7 +23,9 @@ export function LogcatVirtualRow(props: {
   getEnd: () => number | null;
   getDetailEntry: () => LogcatEntry | null;
   getJsonEntry: () => LogcatEntry | null;
+  expandedContext: boolean;
   onRowClick: (e: MouseEvent) => void;
+  onContextMenu: (e: MouseEvent) => void;
   onJsonClick: (e: MouseEvent) => void;
 }): JSX.Element {
   const index = createMemo(() => props.getIndex());
@@ -49,13 +51,19 @@ export function LogcatVirtualRow(props: {
       inSelectionRange={inSelectionRange()}
       focusMarked={focusMarked()}
       jsonSelected={jsonSelected()}
+      expandedContext={props.expandedContext}
       onClick={props.onRowClick}
+      onContextMenu={props.onContextMenu}
       onJsonClick={props.onJsonClick}
     />
   );
 }
 
-export function SeparatorRow(props: { entry: LogcatEntry }): JSX.Element {
+export function SeparatorRow(props: {
+  entry: LogcatEntry;
+  expandedContext?: boolean;
+  onContextMenu?: (e: MouseEvent) => void;
+}): JSX.Element {
   const isDied = () => props.entry.kind === "processDied";
   const pkg = () => props.entry.package ?? props.entry.tag;
   const label = () => (isDied() ? `${pkg()} PROCESS DIED` : `${pkg()} PROCESS RESTARTED`);
@@ -63,8 +71,11 @@ export function SeparatorRow(props: { entry: LogcatEntry }): JSX.Element {
   return (
     <div
       class={[styles.separatorRow, isDied() ? styles.separatorDied : styles.separatorRestarted]
+        .concat(props.expandedContext ? styles.expandedContext : [])
         .filter(Boolean)
         .join(" ")}
+      data-expanded-context={props.expandedContext ? "true" : undefined}
+      onContextMenu={(e) => props.onContextMenu?.(e)}
     >
       <span class={styles.separatorRule} />
       <span class={styles.separatorLabel}>
@@ -132,7 +143,9 @@ function LogcatRow(props: {
   inSelectionRange: boolean;
   focusMarked: boolean;
   jsonSelected: boolean;
+  expandedContext: boolean;
   onClick: (e: MouseEvent) => void;
+  onContextMenu: (e: MouseEvent) => void;
   onJsonClick: (e: MouseEvent) => void;
 }): JSX.Element {
   const cfg = () =>
@@ -155,6 +168,7 @@ function LogcatRow(props: {
     if (props.focusMarked) return ACCENT_FOCUS_BG;
     if (props.inSelectionRange) return ACCENT_RANGE_BG;
     if (props.jsonSelected) return "color-mix(in srgb, var(--info) 12%, transparent)";
+    if (props.expandedContext) return "color-mix(in srgb, var(--success) 10%, transparent)";
     if (props.entry.isCrash) return "color-mix(in srgb, var(--error) 12%, transparent)";
     if (hasAnr()) return "color-mix(in srgb, var(--warning) 8%, transparent)";
     return cfg().bg;
@@ -163,13 +177,17 @@ function LogcatRow(props: {
   return (
     <div
       onClick={(e) => props.onClick(e)}
+      onContextMenu={(e) => props.onContextMenu(e)}
       title="Click to copy · Shift+click to select range"
       class={styles.row}
+      data-expanded-context={props.expandedContext ? "true" : undefined}
       style={{
         background: defaultRowBackground(),
         "border-left": props.focusMarked
           ? "4px solid var(--accent)"
-          : `2px solid ${semanticBorderColor()}`,
+          : props.expandedContext
+            ? "4px solid var(--success)"
+            : `2px solid ${semanticBorderColor()}`,
       }}
       onMouseEnter={(e) => {
         if (!props.focusMarked && !props.inSelectionRange && !props.jsonSelected) {
@@ -182,7 +200,9 @@ function LogcatRow(props: {
             ? "color-mix(in srgb, var(--error) 12%, transparent)"
             : hasAnr()
               ? "color-mix(in srgb, var(--warning) 8%, transparent)"
-              : cfg().bg;
+              : props.expandedContext
+                ? "color-mix(in srgb, var(--success) 10%, transparent)"
+                : cfg().bg;
         } else {
           (e.currentTarget as HTMLElement).style.background = defaultRowBackground();
         }

--- a/src/components/logcat/LogcatRows.tsx
+++ b/src/components/logcat/LogcatRows.tsx
@@ -195,17 +195,7 @@ function LogcatRow(props: {
         }
       }}
       onMouseLeave={(e) => {
-        if (!props.focusMarked && !props.inSelectionRange && !props.jsonSelected) {
-          (e.currentTarget as HTMLElement).style.background = props.entry.isCrash
-            ? "color-mix(in srgb, var(--error) 12%, transparent)"
-            : hasAnr()
-              ? "color-mix(in srgb, var(--warning) 8%, transparent)"
-              : props.expandedContext
-                ? "color-mix(in srgb, var(--success) 10%, transparent)"
-                : cfg().bg;
-        } else {
-          (e.currentTarget as HTMLElement).style.background = defaultRowBackground();
-        }
+        (e.currentTarget as HTMLElement).style.background = defaultRowBackground();
       }}
     >
       <span class={styles.timestamp}>{props.entry.timestamp}</span>

--- a/src/components/logcat/QueryBarParts.tsx
+++ b/src/components/logcat/QueryBarParts.tsx
@@ -201,7 +201,7 @@ export function QueryBarSuggestions(props: {
   onHover: (idx: number) => void;
 }): JSX.Element {
   return (
-    <MenuList style={suggestionMenuStyle()}>
+    <MenuList surface="floating" style={suggestionMenuStyle()}>
       <For each={props.suggestions}>
         {(suggestion, i) => {
           const isSelected = () => i() === props.selectedIdx;

--- a/src/components/logcat/logcat-context-expansion.test.ts
+++ b/src/components/logcat/logcat-context-expansion.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { makeLogEntry } from "@/test/factories/logcat";
+import {
+  isExpandedContextRow,
+  mergeExpandedContextEntries,
+  mergeLogcatEntriesChronologically,
+} from "./logcat-context-expansion";
+
+describe("logcat context expansion", () => {
+  it("merges filtered and expanded entries in chronological id order", () => {
+    const filtered = [
+      makeLogEntry({ id: 10n, message: "filtered 10" }),
+      makeLogEntry({ id: 20n, message: "filtered 20" }),
+    ];
+    const expanded = [
+      makeLogEntry({ id: 19n, message: "expanded 19" }),
+      makeLogEntry({ id: 9n, message: "expanded 9" }),
+    ];
+
+    const merged = mergeLogcatEntriesChronologically(filtered, expanded);
+
+    expect(merged.map((entry) => entry.id)).toEqual([9n, 10n, 19n, 20n]);
+  });
+
+  it("deduplicates expanded context rows and keeps them bounded", () => {
+    const current = [
+      makeLogEntry({ id: 2n, message: "current 2" }),
+      makeLogEntry({ id: 4n, message: "current 4" }),
+    ];
+    const incoming = [
+      makeLogEntry({ id: 1n, message: "incoming 1" }),
+      makeLogEntry({ id: 2n, message: "duplicate 2" }),
+      makeLogEntry({ id: 3n, message: "incoming 3" }),
+    ];
+
+    const merged = mergeExpandedContextEntries(current, incoming, 3);
+
+    expect(merged.map((entry) => entry.id)).toEqual([1n, 2n, 4n]);
+    expect(merged.find((entry) => entry.id === 2n)?.message).toBe("current 2");
+  });
+
+  it("marks only rows brought in as expanded context", () => {
+    const expandedIds = new Set([1n, 2n]);
+    const filteredIds = new Set([2n, 3n]);
+
+    expect(isExpandedContextRow(1n, expandedIds, filteredIds)).toBe(true);
+    expect(isExpandedContextRow(2n, expandedIds, filteredIds)).toBe(false);
+    expect(isExpandedContextRow(3n, expandedIds, filteredIds)).toBe(false);
+  });
+});

--- a/src/components/logcat/logcat-context-expansion.ts
+++ b/src/components/logcat/logcat-context-expansion.ts
@@ -1,0 +1,49 @@
+import type { LogcatEntry } from "@/lib/tauri-api";
+
+export const LOGCAT_CONTEXT_EXPAND_COUNT = 10;
+export const LOGCAT_MAX_EXPANDED_CONTEXT_ENTRIES = 500;
+
+function compareByLogcatOrder(a: LogcatEntry, b: LogcatEntry): number {
+  if (a.id < b.id) return -1;
+  if (a.id > b.id) return 1;
+  return 0;
+}
+
+export function mergeLogcatEntriesChronologically(
+  primaryEntries: LogcatEntry[],
+  contextEntries: LogcatEntry[]
+): LogcatEntry[] {
+  const byId = new Map<LogcatEntry["id"], LogcatEntry>();
+  for (const entry of contextEntries) {
+    byId.set(entry.id, entry);
+  }
+  for (const entry of primaryEntries) {
+    byId.set(entry.id, entry);
+  }
+  return Array.from(byId.values()).sort(compareByLogcatOrder);
+}
+
+export function mergeExpandedContextEntries(
+  currentEntries: LogcatEntry[],
+  incomingEntries: LogcatEntry[],
+  maxEntries = LOGCAT_MAX_EXPANDED_CONTEXT_ENTRIES
+): LogcatEntry[] {
+  const byId = new Map<LogcatEntry["id"], LogcatEntry>();
+  for (const entry of currentEntries) {
+    byId.set(entry.id, entry);
+  }
+  for (const entry of incomingEntries) {
+    if (byId.has(entry.id)) continue;
+    if (byId.size >= maxEntries) break;
+    byId.set(entry.id, entry);
+  }
+  return Array.from(byId.values()).sort(compareByLogcatOrder);
+}
+
+export function isExpandedContextRow(
+  entryId: LogcatEntry["id"],
+  expandedContextIds: ReadonlySet<LogcatEntry["id"]>,
+  filteredEntryIds: ReadonlySet<LogcatEntry["id"]>
+): boolean {
+  return expandedContextIds.has(entryId) && !filteredEntryIds.has(entryId);
+}

--- a/src/components/logcat/querybar-styles.ts
+++ b/src/components/logcat/querybar-styles.ts
@@ -254,10 +254,6 @@ export function suggestionMenuStyle(): Record<string, string> {
     "max-width": "360px",
     "max-height": "260px",
     "overflow-y": "auto",
-    background: "var(--bg-secondary)",
-    border: "1px solid var(--border)",
-    "border-radius": "4px",
-    "box-shadow": "0 6px 20px rgba(0,0,0,0.45)",
     "z-index": "600",
   };
 }

--- a/src/components/ui/MenuList/MenuList.module.css
+++ b/src/components/ui/MenuList/MenuList.module.css
@@ -2,6 +2,13 @@
   padding: 4px 0;
 }
 
+.floatingSurface {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
 .item {
   align-items: center;
   color: var(--text-primary);

--- a/src/components/ui/MenuList/MenuList.stories.tsx
+++ b/src/components/ui/MenuList/MenuList.stories.tsx
@@ -49,3 +49,23 @@ export const Empty: Story = {
     </div>
   ),
 };
+
+export const FloatingContextMenu: Story = {
+  render: () => (
+    <div style={{ height: "140px", position: "relative" }}>
+      <MenuList
+        role="menu"
+        surface="floating"
+        style={{
+          position: "absolute",
+          left: "24px",
+          top: "24px",
+          width: "176px",
+        }}
+      >
+        <MenuListItem onClick={() => {}}>Expand 10 up</MenuListItem>
+        <MenuListItem onClick={() => {}}>Expand 10 down</MenuListItem>
+      </MenuList>
+    </div>
+  ),
+};

--- a/src/components/ui/MenuList/MenuList.test.tsx
+++ b/src/components/ui/MenuList/MenuList.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 import { MenuEmptyState, MenuList, MenuListItem, MenuSectionHeader } from "./MenuList";
+import styles from "./MenuList.module.css";
 
 describe("MenuList", () => {
   it("renders section headers, items, and empty states", () => {
@@ -50,5 +51,23 @@ describe("MenuList", () => {
     ));
 
     expect(screen.getByRole("option", { name: "Run" })).not.toBeNull();
+  });
+
+  it("applies shared floating surface chrome only when requested", () => {
+    render(() => (
+      <>
+        <MenuList role="menu">
+          <MenuListItem onClick={() => undefined}>Flat</MenuListItem>
+        </MenuList>
+        <MenuList role="menu" surface="floating">
+          <MenuListItem onClick={() => undefined}>Floating</MenuListItem>
+        </MenuList>
+      </>
+    ));
+
+    const menus = screen.getAllByRole("menu");
+
+    expect(menus[0].classList.contains(styles.floatingSurface)).toBe(false);
+    expect(menus[1].classList.contains(styles.floatingSurface)).toBe(true);
   });
 });

--- a/src/components/ui/MenuList/MenuList.tsx
+++ b/src/components/ui/MenuList/MenuList.tsx
@@ -7,6 +7,7 @@ export interface MenuListProps {
   style?: JSX.CSSProperties;
   role?: JSX.HTMLAttributes<HTMLDivElement>["role"];
   listRef?: (el: HTMLDivElement) => void;
+  surface?: "floating";
 }
 
 export interface MenuListItemProps {
@@ -34,7 +35,9 @@ export function MenuList(props: MenuListProps): JSX.Element {
     <div
       ref={props.listRef}
       role={props.role}
-      class={[styles.root, props.class].filter(Boolean).join(" ")}
+      class={[styles.root, props.surface === "floating" ? styles.floatingSurface : "", props.class]
+        .filter(Boolean)
+        .join(" ")}
       style={props.style}
     >
       {props.children}

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -437,6 +437,18 @@ export async function getLogcatEntries(opts?: {
   });
 }
 
+export async function getLogcatContextEntries(opts: {
+  anchorId: bigint;
+  direction: "before" | "after";
+  count?: number;
+}): Promise<ProcessedEntry[]> {
+  return invoke<ProcessedEntry[]>("get_logcat_context_entries", {
+    anchorId: opts.anchorId,
+    direction: opts.direction,
+    count: opts.count ?? null,
+  });
+}
+
 export async function getLogcatStatus(): Promise<boolean> {
   return invoke<boolean>("get_logcat_status");
 }

--- a/src/test/mock-backend/logcat.ts
+++ b/src/test/mock-backend/logcat.ts
@@ -66,6 +66,12 @@ type LogcatEntriesArgs = {
   onlyCrashes?: boolean | null;
 };
 
+type LogcatContextEntriesArgs = {
+  anchorId?: bigint | number | string | null;
+  direction?: "before" | "after" | string | null;
+  count?: number | null;
+};
+
 function emptyFilter(): LogcatFilterSpec {
   return { minLevel: null, tag: null, text: null, package: null, onlyCrashes: false };
 }
@@ -125,6 +131,22 @@ function argsToFilter(args: unknown): LogcatFilterSpec {
   };
 }
 
+function contextEntries(args: unknown): ProcessedEntry[] {
+  const opts = (args ?? {}) as LogcatContextEntriesArgs;
+  if (opts.anchorId === null || opts.anchorId === undefined) return [];
+  const anchorId = BigInt(opts.anchorId);
+  const anchorIndex = storedEntries.findIndex((entry) => entry.id === anchorId);
+  if (anchorIndex < 0) return [];
+  const count = Math.max(0, Math.floor(opts.count ?? 10));
+  if (opts.direction === "before") {
+    return storedEntries.slice(Math.max(0, anchorIndex - count), anchorIndex);
+  }
+  if (opts.direction === "after") {
+    return storedEntries.slice(anchorIndex + 1, anchorIndex + 1 + count);
+  }
+  return [];
+}
+
 export function logcatHandlers(): Record<string, (args: unknown) => unknown> {
   return {
     start_logcat: () => {
@@ -162,6 +184,7 @@ export function logcatHandlers(): Record<string, (args: unknown) => unknown> {
       triggerEvent("logcat:cleared", undefined);
     },
     get_logcat_entries: (args: unknown) => filterEntries(storedEntries, argsToFilter(args)),
+    get_logcat_context_entries: (args: unknown) => contextEntries(args),
     get_logcat_status: () => logcatRunning,
     list_logcat_packages: () => ["com.example.mockapp"],
     set_logcat_filter: (args: unknown) => {


### PR DESCRIPTION
## Summary

Added expanded logs when it is filtered.

<img width="1395" height="889" alt="Screenshot 2026-05-11 at 10 11 57 AM" src="https://github.com/user-attachments/assets/c5cdce35-6f5f-4a3b-a1b9-f81f9c598f73" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add context expansion to filtered Logcat: right-click a row and choose “Expand 10 up” or “Expand 10 down” to load adjacent unfiltered rows without clearing the filter. Expanded rows are merged chronologically and marked with a green left indicator.

- **New Features**
  - Backend: added `get_logcat_context_entries` to fetch up to 10 rows before/after an anchor; `LogStore` implements `context_before`/`context_after`.
  - UI: a filter‑only context menu in `LogcatPanel` expands context, merges it with filtered results in order, caps stored context at 500, preserves read mode, and clears context on query, clear, and jump‑to‑end.
  - Docs: user guide and domain patterns updated to describe context expansion and merging behavior.

- **Bug Fixes**
  - Menu surfaces are now opaque for floating menus using `MenuList surface="floating"`, applied to the entry detail filter menu and query suggestions to improve readability.
  - Keep the green expanded‑context highlight after hover, including on crash/lifecycle separator rows.

<sup>Written for commit 2b11206248b9de201ad6835c2dc76900b6e09eca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

