### PR TITLE
fix improviments

### DIFF
--- a/src-tauri/src/commands/build.rs
+++ b/src-tauri/src/commands/build.rs
@@ -52,6 +52,57 @@ fn validate_gradle_task(task: &str) -> Result<(), AppError> {
     Ok(())
 }
 
+pub(crate) struct BuildFinalization {
+    task: String,
+    started_at: String,
+    project_root: Option<String>,
+    success: bool,
+    cancelled: bool,
+    duration_ms: u64,
+    errors: Vec<BuildError>,
+}
+
+pub(crate) async fn finalize_completed_build(
+    build_state: &BuildState,
+    finalization: BuildFinalization,
+) -> BuildCompleteEvent {
+    let error_count = finalization
+        .errors
+        .iter()
+        .filter(|e| e.severity == BuildErrorSeverity::Error)
+        .count() as u32;
+    let warn_count = finalization
+        .errors
+        .iter()
+        .filter(|e| e.severity == BuildErrorSeverity::Warning)
+        .count() as u32;
+    let result = BuildResult {
+        success: finalization.success,
+        duration_ms: finalization.duration_ms,
+        error_count,
+        warning_count: warn_count,
+    };
+
+    build_runner::record_build_result(
+        build_state,
+        finalization.task.clone(),
+        finalization.started_at,
+        result,
+        finalization.errors,
+        finalization.project_root,
+    )
+    .await;
+
+    BuildCompleteEvent {
+        success: finalization.success,
+        cancelled: finalization.cancelled,
+        duration_ms: finalization.duration_ms,
+        error_count,
+        warning_count: warn_count,
+        task: finalization.task,
+    }
+}
+
 // ── Build commands ─────────────────────────────────────────────────────────────
 
 /// Run a Gradle task, streaming output via a Tauri Channel.
@@ -70,13 +121,19 @@ pub async fn run_gradle_task(
 ) -> Result<u32, AppError> {
     validate_gradle_task(&task)?;
 
-    let gradle_root: PathBuf = {
+    let (gradle_root, project_root_for_history): (PathBuf, Option<String>) = {
         let fs = fs_state.0.lock().await;
-        fs.gradle_root
+        let root = fs
+            .gradle_root
             .as_ref()
             .or(fs.project_root.as_ref())
             .cloned()
-            .ok_or_else(|| AppError::NotFound("No project is open".into()))?
+            .ok_or_else(|| AppError::NotFound("No project is open".into()))?;
+        let project_root = fs
+            .project_root
+            .as_ref()
+            .map(|p| p.to_string_lossy().into_owned());
+        (root, project_root)
     };
 
     let (settings, _) = settings_manager::load_settings();
@@ -97,6 +154,7 @@ pub async fn run_gradle_task(
     let success_flag: Arc<StdMutex<bool>> = Arc::new(StdMutex::new(false));
     // Share the BuildLog Arc so the on_line callback can push lines directly.
     let build_log = build_state.build_log.clone();
+    let build_state_for_exit = build_state.inner().clone();
 
     let args_strs: Vec<String> = args;
     let args_refs: Vec<&str> = args_strs.iter().map(|s| s.as_str()).collect();
@@ -158,6 +216,9 @@ pub async fn run_gradle_task(
             on_exit: Box::new({
                 let app = app_handle.clone();
                 let task_name = task.clone();
+                let started_at = started_at.clone();
+                let project_root = project_root_for_history.clone();
+                let build_state = build_state_for_exit.clone();
                 move |_pid, termination| {
                     // std::sync::Mutex::lock() — safe to call from any context.
                     let errs = errors_buf.lock().map(|g| g.clone()).unwrap_or_default();
@@ -168,26 +229,27 @@ pub async fn run_gradle_task(
                     let success = !cancelled
                         && (flag || matches!(termination, ProcessTermination::ExitCode(0)));
 
-                    let error_count = errs
-                        .iter()
-                        .filter(|e| e.severity == BuildErrorSeverity::Error)
-                        .count() as u32;
-                    let warn_count = errs
-                        .iter()
-                        .filter(|e| e.severity == BuildErrorSeverity::Warning)
-                        .count() as u32;
-
-                    let _ = app.emit(
-                        "build:complete",
-                        BuildCompleteEvent {
-                            success,
-                            cancelled,
-                            duration_ms: dur,
-                            error_count,
-                            warning_count: warn_count,
-                            task: task_name.clone(),
-                        },
-                    );
+                    let app = app.clone();
+                    let task_name = task_name.clone();
+                    let started_at = started_at.clone();
+                    let project_root = project_root.clone();
+                    let build_state = build_state.clone();
+                    tauri::async_runtime::spawn(async move {
+                        let event = finalize_completed_build(
+                            &build_state,
+                            BuildFinalization {
+                                task: task_name,
+                                started_at,
+                                project_root,
+                                success,
+                                cancelled,
+                                duration_ms: dur,
+                                errors: errs,
+                            },
+                        )
+                        .await;
+                        let _ = app.emit("build:complete", event);
+                    });
                 }
             }),
         },
@@ -196,7 +258,7 @@ pub async fn run_gradle_task(
     .map_err(AppError::ProcessFailed)?;
 
     // Register immediately (sync, no `.await` before this) so cancel always has a ProcessId.
-    *build_state.active_process_id.lock().unwrap() = Some(id);
+    build_state.set_active_process_id(Some(id));
 
     // Mark build as running in the managed state and clear the log for this run.
     {
@@ -334,7 +396,19 @@ pub async fn get_build_log_entries(id: u32) -> Result<Vec<BuildLine>, String> {
 /// including any `applicationIdSuffix` added by the build variant. Use this
 /// after `find_apk_path` to pass the correct package to `launch_app_on_device`.
 #[tauri::command]
-pub async fn get_package_name_from_apk(apk_path: String) -> Result<String, AppError> {
+pub async fn get_package_name_from_apk(
+    apk_path: String,
+    fs_state: State<'_, FsState>,
+) -> Result<String, AppError> {
+    let root = {
+        let fs = fs_state.0.lock().await;
+        fs.gradle_root
+            .as_ref()
+            .or(fs.project_root.as_ref())
+            .cloned()
+            .ok_or_else(|| AppError::NotFound("No project is open".into()))?
+    };
+
     let (settings, _) = settings_manager::load_settings();
 
     let aapt2 = crate::services::adb_manager::find_aapt2(&settings).ok_or_else(|| {
@@ -343,10 +417,7 @@ pub async fn get_package_name_from_apk(apk_path: String) -> Result<String, AppEr
         )
     })?;
 
-    let apk = PathBuf::from(&apk_path);
-    if !apk.is_file() {
-        return Err(AppError::NotFound(format!("APK not found: {apk_path}")));
-    }
+    let apk = crate::utils::path::validate_apk_within_build_outputs(&root, &apk_path)?;
 
     crate::services::adb_manager::get_package_name_from_apk(&aapt2, &apk)
         .await
@@ -395,5 +466,42 @@ mod tests {
         assert!(validate_gradle_task("assemble$(evil)").is_err());
         assert!(validate_gradle_task("assemble\necho pwned").is_err());
         assert!(validate_gradle_task(&"a".repeat(257)).is_err());
+    }
+
+    #[tokio::test]
+    async fn process_exit_finalization_records_backend_history() {
+        let build_state = BuildState::new();
+        let errors = vec![BuildError {
+            message: "compile failed".to_string(),
+            file: Some("Main.kt".to_string()),
+            line: Some(7),
+            col: Some(3),
+            severity: BuildErrorSeverity::Error,
+        }];
+
+        let event = finalize_completed_build(
+            &build_state,
+            BuildFinalization {
+                task: "assembleDebug".to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                project_root: Some("/tmp/project".to_string()),
+                success: false,
+                cancelled: false,
+                duration_ms: 1234,
+                errors,
+            },
+        )
+        .await;
+
+        assert!(!event.success);
+        assert!(!event.cancelled);
+        assert_eq!(event.error_count, 1);
+
+        let state = build_state.inner.lock().await;
+        assert!(matches!(state.status, BuildStatus::Failed(_)));
+        assert_eq!(
+            state.history.back().map(|r| r.task.as_str()),
+            Some("assembleDebug")
+        );
     }
 }

--- a/src-tauri/src/commands/device.rs
+++ b/src-tauri/src/commands/device.rs
@@ -9,6 +9,7 @@ use crate::services::adb_manager::{
     list_devices, list_system_images, stop_app, stop_emulator, wipe_avd_data, DeviceState,
 };
 use crate::services::settings_manager;
+use crate::FsState;
 use serde::Serialize;
 use std::time::Duration;
 use tauri::ipc::Channel;
@@ -43,6 +44,40 @@ pub(crate) fn validate_device_serial(serial: &str) -> Result<(), AppError> {
     {
         return Err(AppError::InvalidInput(format!(
             "Invalid device serial '{serial}': only alphanumeric, ':', '.', '-', '_' are allowed"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_package_name(package: &str) -> Result<(), AppError> {
+    if package.is_empty() {
+        return Err(AppError::InvalidInput(
+            "Package name cannot be empty".to_string(),
+        ));
+    }
+    let valid = package
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '.' | '_'));
+    if !valid || !package.contains('.') {
+        return Err(AppError::InvalidInput(format!(
+            "Invalid package name '{package}'. Expected format: com.example.app"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_activity_name(activity: &str) -> Result<(), AppError> {
+    if activity.is_empty() {
+        return Err(AppError::InvalidInput(
+            "Activity name cannot be empty".to_string(),
+        ));
+    }
+    let valid = activity
+        .chars()
+        .all(|c| c.is_alphanumeric() || matches!(c, '.' | '_' | '$'));
+    if !valid {
+        return Err(AppError::InvalidInput(format!(
+            "Invalid activity name '{activity}'"
         )));
     }
     Ok(())
@@ -91,13 +126,22 @@ pub async fn get_selected_device(
 
 /// Install an APK on the given device.
 #[tauri::command]
-pub async fn install_apk_on_device(serial: String, apk_path: String) -> Result<String, AppError> {
+pub async fn install_apk_on_device(
+    serial: String,
+    apk_path: String,
+    fs_state: State<'_, FsState>,
+) -> Result<String, AppError> {
     validate_device_serial(&serial)?;
-    if !std::path::Path::new(&apk_path).exists() {
-        return Err(AppError::NotFound(format!(
-            "APK file not found: {apk_path}"
-        )));
-    }
+    let root = {
+        let fs = fs_state.0.lock().await;
+        fs.gradle_root
+            .as_ref()
+            .or(fs.project_root.as_ref())
+            .cloned()
+            .ok_or_else(|| AppError::NotFound("No project is open".into()))?
+    };
+    let apk = crate::utils::path::validate_apk_within_build_outputs(&root, &apk_path)?;
+    let apk_path = apk.to_string_lossy().into_owned();
     let (settings, _) = settings_manager::load_settings();
     let adb = get_adb_path(&settings);
     install_apk(&adb, &serial, &apk_path)
@@ -113,6 +157,10 @@ pub async fn launch_app_on_device(
     activity: Option<String>,
 ) -> Result<String, AppError> {
     validate_device_serial(&serial)?;
+    validate_package_name(&package)?;
+    if let Some(ref activity_name) = activity {
+        validate_activity_name(activity_name)?;
+    }
     let (settings, _) = settings_manager::load_settings();
     let adb = get_adb_path(&settings);
     launch_app(&adb, &serial, &package, activity.as_deref())
@@ -124,6 +172,7 @@ pub async fn launch_app_on_device(
 #[tauri::command]
 pub async fn stop_app_on_device(serial: String, package: String) -> Result<(), AppError> {
     validate_device_serial(&serial)?;
+    validate_package_name(&package)?;
     let (settings, _) = settings_manager::load_settings();
     let adb = get_adb_path(&settings);
     stop_app(&adb, &serial, &package)
@@ -364,5 +413,35 @@ mod tests {
     #[test]
     fn serial_carriage_return_is_rejected() {
         assert!(validate_device_serial("emulator\r5554").is_err());
+    }
+
+    #[test]
+    fn valid_package_names_pass() {
+        assert!(validate_package_name("com.example.app").is_ok());
+        assert!(validate_package_name("com.example.my_app").is_ok());
+    }
+
+    #[test]
+    fn invalid_package_names_are_rejected() {
+        assert!(validate_package_name("").is_err());
+        assert!(validate_package_name("notapackage").is_err());
+        assert!(validate_package_name("com.example; rm -rf").is_err());
+        assert!(validate_package_name("com.example app").is_err());
+        assert!(validate_package_name("com.example\napp").is_err());
+    }
+
+    #[test]
+    fn valid_activity_names_pass() {
+        assert!(validate_activity_name(".MainActivity").is_ok());
+        assert!(validate_activity_name("com.example.app.MainActivity").is_ok());
+        assert!(validate_activity_name("com.example.app.MainActivity$Inner").is_ok());
+    }
+
+    #[test]
+    fn invalid_activity_names_are_rejected() {
+        assert!(validate_activity_name("").is_err());
+        assert!(validate_activity_name("Main Activity").is_err());
+        assert!(validate_activity_name(".MainActivity; rm -rf").is_err());
+        assert!(validate_activity_name(".MainActivity\nOther").is_err());
     }
 }

--- a/src-tauri/src/commands/file_system.rs
+++ b/src-tauri/src/commands/file_system.rs
@@ -20,8 +20,6 @@ fn project_id(path: &std::path::Path) -> String {
 /// Upsert a `ProjectEntry` into `settings.recent_projects` and persist.
 /// Evicts the oldest non-pinned entry when the list exceeds `MAX_RECENT_PROJECTS`.
 fn upsert_project(path: &std::path::Path, gradle_root: Option<&std::path::Path>) {
-    let (mut settings, _) = settings_manager::load_settings();
-
     let id = project_id(path);
     let name = path
         .file_name()
@@ -31,44 +29,44 @@ fn upsert_project(path: &std::path::Path, gradle_root: Option<&std::path::Path>)
     let gradle_root_str = gradle_root.map(|p| p.to_string_lossy().to_string());
     let now = chrono::Utc::now().to_rfc3339();
 
-    // Update existing entry or insert new one.
-    if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
-        entry.last_opened = now;
-        entry.gradle_root = gradle_root_str;
-        entry.name = name;
-    } else {
-        settings.recent_projects.push(ProjectEntry {
-            id,
-            path: path_str.clone(),
-            name,
-            gradle_root: gradle_root_str,
-            last_opened: now,
-            pinned: false,
-            last_build_variant: None,
-            last_device: None,
-        });
+    if let Err(e) = settings_manager::mutate_settings(|settings| {
+        // Update existing entry or insert new one.
+        if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
+            entry.last_opened = now;
+            entry.gradle_root = gradle_root_str;
+            entry.name = name;
+        } else {
+            settings.recent_projects.push(ProjectEntry {
+                id,
+                path: path_str.clone(),
+                name,
+                gradle_root: gradle_root_str,
+                last_opened: now,
+                pinned: false,
+                last_build_variant: None,
+                last_device: None,
+            });
 
-        // Evict oldest non-pinned entries when over the cap.
-        while settings.recent_projects.len() > MAX_RECENT_PROJECTS {
-            // Find the index of the oldest non-pinned entry.
-            let evict_idx = settings
-                .recent_projects
-                .iter()
-                .enumerate()
-                .filter(|(_, e)| !e.pinned)
-                .min_by_key(|(_, e)| e.last_opened.clone())
-                .map(|(i, _)| i);
-            if let Some(idx) = evict_idx {
-                settings.recent_projects.remove(idx);
-            } else {
-                break; // All are pinned — keep them all.
+            // Evict oldest non-pinned entries when over the cap.
+            while settings.recent_projects.len() > MAX_RECENT_PROJECTS {
+                // Find the index of the oldest non-pinned entry.
+                let evict_idx = settings
+                    .recent_projects
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, e)| !e.pinned)
+                    .min_by_key(|(_, e)| e.last_opened.clone())
+                    .map(|(i, _)| i);
+                if let Some(idx) = evict_idx {
+                    settings.recent_projects.remove(idx);
+                } else {
+                    break; // All are pinned — keep them all.
+                }
             }
         }
-    }
 
-    settings.last_active_project = Some(path_str);
-
-    if let Err(e) = settings_manager::save_settings(&settings) {
+        settings.last_active_project = Some(path_str);
+    }) {
         tracing::warn!("Failed to persist project registry: {e}");
     }
 }
@@ -226,39 +224,35 @@ pub async fn list_projects() -> Result<Vec<ProjectEntry>, String> {
 /// Does *not* delete the project from disk.
 #[tauri::command]
 pub async fn remove_project(id: String) -> Result<(), String> {
-    let (mut settings, _) = tokio::task::spawn_blocking(settings_manager::load_settings)
-        .await
-        .map_err(|e| format!("Failed to load settings: {e}"))?;
+    tokio::task::spawn_blocking(move || {
+        settings_manager::mutate_settings(|settings| {
+            settings.recent_projects.retain(|e| e.id != id);
 
-    settings.recent_projects.retain(|e| e.id != id);
-
-    // Clear last_active_project if it was the removed one.
-    if let Some(ref last) = settings.last_active_project.clone() {
-        let still_exists = settings.recent_projects.iter().any(|e| &e.path == last);
-        if !still_exists {
-            settings.last_active_project = None;
-        }
-    }
-
-    tokio::task::spawn_blocking(move || settings_manager::save_settings(&settings))
-        .await
-        .map_err(|e| format!("Failed to save settings: {e}"))?
+            // Clear last_active_project if it was the removed one.
+            if let Some(ref last) = settings.last_active_project.clone() {
+                let still_exists = settings.recent_projects.iter().any(|e| &e.path == last);
+                if !still_exists {
+                    settings.last_active_project = None;
+                }
+            }
+        })
+    })
+    .await
+    .map_err(|e| format!("Failed to save settings: {e}"))?
 }
 
 /// Toggle the `pinned` flag for a project entry.
 #[tauri::command]
 pub async fn pin_project(id: String, pinned: bool) -> Result<(), String> {
-    let (mut settings, _) = tokio::task::spawn_blocking(settings_manager::load_settings)
-        .await
-        .map_err(|e| format!("Failed to load settings: {e}"))?;
-
-    if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
-        entry.pinned = pinned;
-    }
-
-    tokio::task::spawn_blocking(move || settings_manager::save_settings(&settings))
-        .await
-        .map_err(|e| format!("Failed to save settings: {e}"))?
+    tokio::task::spawn_blocking(move || {
+        settings_manager::mutate_settings(|settings| {
+            if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
+                entry.pinned = pinned;
+            }
+        })
+    })
+    .await
+    .map_err(|e| format!("Failed to save settings: {e}"))?
 }
 
 /// Return the path of the last-active project (used on startup to restore the session).
@@ -419,18 +413,16 @@ pub async fn update_project_meta(
     last_build_variant: Option<String>,
     last_device: Option<String>,
 ) -> Result<(), String> {
-    let (mut settings, _) = tokio::task::spawn_blocking(settings_manager::load_settings)
-        .await
-        .map_err(|e| format!("Failed to load settings: {e}"))?;
-
-    if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
-        entry.last_build_variant = last_build_variant;
-        entry.last_device = last_device;
-    }
-
-    tokio::task::spawn_blocking(move || settings_manager::save_settings(&settings))
-        .await
-        .map_err(|e| format!("Failed to save settings: {e}"))?
+    tokio::task::spawn_blocking(move || {
+        settings_manager::mutate_settings(|settings| {
+            if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
+                entry.last_build_variant = last_build_variant;
+                entry.last_device = last_device;
+            }
+        })
+    })
+    .await
+    .map_err(|e| format!("Failed to save settings: {e}"))?
 }
 
 /// Rename the display name of a project in the registry.
@@ -442,19 +434,18 @@ pub async fn rename_project(id: String, new_name: String) -> Result<(), String> 
         return Err("Project name cannot be empty".to_string());
     }
 
-    let (mut settings, _) = tokio::task::spawn_blocking(settings_manager::load_settings)
-        .await
-        .map_err(|e| format!("Failed to load settings: {e}"))?;
-
-    if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
-        entry.name = new_name;
-    } else {
-        return Err(format!("Project with id '{id}' not found"));
-    }
-
-    tokio::task::spawn_blocking(move || settings_manager::save_settings(&settings))
-        .await
-        .map_err(|e| format!("Failed to save settings: {e}"))?
+    tokio::task::spawn_blocking(move || {
+        settings_manager::mutate_settings_with_result(|settings| {
+            if let Some(entry) = settings.recent_projects.iter_mut().find(|e| e.id == id) {
+                entry.name = new_name;
+                Ok(())
+            } else {
+                Err(format!("Project with id '{id}' not found"))
+            }
+        })
+    })
+    .await
+    .map_err(|e| format!("Failed to save settings: {e}"))?
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/logcat.rs
+++ b/src-tauri/src/commands/logcat.rs
@@ -2,6 +2,7 @@ use crate::models::logcat::{LogStats, LogcatFilterSpec, ProcessedEntry};
 use crate::services::logcat::{self, LogcatFilter, LogcatState, LogcatStateInner};
 use crate::services::settings_manager;
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::{AppHandle, State};
 use tokio::sync::Mutex;
 
@@ -28,11 +29,27 @@ pub async fn start_logcat(
     }
 
     let state_clone = logcat_state.inner().clone();
+    let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
     tokio::spawn(async move {
-        logcat::start_logcat_stream(adb_bin, device_serial, state_clone, Some(app_handle)).await;
+        logcat::start_logcat_stream(
+            adb_bin,
+            device_serial,
+            state_clone,
+            Some(app_handle),
+            Some(startup_tx),
+        )
+        .await;
     });
 
-    Ok(())
+    match tokio::time::timeout(Duration::from_secs(5), startup_rx).await {
+        Ok(Ok(Ok(()))) => Ok(()),
+        Ok(Ok(Err(e))) => Err(e),
+        Ok(Err(_)) => Err("Logcat startup task exited before reporting status".to_string()),
+        Err(_) => {
+            logcat_state.lock().await.streaming = false;
+            Err("Timed out waiting for logcat to start".to_string())
+        }
+    }
 }
 
 /// Stop the logcat stream.

--- a/src-tauri/src/services/build_runner.rs
+++ b/src-tauri/src/services/build_runner.rs
@@ -117,6 +117,20 @@ impl BuildState {
             active_process_id: Arc::new(StdMutex::new(None)),
         }
     }
+
+    pub fn take_active_process_id(&self) -> Option<ProcessId> {
+        match self.active_process_id.lock() {
+            Ok(mut guard) => guard.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        }
+    }
+
+    pub fn set_active_process_id(&self, pid: Option<ProcessId>) {
+        match self.active_process_id.lock() {
+            Ok(mut guard) => *guard = pid,
+            Err(poisoned) => *poisoned.into_inner() = pid,
+        }
+    }
 }
 
 impl Clone for BuildState {
@@ -396,7 +410,7 @@ pub fn find_output_apk(gradle_root: &Path, variant_name: &str) -> Option<PathBuf
 /// Cancel the currently running build. Returns `true` if a build was running, `false` otherwise.
 pub async fn cancel_build(build_state: &BuildState, process_manager: &ProcessManager) -> bool {
     let id = {
-        let from_sync = build_state.active_process_id.lock().unwrap().take();
+        let from_sync = build_state.take_active_process_id();
         if let Some(id) = from_sync {
             let mut bs = build_state.inner.lock().await;
             if bs.current_build == Some(id) {
@@ -448,7 +462,7 @@ pub async fn record_build_result(
         .map(|g| g.clone())
         .unwrap_or_default();
 
-    let _ = build_state.active_process_id.lock().unwrap().take();
+    let _ = build_state.take_active_process_id();
 
     let (record_id, history_snapshot) = {
         let mut bs = build_state.inner.lock().await;
@@ -641,7 +655,7 @@ pub async fn run_task(
     .await
     .map_err(|e| format!("Failed to spawn Gradle: {e}"))?;
 
-    *build_state.active_process_id.lock().unwrap() = Some(pid);
+    build_state.set_active_process_id(Some(pid));
     {
         let mut bs = build_state.inner.lock().await;
         if matches!(bs.status, BuildStatus::Cancelled) {
@@ -1263,6 +1277,20 @@ mod tests {
         assert!(
             !dir_path.join("build-99.jsonl").exists(),
             "id=99 (orphan) must be deleted"
+        );
+    }
+
+    #[test]
+    fn production_code_does_not_unwrap_active_process_mutex() {
+        let source = include_str!("build_runner.rs");
+        let production_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production section");
+
+        assert!(
+            !production_source.contains("active_process_id.lock().unwrap()"),
+            "active_process_id mutex must handle poisoning without unwrap()"
         );
     }
 }

--- a/src-tauri/src/services/logcat.rs
+++ b/src-tauri/src/services/logcat.rs
@@ -340,7 +340,9 @@ pub async fn start_logcat_stream(
     device_serial: Option<String>,
     logcat_state: LogcatState,
     app_handle: Option<tauri::AppHandle>,
+    startup_status: Option<tokio::sync::oneshot::Sender<Result<(), String>>>,
 ) {
+    let mut startup_status = startup_status;
     'reconnect: loop {
         // Check whether a graceful stop was requested before (re)connecting.
         {
@@ -363,6 +365,11 @@ pub async fn start_logcat_stream(
             Ok(c) => c,
             Err(e) => {
                 error!("Failed to start logcat: {}", e);
+                if let Some(tx) = startup_status.take() {
+                    let msg = format!("Failed to start logcat: {e}");
+                    let _ = tx.send(Err(msg));
+                    break 'reconnect;
+                }
                 // Retry if streaming is still requested; otherwise give up.
                 let still_streaming = logcat_state.lock().await.streaming;
                 if still_streaming {
@@ -382,9 +389,16 @@ pub async fn start_logcat_stream(
             Some(s) => s,
             None => {
                 error!("logcat process has no stdout");
+                if let Some(tx) = startup_status.take() {
+                    let _ = tx.send(Err("logcat process has no stdout".to_string()));
+                }
                 break 'reconnect;
             }
         };
+
+        if let Some(tx) = startup_status.take() {
+            let _ = tx.send(Ok(()));
+        }
 
         // Channel: reader → pipeline+batcher
         let (tx, mut rx) = mpsc::channel::<RawLogLine>(RAW_LOG_LINE_CHANNEL_CAPACITY);
@@ -1263,7 +1277,14 @@ mod reconnect_tests {
     #[tokio::test]
     async fn exits_immediately_when_not_streaming() {
         let state = make_state(false);
-        start_logcat_stream(PathBuf::from("/nonexistent/adb"), None, state.clone(), None).await;
+        start_logcat_stream(
+            PathBuf::from("/nonexistent/adb"),
+            None,
+            state.clone(),
+            None,
+            None,
+        )
+        .await;
         assert!(
             !state.lock().await.streaming,
             "streaming must be false when function returns"
@@ -1288,6 +1309,7 @@ mod reconnect_tests {
                 None,
                 state.clone(),
                 None,
+                None,
             ),
         )
         .await
@@ -1296,6 +1318,32 @@ mod reconnect_tests {
         assert!(
             !state.lock().await.streaming,
             "streaming must be false when function returns"
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_initial_spawn_failure_and_stops_streaming() {
+        let state = make_state(true);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            start_logcat_stream(
+                PathBuf::from("/definitely/does/not/exist/adb"),
+                None,
+                state.clone(),
+                None,
+                Some(tx),
+            ),
+        )
+        .await
+        .expect("start_logcat_stream must return after initial spawn failure");
+
+        let startup = rx.await.expect("startup status must be sent");
+        assert!(startup.is_err());
+        assert!(
+            !state.lock().await.streaming,
+            "initial spawn failure must clear streaming"
         );
     }
 
@@ -1312,7 +1360,7 @@ mod reconnect_tests {
 
         tokio::time::timeout(
             Duration::from_secs(5),
-            start_logcat_stream(instant_exit_bin(), None, state.clone(), None),
+            start_logcat_stream(instant_exit_bin(), None, state.clone(), None, None),
         )
         .await
         .expect("start_logcat_stream must return within 5 s");
@@ -1356,7 +1404,7 @@ mod reconnect_tests {
 
         tokio::time::timeout(
             Duration::from_secs(5),
-            start_logcat_stream(instant_exit_bin(), None, state.clone(), None),
+            start_logcat_stream(instant_exit_bin(), None, state.clone(), None, None),
         )
         .await
         .expect("start_logcat_stream must return within 5 s");
@@ -1392,7 +1440,7 @@ mod reconnect_tests {
 
         tokio::time::timeout(
             Duration::from_secs(5),
-            start_logcat_stream(instant_exit_bin(), None, state.clone(), None),
+            start_logcat_stream(instant_exit_bin(), None, state.clone(), None, None),
         )
         .await
         .expect("start_logcat_stream must return within 5 s after stop during reconnect sleep");

--- a/src-tauri/src/services/mcp_server.rs
+++ b/src-tauri/src/services/mcp_server.rs
@@ -807,10 +807,33 @@ impl AndroidMcpServer {
         let logcat_state = self.logcat_state.clone();
         let app_handle = self.app_handle.clone();
 
+        let (startup_tx, startup_rx) = tokio::sync::oneshot::channel();
         tokio::spawn(async move {
-            crate::services::logcat::start_logcat_stream(adb_bin, serial, logcat_state, app_handle)
-                .await;
+            crate::services::logcat::start_logcat_stream(
+                adb_bin,
+                serial,
+                logcat_state,
+                app_handle,
+                Some(startup_tx),
+            )
+            .await;
         });
+
+        match tokio::time::timeout(std::time::Duration::from_secs(5), startup_rx).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(e))) => return Ok(CallToolResult::error(vec![Content::text(e)])),
+            Ok(Err(_)) => {
+                return Ok(CallToolResult::error(vec![Content::text(
+                    "Logcat startup task exited before reporting status.",
+                )]))
+            }
+            Err(_) => {
+                self.logcat_state.lock().await.streaming = false;
+                return Ok(CallToolResult::error(vec![Content::text(
+                    "Timed out waiting for logcat to start.",
+                )]));
+            }
+        }
 
         Ok(CallToolResult::success(vec![Content::text(
             "Logcat streaming started. Use get_logcat_entries to read entries.",

--- a/src-tauri/src/services/process_manager.rs
+++ b/src-tauri/src/services/process_manager.rs
@@ -97,7 +97,7 @@ impl Default for ProcessManager {
 /// # Errors
 /// Returns an error string if the process fails to start.
 pub async fn spawn(
-    manager: &Mutex<ProcessManagerInner>,
+    manager: &Arc<Mutex<ProcessManagerInner>>,
     cmd: &str,
     args: &[&str],
     cwd: PathBuf,
@@ -105,6 +105,11 @@ pub async fn spawn(
     options: SpawnOptions,
 ) -> Result<ProcessId, String> {
     let id = NEXT_PROCESS_ID.fetch_add(1, Ordering::SeqCst);
+
+    let mut inner = manager.lock().await;
+    if inner.processes.len() >= 10 {
+        return Err("Maximum concurrent processes (10) reached".into());
+    }
 
     let mut command = Command::new(cmd);
     command
@@ -136,6 +141,7 @@ pub async fn spawn(
         let on_line = on_line.clone();
         let on_exit = on_exit.clone();
         let cancelled_flag = cancelled.clone();
+        let manager_for_cleanup = manager.clone();
 
         tokio::spawn(async move {
             let stdout_reader = BufReader::new(stdout);
@@ -197,6 +203,7 @@ pub async fn spawn(
                 termination
             };
             on_exit(id, final_termination);
+            manager_for_cleanup.lock().await.processes.remove(&id);
         })
     };
 
@@ -206,11 +213,6 @@ pub async fn spawn(
         cancelled,
     };
 
-    let mut inner = manager.lock().await;
-    // Enforce max 10 concurrent processes (bounded collection rule).
-    if inner.processes.len() >= 10 {
-        return Err("Maximum concurrent processes (10) reached".into());
-    }
     inner.processes.insert(id, record);
 
     Ok(id)
@@ -361,5 +363,143 @@ mod tests {
 
         // Give the reader task time to observe the flag and call on_exit.
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    #[tokio::test]
+    async fn completed_processes_are_removed_from_tracking() {
+        let manager = ProcessManager::new();
+        let exited = Arc::new(std::sync::atomic::AtomicU32::new(0));
+
+        for _ in 0..10 {
+            let exited_clone = exited.clone();
+            spawn(
+                &manager.0,
+                "echo",
+                &["done"],
+                std::env::temp_dir(),
+                vec![],
+                SpawnOptions {
+                    on_line: Box::new(|_| {}),
+                    on_exit: Box::new(move |_, _| {
+                        exited_clone.fetch_add(1, Ordering::SeqCst);
+                    }),
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        for _ in 0..20 {
+            if exited.load(Ordering::SeqCst) == 10 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        assert_eq!(exited.load(Ordering::SeqCst), 10);
+        assert_eq!(manager.0.lock().await.processes.len(), 0);
+
+        let id = spawn(
+            &manager.0,
+            "echo",
+            &["after cleanup"],
+            std::env::temp_dir(),
+            vec![],
+            SpawnOptions {
+                on_line: Box::new(|_| {}),
+                on_exit: Box::new(|_, _| {}),
+            },
+        )
+        .await
+        .unwrap();
+        cancel(&manager.0, id).await;
+    }
+
+    #[tokio::test]
+    async fn capacity_is_checked_before_spawning_child() {
+        let manager = ProcessManager::new();
+        {
+            let mut inner = manager.0.lock().await;
+            for id in 1..=10 {
+                inner.processes.insert(
+                    id,
+                    ProcessRecord {
+                        os_pid: None,
+                        _reader_task: tokio::spawn(async {}),
+                        cancelled: Arc::new(AtomicBool::new(false)),
+                    },
+                );
+            }
+        }
+
+        let err = spawn(
+            &manager.0,
+            "definitely-not-a-real-keynobi-command",
+            &[],
+            std::env::temp_dir(),
+            vec![],
+            SpawnOptions {
+                on_line: Box::new(|_| {}),
+                on_exit: Box::new(|_, _| {}),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(err, "Maximum concurrent processes (10) reached");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_spawns_cannot_exceed_capacity() {
+        let manager = ProcessManager::new();
+        {
+            let mut inner = manager.0.lock().await;
+            for id in 100_000..100_009 {
+                inner.processes.insert(
+                    id,
+                    ProcessRecord {
+                        os_pid: None,
+                        _reader_task: tokio::spawn(async {}),
+                        cancelled: Arc::new(AtomicBool::new(false)),
+                    },
+                );
+            }
+        }
+
+        let mut tasks = tokio::task::JoinSet::new();
+        for _ in 0..50 {
+            let manager = manager.clone();
+            tasks.spawn(async move {
+                spawn(
+                    &manager.0,
+                    "sleep",
+                    &["2"],
+                    std::env::temp_dir(),
+                    vec![],
+                    SpawnOptions {
+                        on_line: Box::new(|_| {}),
+                        on_exit: Box::new(|_, _| {}),
+                    },
+                )
+                .await
+            });
+        }
+
+        let mut spawned = Vec::new();
+        while let Some(result) = tasks.join_next().await {
+            if let Ok(Ok(id)) = result {
+                spawned.push(id);
+            }
+        }
+
+        assert_eq!(spawned.len(), 1, "only one slot should be available");
+        assert!(
+            manager.0.lock().await.processes.len() <= 10,
+            "tracked processes must remain capped"
+        );
+
+        for id in spawned {
+            cancel(&manager.0, id).await;
+        }
     }
 }

--- a/src-tauri/src/services/process_manager.rs
+++ b/src-tauri/src/services/process_manager.rs
@@ -202,8 +202,8 @@ pub async fn spawn(
             } else {
                 termination
             };
-            on_exit(id, final_termination);
             manager_for_cleanup.lock().await.processes.remove(&id);
+            on_exit(id, final_termination);
         })
     };
 
@@ -413,6 +413,93 @@ mod tests {
         .await
         .unwrap();
         cancel(&manager.0, id).await;
+    }
+
+    #[tokio::test]
+    async fn completed_process_is_removed_before_on_exit_callback() {
+        let manager = ProcessManager::new();
+        {
+            let mut inner = manager.0.lock().await;
+            for id in 100_000..100_009 {
+                inner.processes.insert(
+                    id,
+                    ProcessRecord {
+                        os_pid: None,
+                        _reader_task: tokio::spawn(async {}),
+                        cancelled: Arc::new(AtomicBool::new(false)),
+                    },
+                );
+            }
+        }
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let tx = std::sync::Mutex::new(Some(tx));
+        let manager_for_callback = manager.clone();
+        spawn(
+            &manager.0,
+            "echo",
+            &["done"],
+            std::env::temp_dir(),
+            vec![],
+            SpawnOptions {
+                on_line: Box::new(|_| {}),
+                on_exit: Box::new(move |_, _| {
+                    let len = manager_for_callback
+                        .0
+                        .try_lock()
+                        .map(|inner| inner.processes.len())
+                        .unwrap_or(usize::MAX);
+                    if let Some(tx) = tx.lock().unwrap().take() {
+                        let _ = tx.send(len);
+                    }
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+        let len_during_callback = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            len_during_callback, 9,
+            "completed process should be removed before on_exit runs"
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_process_is_removed_even_if_on_exit_panics() {
+        let manager = ProcessManager::new();
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+
+        spawn(
+            &manager.0,
+            "echo",
+            &["done"],
+            std::env::temp_dir(),
+            vec![],
+            SpawnOptions {
+                on_line: Box::new(|_| {}),
+                on_exit: Box::new(|_, _| {
+                    panic!("on_exit panic should not leak process record");
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+        for _ in 0..20 {
+            if manager.0.lock().await.processes.is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        std::panic::set_hook(previous_hook);
+
+        assert_eq!(manager.0.lock().await.processes.len(), 0);
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/settings_manager.rs
+++ b/src-tauri/src/services/settings_manager.rs
@@ -1,5 +1,6 @@
 use crate::models::settings::AppSettings;
 use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex as StdMutex};
 
 const KNOWN_SETTINGS_FIELDS: &[&str] = &[
     "appearance",
@@ -16,6 +17,8 @@ const KNOWN_SETTINGS_FIELDS: &[&str] = &[
     "recentProjects",
     "lastActiveProject",
 ];
+
+static SETTINGS_MUTATION_LOCK: LazyLock<StdMutex<()>> = LazyLock::new(|| StdMutex::new(()));
 
 /// Log a warning for each top-level key in the JSON that isn't a known settings field.
 /// This catches typos early (e.g. "fontSizee" silently ignored by serde(default)).
@@ -87,6 +90,25 @@ pub fn load_settings() -> (AppSettings, bool) {
 /// Save settings to disk atomically (temp file + rename).
 pub fn save_settings(settings: &AppSettings) -> Result<(), String> {
     let dir = settings_dir();
+    let path = settings_file();
+    let _guard = SETTINGS_MUTATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    save_settings_to_path(&path, settings, Some(&dir))
+}
+
+fn save_settings_to_path(
+    path: &std::path::Path,
+    settings: &AppSettings,
+    dir_override: Option<&std::path::Path>,
+) -> Result<(), String> {
+    let dir = match dir_override {
+        Some(dir) => dir.to_path_buf(),
+        None => path
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from(".")),
+    };
     std::fs::create_dir_all(&dir)
         .map_err(|e| format!("Failed to create settings directory: {e}"))?;
 
@@ -96,13 +118,45 @@ pub fn save_settings(settings: &AppSettings) -> Result<(), String> {
     let json = serde_json::to_string_pretty(&normalized)
         .map_err(|e| format!("Failed to serialize settings: {e}"))?;
 
-    let path = settings_file();
     let tmp = path.with_extension("json.tmp");
 
     std::fs::write(&tmp, &json).map_err(|e| format!("Failed to write settings: {e}"))?;
-    std::fs::rename(&tmp, &path).map_err(|e| format!("Failed to save settings: {e}"))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("Failed to save settings: {e}"))?;
 
     Ok(())
+}
+
+pub fn mutate_settings_at_path(
+    settings_path: &std::path::Path,
+    mutate: impl FnOnce(&mut AppSettings),
+) -> Result<(), String> {
+    mutate_settings_at_path_with_result(settings_path, |settings| {
+        mutate(settings);
+        Ok(())
+    })
+}
+
+pub fn mutate_settings_at_path_with_result<R>(
+    settings_path: &std::path::Path,
+    mutate: impl FnOnce(&mut AppSettings) -> Result<R, String>,
+) -> Result<R, String> {
+    let _guard = SETTINGS_MUTATION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let (mut settings, _) = load_settings_from_path(settings_path);
+    let result = mutate(&mut settings)?;
+    save_settings_to_path(settings_path, &settings, None)?;
+    Ok(result)
+}
+
+pub fn mutate_settings(mutate: impl FnOnce(&mut AppSettings)) -> Result<(), String> {
+    mutate_settings_at_path(&settings_file(), mutate)
+}
+
+pub fn mutate_settings_with_result<R>(
+    mutate: impl FnOnce(&mut AppSettings) -> Result<R, String>,
+) -> Result<R, String> {
+    mutate_settings_at_path_with_result(&settings_file(), mutate)
 }
 
 /// Read `last_build_variant` for the given project path from a specific settings file.
@@ -127,19 +181,15 @@ pub fn set_active_variant_for_project_path(
     project_path: &str,
     variant: &str,
 ) -> Result<(), String> {
-    let (mut settings, _) = load_settings_from_path(settings_path);
-    if let Some(entry) = settings
-        .recent_projects
-        .iter_mut()
-        .find(|e| e.path == project_path || e.gradle_root.as_deref() == Some(project_path))
-    {
-        entry.last_build_variant = Some(variant.to_string());
-        let json = serde_json::to_string_pretty(&settings)
-            .map_err(|e| format!("Failed to serialize settings: {e}"))?;
-        std::fs::write(settings_path, json)
-            .map_err(|e| format!("Failed to write settings: {e}"))?;
-    }
-    Ok(())
+    mutate_settings_at_path(settings_path, |settings| {
+        if let Some(entry) = settings
+            .recent_projects
+            .iter_mut()
+            .find(|e| e.path == project_path || e.gradle_root.as_deref() == Some(project_path))
+        {
+            entry.last_build_variant = Some(variant.to_string());
+        }
+    })
 }
 
 /// Production wrapper: get active variant from the default settings file.
@@ -511,5 +561,61 @@ mod variant_tests {
         write_settings(&settings_path, "{}");
         let result = set_active_variant_for_project_path(&settings_path, "/proj/unknown", "debug");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn settings_mutations_are_serialized() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir().unwrap();
+        let settings_path = dir.path().join("settings.json");
+        write_settings(&settings_path, "{}");
+
+        let first_path = settings_path.clone();
+        let second_path = settings_path.clone();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let (second_entered_tx, second_entered_rx) = mpsc::channel();
+
+        let first = std::thread::spawn(move || {
+            mutate_settings_at_path(&first_path, |settings| {
+                settings.onboarding_completed = true;
+                entered_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            })
+            .unwrap();
+        });
+
+        entered_rx.recv().unwrap();
+
+        let second = std::thread::spawn(move || {
+            mutate_settings_at_path(&second_path, |settings| {
+                settings.last_active_project = Some("/proj/second".to_string());
+                second_entered_tx.send(()).unwrap();
+            })
+            .unwrap();
+        });
+
+        assert!(
+            second_entered_rx
+                .recv_timeout(Duration::from_millis(50))
+                .is_err(),
+            "second mutation must wait for the first mutation to finish"
+        );
+
+        release_tx.send(()).unwrap();
+        second_entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        first.join().unwrap();
+        second.join().unwrap();
+
+        let (settings, _) = load_settings_from_path(&settings_path);
+        assert!(settings.onboarding_completed);
+        assert_eq!(
+            settings.last_active_project.as_deref(),
+            Some("/proj/second")
+        );
     }
 }

--- a/src-tauri/src/utils/path.rs
+++ b/src-tauri/src/utils/path.rs
@@ -55,6 +55,43 @@ pub fn validate_within_root(root: &Path, untrusted: &str) -> Result<PathBuf, App
     Ok(canonical_file)
 }
 
+/// Validate that an APK path resolves inside `{root}/app/build/outputs`.
+///
+/// Unlike [`validate_within_root`], this accepts absolute paths because APK
+/// paths returned by build discovery are absolute. Canonicalization still
+/// enforces the project/build-output boundary and catches symlink escapes.
+pub fn validate_apk_within_build_outputs(
+    root: &Path,
+    untrusted: impl AsRef<Path>,
+) -> Result<PathBuf, AppError> {
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|e| AppError::io(root.display(), e))?;
+    let build_outputs = canonical_root.join("app").join("build").join("outputs");
+    let canonical_outputs = build_outputs
+        .canonicalize()
+        .map_err(|_| AppError::NotFound("Build outputs directory not found".to_string()))?;
+
+    let untrusted = untrusted.as_ref();
+    let canonical_apk = untrusted
+        .canonicalize()
+        .map_err(|_| AppError::NotFound(format!("APK path not found: {}", untrusted.display())))?;
+
+    if !canonical_apk.starts_with(&canonical_outputs) {
+        return Err(AppError::PermissionDenied(
+            "APK path must be within app/build/outputs".to_string(),
+        ));
+    }
+
+    if canonical_apk.extension().and_then(|e| e.to_str()) != Some("apk") {
+        return Err(AppError::InvalidInput(
+            "Path must point to a .apk file".to_string(),
+        ));
+    }
+
+    Ok(canonical_apk)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -98,5 +135,59 @@ mod tests {
         std::fs::write(tmp.path().join("src/main/Foo.kt"), b"// test").unwrap();
         let result = validate_within_root(tmp.path(), "src/main/Foo.kt");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn apk_validation_accepts_apk_inside_build_outputs() {
+        let tmp = TempDir::new().unwrap();
+        let apk = tmp.path().join("app/build/outputs/apk/debug/app-debug.apk");
+        std::fs::create_dir_all(apk.parent().unwrap()).unwrap();
+        std::fs::write(&apk, b"apk").unwrap();
+
+        let result = validate_apk_within_build_outputs(tmp.path(), &apk).unwrap();
+
+        assert_eq!(result, apk.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn apk_validation_rejects_path_outside_build_outputs() {
+        let tmp = TempDir::new().unwrap();
+        let apk = tmp.path().join("outside.apk");
+        std::fs::write(&apk, b"apk").unwrap();
+        std::fs::create_dir_all(tmp.path().join("app/build/outputs")).unwrap();
+
+        let result = validate_apk_within_build_outputs(tmp.path(), &apk);
+
+        assert!(matches!(result, Err(AppError::PermissionDenied(_))));
+    }
+
+    #[test]
+    fn apk_validation_rejects_non_apk_extension() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("app/build/outputs/apk/debug/app-debug.txt");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, b"not apk").unwrap();
+
+        let result = validate_apk_within_build_outputs(tmp.path(), &file);
+
+        assert!(matches!(result, Err(AppError::InvalidInput(_))));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apk_validation_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let outside_dir = TempDir::new().unwrap();
+        let outside_apk = outside_dir.path().join("outside.apk");
+        std::fs::write(&outside_apk, b"apk").unwrap();
+        let link = tmp.path().join("app/build/outputs/apk/debug/link.apk");
+        std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+        symlink(&outside_apk, &link).unwrap();
+
+        let result = validate_apk_within_build_outputs(tmp.path(), &link);
+
+        assert!(matches!(result, Err(AppError::PermissionDenied(_))));
     }
 }

--- a/src-tauri/tests/ipc/tauri_commands.rs
+++ b/src-tauri/tests/ipc/tauri_commands.rs
@@ -60,8 +60,8 @@ fn request(cmd: &str, body: Value) -> InvokeRequest {
         } else {
             "tauri://localhost"
         }
-            .parse()
-            .expect("valid Tauri test URL"),
+        .parse()
+        .expect("valid Tauri test URL"),
         body: InvokeBody::Json(body),
         headers: Default::default(),
         invoke_key: INVOKE_KEY.to_string(),

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -23,9 +23,7 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
 
     await cancelBuild();
 
-    const finalizeCalls = mockInvoke.mock.calls.filter(
-      ([cmd]) => cmd === "finalize_build"
-    );
+    const finalizeCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "finalize_build");
     expect(finalizeCalls).toHaveLength(0);
   });
 
@@ -40,27 +38,22 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
 
     await cancelBuild();
 
-    const finalizeCalls = mockInvoke.mock.calls.filter(
-      ([cmd]) => cmd === "finalize_build"
-    );
+    const finalizeCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "finalize_build");
     expect(finalizeCalls).toHaveLength(0);
   });
 
-  it("calls cancel_build and finalize_build when a build is actually running", async () => {
+  it("calls cancel_build without frontend finalization when a build is actually running", async () => {
     startBuild("assembleDebug");
     expect(buildState.phase).toBe("running");
 
-    // cancelBuild will try to cancel and finalize — resolve all IPC calls.
+    // Rust records the final build result from process exit; the frontend only
+    // requests cancellation and updates local state immediately.
     await cancelBuild();
 
     const cancelCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "cancel_build");
     const finalizeCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "finalize_build");
 
     expect(cancelCalls).toHaveLength(1);
-    expect(finalizeCalls).toHaveLength(1);
-
-    // The finalize call must carry the correct task name (not "unknown").
-    const [, finalizeArgs] = finalizeCalls[0] as [string, Record<string, unknown>];
-    expect(finalizeArgs?.task).toBe("assembleDebug");
+    expect(finalizeCalls).toHaveLength(0);
   });
 });

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -1,7 +1,6 @@
 import {
   runGradleTask,
   cancelBuild as cancelBuildApi,
-  finalizeBuild,
   findApkPath,
   getPackageNameFromApk,
   installApkOnDevice,
@@ -52,8 +51,13 @@ export async function initBuildService(): Promise<void> {
       });
     }
     // Resolve the pending build promise if there is one.
-    // History reload happens AFTER finalizeBuild in runBuild/cancelBuild so the
-    // new record is already persisted when we fetch.
+    // Rust records history before emitting build:complete, so this fetch sees
+    // the completed record without a frontend finalize step.
+    getBuildHistory()
+      .then(setBuildHistory)
+      .catch((err) => {
+        console.error("[build] Failed to reload build history:", err);
+      });
     _resolveBuildComplete?.({ success: e.success, durationMs: e.durationMs });
     _resolveBuildComplete = null;
   });
@@ -97,9 +101,6 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
 
   logBuildHeader(effectiveTask);
 
-  const startedAt = new Date().toISOString();
-  const accumulatedErrors: BuildError[] = [];
-
   // Create a promise that resolves when the build:complete event fires.
   // A 5-minute timeout prevents the deploy from hanging forever if
   // something goes wrong in the Rust on_exit callback.
@@ -119,16 +120,6 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
   try {
     await runGradleTask(effectiveTask, (line: BuildLine) => {
       addBuildLine(line);
-
-      if (line.kind === "error" || line.kind === "warning") {
-        accumulatedErrors.push({
-          message: line.content,
-          file: line.file ?? null,
-          line: line.line ?? null,
-          col: line.col ?? null,
-          severity: line.kind === "error" ? "error" : "warning",
-        });
-      }
     });
   } catch (e) {
     // Process-level spawn failure (e.g. gradlew not found).
@@ -146,9 +137,8 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
   }
 
   // runGradleTask resolves right after spawn; wait for the actual completion event.
-  let result: { success: boolean; durationMs: number };
   try {
-    result = await buildComplete;
+    await buildComplete;
   } catch (e) {
     // Timeout or unexpected rejection.
     const msg = formatError(e);
@@ -163,21 +153,8 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
     throw e;
   }
 
-  // cancelBuild() already called finalizeBuild — don't duplicate.
+  // Rust already recorded the build result before emitting build:complete.
   if (buildState.phase === "cancelled") return;
-
-  // Persist finalized result + history to the backend, then refresh the
-  // history store so the new record is visible in the side panel.
-  await finalizeBuild({
-    success: result.success,
-    durationMs: result.durationMs,
-    errors: accumulatedErrors,
-    task: effectiveTask,
-    startedAt,
-    projectRoot: projectState.projectRoot ?? null,
-  }).catch((err) => {
-    console.error("[build] Failed to finalize build:", err);
-  });
 
   getBuildHistory()
     .then(setBuildHistory)
@@ -290,32 +267,8 @@ export async function cancelBuild(): Promise<void> {
   // Flush any buffered log lines before finalising state.
   flushPendingLines();
 
-  const task = buildState.currentTask ?? "unknown";
-  const startedAtMs = buildState.startedAt ?? Date.now();
-  const startedAt = new Date(startedAtMs).toISOString();
-  const errors = buildState.errors.slice(); // snapshot before state is mutated
-  const durationMs = Date.now() - startedAtMs;
-
   cancelBuildState();
   await cancelBuildApi();
-
-  // Persist the cancelled build to history so it appears in the side panel.
-  await finalizeBuild({
-    success: false,
-    durationMs,
-    errors,
-    task,
-    startedAt,
-    projectRoot: projectState.projectRoot ?? null,
-  }).catch((err) => {
-    console.error("[build] Failed to finalize cancelled build:", err);
-  });
-
-  getBuildHistory()
-    .then(setBuildHistory)
-    .catch((err) => {
-      console.error("[build] Failed to reload build history after cancel:", err);
-    });
 
   // Unblock runBuild immediately so it doesn't hang until timeout.
   resolve?.({ success: false, durationMs: 0 });

--- a/src/stores/device.store.test.ts
+++ b/src/stores/device.store.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { waitFor } from "@solidjs/testing-library";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import {
@@ -48,6 +49,14 @@ const mockAvds: AvdInfo[] = [
 
 const mockInvoke = vi.mocked(invoke);
 const mockListen = vi.mocked(listen);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 describe("device.store", () => {
   beforeEach(() => {
@@ -124,6 +133,23 @@ describe("device.store", () => {
     expect(mockListen).toHaveBeenCalledTimes(1);
 
     resetDeviceState();
+    expect(unlisten).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetDeviceState disposes a device list listener that resolves after reset", async () => {
+    const unlisten = vi.fn();
+    const listener = deferred<() => void>();
+    mockListen.mockReturnValueOnce(listener.promise);
+
+    const init = initDevices();
+    await waitFor(() => expect(mockListen).toHaveBeenCalledTimes(1));
+
+    resetDeviceState();
+    expect(unlisten).not.toHaveBeenCalled();
+
+    listener.resolve(unlisten);
+    await init;
+
     expect(unlisten).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/stores/device.store.test.ts
+++ b/src/stores/device.store.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import {
   deviceState,
   setDevices,
@@ -8,6 +10,7 @@ import {
   onlineDevices,
   selectedDevice,
   resetDeviceState,
+  initDevices,
 } from "@/stores/device.store";
 import type { Device, AvdInfo } from "@/bindings";
 
@@ -43,9 +46,20 @@ const mockAvds: AvdInfo[] = [
   },
 ];
 
+const mockInvoke = vi.mocked(invoke);
+const mockListen = vi.mocked(listen);
+
 describe("device.store", () => {
   beforeEach(() => {
     resetDeviceState();
+    vi.clearAllMocks();
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === "refresh_devices") return Promise.resolve([]);
+      if (cmd === "list_avd_devices") return Promise.resolve([]);
+      if (cmd === "start_device_polling") return Promise.resolve(undefined);
+      if (cmd === "select_device") return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
   });
 
   it("starts with empty device list", () => {
@@ -100,6 +114,17 @@ describe("device.store", () => {
     expect(deviceState.devices).toHaveLength(0);
     expect(deviceState.avds).toHaveLength(0);
     expect(deviceState.selectedSerial).toBeNull();
+  });
+
+  it("resetDeviceState disposes the device list listener", async () => {
+    const unlisten = vi.fn();
+    mockListen.mockResolvedValueOnce(unlisten);
+
+    await initDevices();
+    expect(mockListen).toHaveBeenCalledTimes(1);
+
+    resetDeviceState();
+    expect(unlisten).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/stores/device.store.test.ts
+++ b/src/stores/device.store.test.ts
@@ -152,6 +152,30 @@ describe("device.store", () => {
 
     expect(unlisten).toHaveBeenCalledTimes(1);
   });
+
+  it("resetDeviceState prevents an in-flight initDevices from repopulating devices", async () => {
+    const refresh = deferred<Device[]>();
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === "refresh_devices") return refresh.promise;
+      if (cmd === "list_avd_devices") return Promise.resolve(mockAvds);
+      if (cmd === "start_device_polling") return Promise.resolve(undefined);
+      if (cmd === "select_device") return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+
+    const init = initDevices();
+    await waitFor(() => expect(mockInvoke).toHaveBeenCalledWith("refresh_devices"));
+
+    resetDeviceState();
+    refresh.resolve(mockDevices);
+    await init;
+
+    expect(deviceState.devices).toHaveLength(0);
+    expect(deviceState.avds).toHaveLength(0);
+    expect(deviceState.polling).toBe(false);
+    expect(mockInvoke).not.toHaveBeenCalledWith("start_device_polling");
+    expect(mockListen).not.toHaveBeenCalled();
+  });
 });
 
 describe("device store error state transitions", () => {

--- a/src/stores/device.store.ts
+++ b/src/stores/device.store.ts
@@ -137,6 +137,8 @@ export function onDeviceChange(cb: (serial: string) => void): void {
   _onDeviceChange = cb;
 }
 
+let deviceListUnlisten: (() => void) | null = null;
+
 export function setLaunchingAvd(avdName: string | null): void {
   setDeviceState("launchingAvd", avdName);
 }
@@ -157,13 +159,15 @@ export async function initDevices(): Promise<void> {
       showToast(`Device polling failed: ${err}`, "error");
     });
     // eslint-disable-next-line solid/reactivity
-    await listenDeviceListChanged((newDevices) => {
+    deviceListUnlisten = await listenDeviceListChanged((newDevices) => {
       setDevices(newDevices);
     });
   }
 }
 
 export function resetDeviceState(): void {
+  deviceListUnlisten?.();
+  deviceListUnlisten = null;
   setDeviceState({
     devices: [],
     avds: [],

--- a/src/stores/device.store.ts
+++ b/src/stores/device.store.ts
@@ -138,6 +138,7 @@ export function onDeviceChange(cb: (serial: string) => void): void {
 }
 
 let deviceListUnlisten: (() => void) | null = null;
+let deviceListListenerGeneration = 0;
 
 export function setLaunchingAvd(avdName: string | null): void {
   setDeviceState("launchingAvd", avdName);
@@ -154,18 +155,25 @@ export async function initDevices(): Promise<void> {
   // Start polling and register event listener.
   if (!deviceState.polling) {
     setDeviceState("polling", true);
+    const listenerGeneration = deviceListListenerGeneration;
     await startDevicePolling().catch((err) => {
       console.error("[device] Failed to start device polling:", err);
       showToast(`Device polling failed: ${err}`, "error");
     });
     // eslint-disable-next-line solid/reactivity
-    deviceListUnlisten = await listenDeviceListChanged((newDevices) => {
+    const unlisten = await listenDeviceListChanged((newDevices) => {
       setDevices(newDevices);
     });
+    if (listenerGeneration !== deviceListListenerGeneration || !deviceState.polling) {
+      unlisten();
+      return;
+    }
+    deviceListUnlisten = unlisten;
   }
 }
 
 export function resetDeviceState(): void {
+  deviceListListenerGeneration += 1;
   deviceListUnlisten?.();
   deviceListUnlisten = null;
   setDeviceState({

--- a/src/stores/device.store.ts
+++ b/src/stores/device.store.ts
@@ -145,17 +145,19 @@ export function setLaunchingAvd(avdName: string | null): void {
 }
 
 export async function initDevices(): Promise<void> {
+  const initGeneration = deviceListListenerGeneration;
   const [devices, avds] = await Promise.all([
     refreshDevices().catch(() => [] as Device[]),
     listAvdDevices().catch(() => [] as AvdInfo[]),
   ]);
+  if (initGeneration !== deviceListListenerGeneration) return;
+
   setDevices(devices);
   setAvds(avds);
 
   // Start polling and register event listener.
   if (!deviceState.polling) {
     setDeviceState("polling", true);
-    const listenerGeneration = deviceListListenerGeneration;
     await startDevicePolling().catch((err) => {
       console.error("[device] Failed to start device polling:", err);
       showToast(`Device polling failed: ${err}`, "error");
@@ -164,7 +166,7 @@ export async function initDevices(): Promise<void> {
     const unlisten = await listenDeviceListChanged((newDevices) => {
       setDevices(newDevices);
     });
-    if (listenerGeneration !== deviceListListenerGeneration || !deviceState.polling) {
+    if (initGeneration !== deviceListListenerGeneration || !deviceState.polling) {
       unlisten();
       return;
     }

--- a/src/stores/variant.loadVariants.test.ts
+++ b/src/stores/variant.loadVariants.test.ts
@@ -10,7 +10,12 @@ vi.mock("@/lib/tauri-api", () => ({
   setActiveVariant: vi.fn(),
 }));
 
-import { loadVariants, resetVariantState, clearVariantCache, variantState } from "@/stores/variant.store";
+import {
+  loadVariants,
+  resetVariantState,
+  clearVariantCache,
+  variantState,
+} from "@/stores/variant.store";
 import { setProject, setProjectState } from "@/stores/project.store";
 
 const sampleVariant: BuildVariant = {
@@ -26,6 +31,32 @@ const sampleList: VariantList = {
   active: "debug",
   defaultVariant: null,
 };
+
+function variantNamed(name: string): BuildVariant {
+  return {
+    name,
+    buildType: "debug",
+    flavors: [],
+    assembleTask: `assemble${name.charAt(0).toUpperCase()}${name.slice(1)}`,
+    installTask: `install${name.charAt(0).toUpperCase()}${name.slice(1)}`,
+  };
+}
+
+function listFor(name: string): VariantList {
+  return {
+    variants: [variantNamed(name)],
+    active: name,
+    defaultVariant: null,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 function resetProjectState() {
   setProjectState({ projectRoot: null, gradleRoot: null, projectName: null, loading: false });
@@ -43,7 +74,7 @@ describe("loadVariants coalescing", () => {
       () =>
         new Promise<VariantList>((resolve) => {
           setTimeout(() => resolve(sampleList), 15);
-        }),
+        })
     );
   });
 
@@ -135,6 +166,37 @@ describe("loadVariants cache", () => {
     expect(variantState.variants[0].name).toBe("debug");
     expect(variantState.fromGradle).toBe(true);
     expect(variantState.gradleLoading).toBe(false);
+  });
+
+  it("does not apply stale variants when project changes during an in-flight load", async () => {
+    const projectA = listFor("projectADebug");
+    const projectB = listFor("projectBDebug");
+    const aPreview = deferred<VariantList>();
+    const aGradle = deferred<VariantList>();
+    const emptyList: VariantList = { variants: [], active: null, defaultVariant: null };
+
+    mockPreview
+      .mockImplementationOnce(() => aPreview.promise)
+      .mockImplementationOnce(() => Promise.resolve(emptyList));
+    mockGradle
+      .mockImplementationOnce(() => aGradle.promise)
+      .mockImplementationOnce(() => Promise.resolve(projectB));
+
+    setProject("/projects/project-a", "project-a");
+    const loadA = loadVariants();
+    aPreview.resolve(emptyList);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockGradle).toHaveBeenCalledTimes(1);
+
+    setProject("/projects/project-b", "project-b");
+    resetVariantState();
+    const loadB = loadVariants();
+
+    aGradle.resolve(projectA);
+    await Promise.all([loadA, loadB]);
+
+    expect(mockGradle).toHaveBeenCalledTimes(2);
+    expect(variantState.activeVariant).toBe("projectBDebug");
   });
 });
 

--- a/src/stores/variant.store.ts
+++ b/src/stores/variant.store.ts
@@ -85,8 +85,8 @@ function resolveActive(list: VariantList, currentActive: string | null): string 
 
 // ── Actions ───────────────────────────────────────────────────────────────────
 
-/** Coalesces concurrent callers (e.g. project restore + status bar mount) onto one Gradle run. */
-let loadVariantsPending: Promise<void> | null = null;
+/** Coalesces concurrent callers for the same project root onto one Gradle run. */
+const loadVariantsPending = new Map<string, Promise<void>>();
 
 /**
  * Load variants using a two-phase approach:
@@ -104,30 +104,40 @@ let loadVariantsPending: Promise<void> | null = null;
  * Pass `{ force: true }` to bypass the cache (e.g. the Refresh button).
  */
 export function loadVariants(opts?: { force?: boolean }): Promise<void> {
+  const root = projectState.projectRoot;
   if (opts?.force) {
-    const root = projectState.projectRoot;
     if (root !== null) variantCache.delete(root);
   }
-  if (!loadVariantsPending) {
-    loadVariantsPending = runLoadVariants().finally(() => {
-      loadVariantsPending = null;
-    });
-  }
-  return loadVariantsPending;
+  const pendingKey = root ?? "__no_project__";
+  const pending = loadVariantsPending.get(pendingKey);
+  if (pending) return pending;
+
+  const next = runLoadVariants(root).finally(() => {
+    loadVariantsPending.delete(pendingKey);
+  });
+  loadVariantsPending.set(pendingKey, next);
+  return next;
 }
 
-async function runLoadVariants(): Promise<void> {
-  setVariantState({
-    loading: true,
-    gradleLoading: true,
-    error: null,
-    gradleError: null,
-    fromGradle: false,
-  });
+function isCurrentProject(root: string | null): boolean {
+  return projectState.projectRoot === root;
+}
+
+async function runLoadVariants(rootAtStart: string | null): Promise<void> {
+  if (isCurrentProject(rootAtStart)) {
+    setVariantState({
+      loading: true,
+      gradleLoading: true,
+      error: null,
+      gradleError: null,
+      fromGradle: false,
+    });
+  }
 
   // ── Phase 1: instant preview from static parse ─────────────────────────────
   try {
     const preview = await getVariantsPreview();
+    if (!isCurrentProject(rootAtStart)) return;
     if (preview.variants.length > 0) {
       setVariantState({
         variants: preview.variants,
@@ -139,14 +149,17 @@ async function runLoadVariants(): Promise<void> {
     }
   } catch {
     // Preview failure is non-fatal — Gradle query will still run.
-    setVariantState({ loading: false });
+    if (isCurrentProject(rootAtStart)) {
+      setVariantState({ loading: false });
+    }
   }
 
   // ── Phase 2: authoritative list from Gradle (or session cache) ───────────────
-  const cacheKey = projectState.projectRoot;
+  const cacheKey = rootAtStart;
   const cached = cacheKey !== null ? variantCache.get(cacheKey) : undefined;
 
   if (cached) {
+    if (!isCurrentProject(rootAtStart)) return;
     setVariantState({
       variants: cached.variants,
       activeVariant: resolveActive(
@@ -167,6 +180,7 @@ async function runLoadVariants(): Promise<void> {
 
   try {
     const full = await getVariantsFromGradle();
+    if (!isCurrentProject(rootAtStart)) return;
     if (cacheKey !== null) {
       variantCache.set(cacheKey, {
         variants: full.variants,
@@ -182,6 +196,7 @@ async function runLoadVariants(): Promise<void> {
       error: null,
     });
   } catch (e) {
+    if (!isCurrentProject(rootAtStart)) return;
     const msg = typeof e === "string" ? e : ((e as Error).message ?? String(e));
     setVariantState({
       gradleLoading: false,


### PR DESCRIPTION
## Summary

fix improviments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalize builds on process exit and auto-reload history. Improve process/logcat reliability, serialize settings writes, and harden APK/package validation while fixing race conditions in variants and devices.

- **Refactors**
  - Build: record results server-side via `finalize_completed_build` before emitting `build:complete`; frontend no longer calls `finalizeBuild`. Added safe `set_/take_active_process_id` and tests to avoid poisoned-mutex unwraps.
  - Paths: added `validate_apk_within_build_outputs` and used it in `install_apk_on_device` and `get_package_name_from_apk` (now requires `fs_state`) to ensure APKs live under `app/build/outputs` and have `.apk` extension.
  - Settings: introduced a global lock with `mutate_settings*` helpers to serialize writes; applied across project list mutations; atomic save maintained; added tests for serialization.
  - Logcat/Process manager: logcat adds a 5s startup acknowledgment and clear error propagation; MCP server waits and surfaces failures. Process manager enforces a 10‑process cap before spawning, removes completed processes from tracking before `on_exit`, and remains resilient if callbacks panic; added capacity/concurrency tests.

- **Bug Fixes**
  - Variants: coalesce loads per project root and drop stale results when the project changes mid‑load; added tests.
  - Devices: dispose the device‑list listener on reset (including late resolves); validate package and activity names; added tests.
  - Builds: removed frontend finalize calls; cancellation only invokes `cancel_build`, Rust records final state on process exit; history reloads after `build:complete`.
  - Concurrency/robustness: avoid unwraps on the build process mutex, ensure completed processes are cleaned up, and surface logcat start errors/timeouts while clearing streaming state.

<sup>Written for commit 9bf1cc72f73dc890f41ae66c7f51413da277ad3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thiagodmont/keynobi/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

