### PR TITLE
Fix/new improviments

### DIFF
--- a/src-tauri/src/commands/build.rs
+++ b/src-tauri/src/commands/build.rs
@@ -146,6 +146,24 @@ pub async fn run_gradle_task(
     let env = build_env_vars(&settings, &gradle_root);
     let started_at = Utc::now().to_rfc3339();
 
+    {
+        let mut bs = build_state.inner.lock().await;
+        if bs.starting
+            || bs.current_build.is_some()
+            || matches!(bs.status, BuildStatus::Running { .. })
+        {
+            return Err(AppError::InvalidInput(
+                "A Gradle build is already running".to_string(),
+            ));
+        }
+        bs.starting = true;
+        bs.status = BuildStatus::Running {
+            task: task.clone(),
+            started_at: started_at.clone(),
+        };
+        bs.current_errors.clear();
+    }
+
     // Use std::sync::Mutex (not tokio) for these accumulators — they are
     // accessed only from sync callbacks (on_line / on_exit) and must never
     // use blocking_lock on a tokio mutex inside an async task.
@@ -162,7 +180,7 @@ pub async fn run_gradle_task(
     // Clear the log for this run BEFORE spawning so no early lines can be clobbered.
     build_runner::clear_build_log(&build_state.build_log);
 
-    let id = process_manager::spawn(
+    let spawn_result = process_manager::spawn(
         &process_manager.0,
         gradlew.to_str().unwrap_or("./gradlew"),
         &args_refs,
@@ -254,25 +272,50 @@ pub async fn run_gradle_task(
             }),
         },
     )
-    .await
-    .map_err(AppError::ProcessFailed)?;
+    .await;
+
+    let id = match spawn_result {
+        Ok(id) => id,
+        Err(e) => {
+            let mut bs = build_state.inner.lock().await;
+            bs.starting = false;
+            bs.current_build = None;
+            bs.status = BuildStatus::Failed(BuildResult {
+                success: false,
+                duration_ms: 0,
+                error_count: 1,
+                warning_count: 0,
+            });
+            return Err(AppError::ProcessFailed(e));
+        }
+    };
 
     // Register immediately (sync, no `.await` before this) so cancel always has a ProcessId.
     build_state.set_active_process_id(Some(id));
 
     // Mark build as running in the managed state and clear the log for this run.
-    {
+    let cancel_after_spawn = {
         let mut bs = build_state.inner.lock().await;
         if matches!(bs.status, BuildStatus::Cancelled) {
             // User cancelled in the window after spawn but before this lock — Gradle may already be gone.
-            return Ok(id);
+            bs.starting = false;
+            true
+        } else {
+            bs.starting = false;
+            bs.status = BuildStatus::Running {
+                task: task.clone(),
+                started_at: started_at.clone(),
+            };
+            bs.current_build = Some(id);
+            bs.current_errors.clear();
+            false
         }
-        bs.status = BuildStatus::Running {
-            task: task.clone(),
-            started_at: started_at.clone(),
-        };
-        bs.current_build = Some(id);
-        bs.current_errors.clear();
+    };
+
+    if cancel_after_spawn {
+        let _ = build_state.take_active_process_id();
+        process_manager::cancel(&process_manager.0, id).await;
+        return Ok(id);
     }
 
     Ok(id)

--- a/src-tauri/src/commands/build.rs
+++ b/src-tauri/src/commands/build.rs
@@ -26,6 +26,19 @@ pub struct BuildCompleteEvent {
     pub task: String,
 }
 
+fn mark_build_spawn_failed(bs: &mut build_runner::BuildStateInner) {
+    bs.starting = false;
+    bs.current_build = None;
+    if !matches!(bs.status, BuildStatus::Cancelled) {
+        bs.status = BuildStatus::Failed(BuildResult {
+            success: false,
+            duration_ms: 0,
+            error_count: 1,
+            warning_count: 0,
+        });
+    }
+}
+
 // ── Validation helpers ─────────────────────────────────────────────────────────
 
 /// Validate a Gradle task name against an allowlist.
@@ -278,14 +291,7 @@ pub async fn run_gradle_task(
         Ok(id) => id,
         Err(e) => {
             let mut bs = build_state.inner.lock().await;
-            bs.starting = false;
-            bs.current_build = None;
-            bs.status = BuildStatus::Failed(BuildResult {
-                success: false,
-                duration_ms: 0,
-                error_count: 1,
-                warning_count: 0,
-            });
+            mark_build_spawn_failed(&mut bs);
             return Err(AppError::ProcessFailed(e));
         }
     };
@@ -509,6 +515,35 @@ mod tests {
         assert!(validate_gradle_task("assemble$(evil)").is_err());
         assert!(validate_gradle_task("assemble\necho pwned").is_err());
         assert!(validate_gradle_task(&"a".repeat(257)).is_err());
+    }
+
+    #[test]
+    fn spawn_failure_preserves_cancelled_status() {
+        let mut state = build_runner::BuildStateInner::new();
+        state.starting = true;
+        state.status = BuildStatus::Cancelled;
+
+        mark_build_spawn_failed(&mut state);
+
+        assert!(!state.starting);
+        assert!(state.current_build.is_none());
+        assert!(matches!(state.status, BuildStatus::Cancelled));
+    }
+
+    #[test]
+    fn spawn_failure_marks_non_cancelled_build_failed() {
+        let mut state = build_runner::BuildStateInner::new();
+        state.starting = true;
+        state.status = BuildStatus::Running {
+            task: "assembleDebug".to_string(),
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+
+        mark_build_spawn_failed(&mut state);
+
+        assert!(!state.starting);
+        assert!(state.current_build.is_none());
+        assert!(matches!(state.status, BuildStatus::Failed(_)));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/device.rs
+++ b/src-tauri/src/commands/device.rs
@@ -6,7 +6,8 @@ use crate::services::adb_manager::{
     create_avd, delete_avd, download_system_image, enrich_device_props, get_adb_path,
     get_avdmanager_path, get_emulator_path, get_sdkmanager_path, install_apk, launch_app,
     launch_emulator, list_available_system_images, list_avds, list_device_definitions,
-    list_devices, list_system_images, stop_app, stop_emulator, wipe_avd_data, DeviceState,
+    list_devices, list_system_images, stop_app, stop_emulator, validate_avd_name,
+    validate_device_profile_id, validate_system_image_id, wipe_avd_data, DeviceState,
 };
 use crate::services::settings_manager;
 use crate::FsState;
@@ -21,6 +22,14 @@ use tauri::{AppHandle, Emitter, State};
 #[serde(rename_all = "camelCase")]
 pub struct DeviceListChangedEvent {
     pub devices: Vec<Device>,
+}
+
+fn record_polled_devices(
+    state: &mut crate::services::adb_manager::DeviceStateInner,
+    devices: Vec<Device>,
+) -> DeviceListChangedEvent {
+    state.devices = devices.clone();
+    DeviceListChangedEvent { devices }
 }
 
 // ── Validation helpers ─────────────────────────────────────────────────────────
@@ -195,6 +204,8 @@ pub async fn launch_avd(
     app_handle: AppHandle,
     device_state: State<'_, DeviceState>,
 ) -> Result<String, String> {
+    validate_avd_name(&avd_name)?;
+
     let (settings, _) = settings_manager::load_settings();
     let adb = get_adb_path(&settings);
     let emulator = get_emulator_path(&settings);
@@ -269,10 +280,11 @@ pub async fn start_device_polling(
                     enrich_device_props(&adb, d).await;
                 }
                 last_serials = current_serials;
-                let _ = app.emit(
-                    "device:list_changed",
-                    DeviceListChangedEvent { devices: current },
-                );
+                let event = {
+                    let mut state = device_state_bg.lock().await;
+                    record_polled_devices(&mut state, current)
+                };
+                let _ = app.emit("device:list_changed", event);
             }
         }
     });
@@ -314,6 +326,12 @@ pub async fn create_avd_device(
     system_image: String,
     device: Option<String>,
 ) -> Result<Vec<AvdInfo>, String> {
+    validate_avd_name(&name)?;
+    validate_system_image_id(&system_image)?;
+    if let Some(device_id) = device.as_deref() {
+        validate_device_profile_id(device_id)?;
+    }
+
     let (settings, _) = settings_manager::load_settings();
     let avdmanager = get_avdmanager_path(&settings);
     create_avd(&avdmanager, &name, &system_image, device.as_deref()).await?;
@@ -323,6 +341,8 @@ pub async fn create_avd_device(
 /// Delete an existing AVD using avdmanager.
 #[tauri::command]
 pub async fn delete_avd_device(name: String) -> Result<Vec<AvdInfo>, String> {
+    validate_avd_name(&name)?;
+
     let (settings, _) = settings_manager::load_settings();
     let avdmanager = get_avdmanager_path(&settings);
     delete_avd(&avdmanager, &name).await?;
@@ -332,6 +352,8 @@ pub async fn delete_avd_device(name: String) -> Result<Vec<AvdInfo>, String> {
 /// Wipe an AVD's user data by relaunching it with -wipe-data.
 #[tauri::command]
 pub async fn wipe_avd_data_cmd(name: String) -> Result<(), String> {
+    validate_avd_name(&name)?;
+
     let (settings, _) = settings_manager::load_settings();
     let emulator = get_emulator_path(&settings);
     let adb = get_adb_path(&settings);
@@ -353,6 +375,8 @@ pub async fn download_system_image_cmd(
     sdk_id: String,
     on_progress: Channel<SdkDownloadProgress>,
 ) -> Result<(), String> {
+    validate_system_image_id(&sdk_id)?;
+
     let (settings, _) = settings_manager::load_settings();
     let sdkmanager = get_sdkmanager_path(&settings);
 
@@ -380,6 +404,8 @@ pub async fn download_system_image_cmd(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::device::{DeviceConnectionState, DeviceKind};
+    use crate::services::adb_manager::DeviceStateInner;
 
     #[test]
     fn valid_serials_pass() {
@@ -413,6 +439,31 @@ mod tests {
     #[test]
     fn serial_carriage_return_is_rejected() {
         assert!(validate_device_serial("emulator\r5554").is_err());
+    }
+
+    #[test]
+    fn record_polled_devices_updates_state_and_event_payload() {
+        let device = Device {
+            serial: "emulator-5554".to_string(),
+            name: "Pixel".to_string(),
+            model: None,
+            device_kind: DeviceKind::Emulator,
+            connection_state: DeviceConnectionState::Online,
+            api_level: Some(35),
+            android_version: Some("15".to_string()),
+        };
+        let mut state = DeviceStateInner {
+            devices: vec![],
+            selected_serial: None,
+            polling: true,
+        };
+
+        let event = record_polled_devices(&mut state, vec![device.clone()]);
+
+        assert_eq!(state.devices.len(), 1);
+        assert_eq!(state.devices[0].serial, "emulator-5554");
+        assert_eq!(event.devices.len(), 1);
+        assert_eq!(event.devices[0].serial, device.serial);
     }
 
     #[test]

--- a/src-tauri/src/commands/file_system.rs
+++ b/src-tauri/src/commands/file_system.rs
@@ -396,10 +396,10 @@ fn validate_version_name(value: &str) -> Result<(), String> {
     }
     if value
         .chars()
-        .any(|c| matches!(c, '"' | '\\' | '\n' | '\r') || c.is_control())
+        .any(|c| matches!(c, '"' | '\\' | '$' | '\n' | '\r') || c.is_control())
     {
         return Err(
-            "Version name cannot contain quotes, backslashes, line breaks, or control characters"
+            "Version name cannot contain quotes, backslashes, '$', line breaks, or control characters"
                 .to_string(),
         );
     }
@@ -506,6 +506,7 @@ mod tests {
         assert!(validate_version_name("").is_err());
         assert!(validate_version_name("1.2\"3").is_err());
         assert!(validate_version_name("1.2\\3").is_err());
+        assert!(validate_version_name("1.$0").is_err());
         assert!(validate_version_name("1.2\n3").is_err());
     }
 

--- a/src-tauri/src/commands/file_system.rs
+++ b/src-tauri/src/commands/file_system.rs
@@ -320,6 +320,9 @@ pub async fn save_project_app_info(
     version_code: i64,
     state: State<'_, FsState>,
 ) -> Result<(), String> {
+    validate_version_name(&version_name)?;
+    validate_version_code(version_code)?;
+
     let guard = state.0.lock().await;
     let root = guard
         .gradle_root
@@ -387,6 +390,29 @@ fn extract_version_code(content: &str) -> Option<i64> {
     caps.get(1)?.as_str().parse().ok()
 }
 
+fn validate_version_name(value: &str) -> Result<(), String> {
+    if value.trim().is_empty() {
+        return Err("Version name cannot be empty".to_string());
+    }
+    if value
+        .chars()
+        .any(|c| matches!(c, '"' | '\\' | '\n' | '\r') || c.is_control())
+    {
+        return Err(
+            "Version name cannot contain quotes, backslashes, line breaks, or control characters"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_version_code(value: i64) -> Result<(), String> {
+    if value < 0 {
+        return Err("Version code must be a non-negative integer".to_string());
+    }
+    Ok(())
+}
+
 fn replace_version_name(content: &str, new_value: &str) -> String {
     RE_VERSION_NAME
         .replace(content, |caps: &regex::Captures| {
@@ -450,6 +476,7 @@ pub async fn rename_project(id: String, new_name: String) -> Result<(), String> 
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -472,5 +499,38 @@ mod tests {
         let path = tmp.path();
         assert!(path.exists(), "tempdir must exist");
         assert!(path.is_dir(), "tempdir must be a directory");
+    }
+
+    #[test]
+    fn version_name_validation_rejects_gradle_string_breakers() {
+        assert!(validate_version_name("").is_err());
+        assert!(validate_version_name("1.2\"3").is_err());
+        assert!(validate_version_name("1.2\\3").is_err());
+        assert!(validate_version_name("1.2\n3").is_err());
+    }
+
+    #[test]
+    fn version_code_validation_rejects_negative_values() {
+        assert!(validate_version_code(-1).is_err());
+        assert!(validate_version_code(0).is_ok());
+        assert!(validate_version_code(42).is_ok());
+    }
+
+    #[test]
+    fn replace_version_info_preserves_gradle_syntax_for_valid_values() {
+        let content = r#"
+android {
+    defaultConfig {
+        versionName = "1.0"
+        versionCode = 1
+    }
+}
+"#;
+
+        let updated = replace_version_name(content, "2.0.1");
+        let updated = replace_version_code(&updated, 12);
+
+        assert!(updated.contains(r#"versionName = "2.0.1""#));
+        assert!(updated.contains("versionCode = 12"));
     }
 }

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -639,10 +639,7 @@ pub async fn launch_emulator(
 fn newly_online_emulator_serial(before: &[Device], after: &[Device]) -> Option<String> {
     let before_serials: std::collections::HashSet<&str> = before
         .iter()
-        .filter(|d| {
-            d.device_kind == DeviceKind::Emulator
-                && d.connection_state == DeviceConnectionState::Online
-        })
+        .filter(|d| d.device_kind == DeviceKind::Emulator)
         .map(|d| d.serial.as_str())
         .collect();
 
@@ -1420,6 +1417,32 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
         let after = before.clone();
 
         assert_eq!(newly_online_emulator_serial(&before, &after), None);
+    }
+
+    #[test]
+    fn newly_online_emulator_serial_ignores_existing_offline_emulators() {
+        let before = vec![test_device(
+            "emulator-5554",
+            DeviceKind::Emulator,
+            DeviceConnectionState::Offline,
+        )];
+        let after = vec![
+            test_device(
+                "emulator-5554",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+            test_device(
+                "emulator-5556",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+        ];
+
+        assert_eq!(
+            newly_online_emulator_serial(&before, &after),
+            Some("emulator-5556".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -9,6 +9,83 @@ use std::time::Duration;
 use tokio::process::Command;
 use tokio::sync::Mutex;
 
+// ── External tool argument validation ─────────────────────────────────────────
+
+/// Validate an Android Virtual Device name before passing it to emulator/avdmanager.
+pub fn validate_avd_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("AVD name must not be empty".to_string());
+    }
+    if name.len() > 128 {
+        return Err("AVD name is too long (max 128 characters)".to_string());
+    }
+    if name.starts_with('-') {
+        return Err("AVD name must not start with '-'".to_string());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | ' '))
+    {
+        return Err(
+            "AVD name may only contain letters, numbers, spaces, '_', '-', and '.'".to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Validate an avdmanager hardware profile id.
+pub fn validate_device_profile_id(device_id: &str) -> Result<(), String> {
+    if device_id.is_empty() {
+        return Err("Device profile id must not be empty".to_string());
+    }
+    if device_id.len() > 128 {
+        return Err("Device profile id is too long (max 128 characters)".to_string());
+    }
+    if device_id.starts_with('-') {
+        return Err("Device profile id must not start with '-'".to_string());
+    }
+    if !device_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+    {
+        return Err(
+            "Device profile id may only contain letters, numbers, '_', '-', and '.'".to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Validate a sdkmanager system image package id.
+pub fn validate_system_image_id(sdk_id: &str) -> Result<(), String> {
+    let parts: Vec<&str> = sdk_id.split(';').collect();
+    if parts.len() != 4 || parts[0] != "system-images" {
+        return Err(
+            "System image id must look like system-images;android-35;google_apis;x86_64"
+                .to_string(),
+        );
+    }
+    if !parts[1]
+        .strip_prefix("android-")
+        .is_some_and(|api| !api.is_empty() && api.chars().all(|c| c.is_ascii_digit()))
+    {
+        return Err("System image id must include an android API target".to_string());
+    }
+    for part in &parts[2..] {
+        if part.is_empty()
+            || part.starts_with('-')
+            || !part
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+        {
+            return Err(
+                "System image id components may only contain letters, numbers, '_', '-', and '.'"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
 // ── ADB path resolution ────────────────────────────────────────────────────────
 
 /// Resolve the `adb` binary path from settings or fall back to PATH.
@@ -535,6 +612,8 @@ pub async fn launch_emulator(
     adb: &Path,
     avd_name: &str,
 ) -> Result<String, String> {
+    let before = list_devices(adb).await;
+
     // Spawn detached — we don't wait for the emulator process to exit.
     tokio::process::Command::new(emulator_bin)
         .args([&format!("@{avd_name}"), "-no-boot-anim", "-gpu", "auto"])
@@ -548,16 +627,33 @@ pub async fn launch_emulator(
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_secs(2)).await;
         let devices = list_devices(adb).await;
-        if let Some(d) = devices.iter().find(|d| {
-            d.device_kind == DeviceKind::Emulator
-                && d.connection_state == DeviceConnectionState::Online
-        }) {
-            return Ok(d.serial.clone());
+        if let Some(serial) = newly_online_emulator_serial(&before, &devices) {
+            return Ok(serial);
         }
     }
     Err(format!(
         "Emulator '{avd_name}' did not come online within 60 seconds"
     ))
+}
+
+fn newly_online_emulator_serial(before: &[Device], after: &[Device]) -> Option<String> {
+    let before_serials: std::collections::HashSet<&str> = before
+        .iter()
+        .filter(|d| {
+            d.device_kind == DeviceKind::Emulator
+                && d.connection_state == DeviceConnectionState::Online
+        })
+        .map(|d| d.serial.as_str())
+        .collect();
+
+    after
+        .iter()
+        .find(|d| {
+            d.device_kind == DeviceKind::Emulator
+                && d.connection_state == DeviceConnectionState::Online
+                && !before_serials.contains(d.serial.as_str())
+        })
+        .map(|d| d.serial.clone())
 }
 
 /// Kill an emulator via `adb -s <serial> emu kill`.
@@ -1221,6 +1317,22 @@ pub async fn resolve_device_serial(
 mod tests {
     use super::*;
 
+    fn test_device(
+        serial: &str,
+        device_kind: DeviceKind,
+        connection_state: DeviceConnectionState,
+    ) -> Device {
+        Device {
+            serial: serial.to_string(),
+            name: serial.to_string(),
+            model: None,
+            device_kind,
+            connection_state,
+            api_level: None,
+            android_version: None,
+        }
+    }
+
     #[test]
     fn parses_online_physical_device() {
         let output = "List of devices attached\n\
@@ -1270,5 +1382,58 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
     fn parse_ini_value_finds_key() {
         let content = "path=/home/user/.android/avd/Pixel_7.avd\ntarget=android-34\n";
         assert_eq!(parse_ini_value(content, "target"), Some("android-34"));
+    }
+
+    #[test]
+    fn newly_online_emulator_serial_ignores_existing_emulators() {
+        let before = vec![test_device(
+            "emulator-5554",
+            DeviceKind::Emulator,
+            DeviceConnectionState::Online,
+        )];
+        let after = vec![
+            test_device(
+                "emulator-5554",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+            test_device(
+                "emulator-5556",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+        ];
+
+        assert_eq!(
+            newly_online_emulator_serial(&before, &after),
+            Some("emulator-5556".to_string())
+        );
+    }
+
+    #[test]
+    fn newly_online_emulator_serial_returns_none_for_only_existing_emulators() {
+        let before = vec![test_device(
+            "emulator-5554",
+            DeviceKind::Emulator,
+            DeviceConnectionState::Online,
+        )];
+        let after = before.clone();
+
+        assert_eq!(newly_online_emulator_serial(&before, &after), None);
+    }
+
+    #[test]
+    fn avd_argument_validators_accept_sdk_tool_ids() {
+        assert!(validate_avd_name("Pixel 8_API_35").is_ok());
+        assert!(validate_device_profile_id("pixel_8").is_ok());
+        assert!(validate_system_image_id("system-images;android-35;google_apis;x86_64").is_ok());
+    }
+
+    #[test]
+    fn avd_argument_validators_reject_shell_sensitive_input() {
+        assert!(validate_avd_name("bad;rm").is_err());
+        assert!(validate_avd_name("-bad").is_err());
+        assert!(validate_device_profile_id("pixel 8").is_err());
+        assert!(validate_system_image_id("system-images;android-35;google_apis;$(bad)").is_err());
     }
 }

--- a/src-tauri/src/services/build_runner.rs
+++ b/src-tauri/src/services/build_runner.rs
@@ -63,6 +63,8 @@ pub const MAX_BUILD_LOG: usize = 5_000;
 pub struct BuildStateInner {
     /// Process ID of the currently running Gradle process, if any.
     pub current_build: Option<ProcessId>,
+    /// True after a build request reserves the slot and before the process ID is known.
+    pub starting: bool,
     /// Current build status.
     pub status: BuildStatus,
     /// Ring-buffer of past build records.
@@ -85,6 +87,7 @@ impl BuildStateInner {
         let next_id = history.iter().map(|r| r.id).max().unwrap_or(0) + 1;
         Self {
             current_build: None,
+            starting: false,
             status: BuildStatus::Idle,
             history,
             current_errors: vec![],
@@ -409,30 +412,32 @@ pub fn find_output_apk(gradle_root: &Path, variant_name: &str) -> Option<PathBuf
 
 /// Cancel the currently running build. Returns `true` if a build was running, `false` otherwise.
 pub async fn cancel_build(build_state: &BuildState, process_manager: &ProcessManager) -> bool {
-    let id = {
+    let (id, was_running) = {
         let from_sync = build_state.take_active_process_id();
         if let Some(id) = from_sync {
             let mut bs = build_state.inner.lock().await;
             if bs.current_build == Some(id) {
                 bs.current_build = None;
             }
+            bs.starting = false;
             bs.status = BuildStatus::Cancelled;
-            Some(id)
+            (Some(id), true)
         } else {
             let mut bs = build_state.inner.lock().await;
             let pid = bs.current_build.take();
-            if pid.is_some() {
+            let was_running =
+                pid.is_some() || bs.starting || matches!(bs.status, BuildStatus::Running { .. });
+            if was_running {
+                bs.starting = false;
                 bs.status = BuildStatus::Cancelled;
             }
-            pid
+            (pid, was_running)
         }
     };
     if let Some(id) = id {
         process_manager::cancel(&process_manager.0, id).await;
-        true
-    } else {
-        false
     }
+    was_running
 }
 
 /// Clear all build history from memory and disk.
@@ -471,6 +476,7 @@ pub async fn record_build_result(
         } else {
             BuildStatus::Failed(result.clone())
         };
+        bs.starting = false;
         bs.current_errors = errors.clone();
         bs.current_build = None;
 
@@ -956,6 +962,28 @@ mod tests {
             !was_running,
             "cancel_build should return false when no build is running"
         );
+    }
+
+    #[tokio::test]
+    async fn cancel_build_returns_true_while_build_is_starting() {
+        let state = BuildState::new();
+        let pm = ProcessManager::new();
+
+        {
+            let mut inner = state.inner.lock().await;
+            inner.starting = true;
+            inner.status = BuildStatus::Running {
+                task: "assembleDebug".into(),
+                started_at: "2024-01-01T00:00:00Z".into(),
+            };
+        }
+
+        let was_running = cancel_build(&state, &pm).await;
+        let inner = state.inner.lock().await;
+
+        assert!(was_running, "starting builds should be cancellable");
+        assert!(!inner.starting, "starting flag must be cleared on cancel");
+        assert!(matches!(inner.status, BuildStatus::Cancelled));
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/mcp_server.rs
+++ b/src-tauri/src/services/mcp_server.rs
@@ -2461,6 +2461,8 @@ impl AndroidMcpServer {
         &self,
         Parameters(p): Parameters<LaunchAvdParams>,
     ) -> Result<CallToolResult, McpError> {
+        adb_manager::validate_avd_name(&p.name).map_err(|e| McpError::invalid_params(e, None))?;
+
         let (settings, _) = settings_manager::load_settings();
         let emulator = adb_manager::get_emulator_path(&settings);
         let adb = adb_manager::get_adb_path(&settings);

--- a/src/components/logcat/LogcatPanel.click-filter.test.tsx
+++ b/src/components/logcat/LogcatPanel.click-filter.test.tsx
@@ -100,26 +100,27 @@ function installLogcatPanelMocks(entries: ProcessedEntry[]): {
   setFilterCalls: () => LogcatFilterSpec[];
 } {
   let activeFilter = emptyFilter();
+  let storedEntries = [...entries];
   const setFilterCalls: LogcatFilterSpec[] = [];
   const listeners = new Map<string, (event: { payload: unknown }) => void>();
 
   vi.mocked(invoke).mockImplementation(async (command: string, args?: unknown) => {
     switch (command) {
       case "get_logcat_entries":
-        return filterEntries(entries, activeFilter);
+        return filterEntries(storedEntries, activeFilter);
       case "get_logcat_context_entries":
-        return contextEntries(entries, args);
+        return contextEntries(storedEntries, args);
       case "get_logcat_status":
         return false;
       case "get_logcat_stats":
         return {
-          totalIngested: BigInt(entries.length),
+          totalIngested: BigInt(storedEntries.length),
           countsByLevel: [0n, 0n, 0n, 0n, 0n, 0n, 0n],
           crashCount: 0n,
           jsonCount: 0n,
           packagesSeen: 1,
           bufferUsagePct: 0,
-          bufferEntryCount: BigInt(entries.length),
+          bufferEntryCount: BigInt(storedEntries.length),
         } satisfies LogStats;
       case "set_logcat_filter": {
         const payload = args as { filterSpec?: LogcatFilterSpec };
@@ -141,6 +142,7 @@ function installLogcatPanelMocks(entries: ProcessedEntry[]): {
 
   return {
     emitLogcatEntries(nextEntries: ProcessedEntry[]) {
+      storedEntries = [...storedEntries, ...nextEntries];
       listeners.get("logcat:entries")?.({ payload: filterEntries(nextEntries, activeFilter) });
     },
     setFilterCalls() {
@@ -277,6 +279,34 @@ describe("LogcatPanel Entry Detail click-to-filter integration", () => {
     fireEvent.click(screen.getByTitle("1 new log available - Jump to end"));
 
     expect(await screen.findByText("Incoming row should wait")).not.toBeNull();
+  });
+
+  it("backfills log entries that arrived while paused when resuming", async () => {
+    const visibleEntry = {
+      ...BASE_ENTRY,
+      id: 25n,
+      tag: "VisibleTag",
+      message: "visible before pause",
+    } satisfies ProcessedEntry;
+    const pausedEntry = {
+      ...BASE_ENTRY,
+      id: 26n,
+      tag: "PausedTag",
+      message: "arrived while paused",
+    } satisfies ProcessedEntry;
+    const { emitLogcatEntries } = installLogcatPanelMocks([visibleEntry]);
+    render(() => <LogcatPanel />);
+
+    expect(await screen.findByText("visible before pause")).not.toBeNull();
+
+    fireEvent.click(screen.getByTitle("Pause new entries"));
+    emitLogcatEntries([pausedEntry]);
+
+    expect(screen.queryByText("arrived while paused")).toBeNull();
+
+    fireEvent.click(screen.getByTitle("Resume"));
+
+    expect(await screen.findByText("arrived while paused")).not.toBeNull();
   });
 
   it("hides and restores buffered lifecycle and process entries from the quick filter", async () => {

--- a/src/components/logcat/LogcatPanel.tsx
+++ b/src/components/logcat/LogcatPanel.tsx
@@ -708,6 +708,16 @@ export function LogcatPanel(): JSX.Element {
     }
   }
 
+  async function handleTogglePaused() {
+    if (!paused()) {
+      setPaused(true);
+      return;
+    }
+
+    setPaused(false);
+    await syncBackendFilter(parseFilterGroups(effectiveDebouncedQuery()));
+  }
+
   async function handleClear() {
     try {
       await clearLogcat();
@@ -930,7 +940,9 @@ export function LogcatPanel(): JSX.Element {
         toolbarCount={toolbarCount()}
         onStart={handleStart}
         onStop={handleStop}
-        onTogglePaused={() => setPaused((v) => !v)}
+        onTogglePaused={() => {
+          void handleTogglePaused();
+        }}
         onRestart={handleRestart}
         onClear={handleClear}
         onJumpToLastCrash={jumpToLastCrash}

--- a/src/components/projects/ProjectInfoEditor.test.ts
+++ b/src/components/projects/ProjectInfoEditor.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { validateProjectInfoInput } from "./ProjectInfoEditor";
+
+describe("validateProjectInfoInput", () => {
+  it("accepts valid version info and trims the version name", () => {
+    const result = validateProjectInfoInput(" 1.2.3 ", "42");
+
+    expect(result).toEqual({ ok: true, versionName: "1.2.3", versionCode: 42n });
+  });
+
+  it("rejects partially numeric version codes", () => {
+    const result = validateProjectInfoInput("1.2.3", "42beta");
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Version code must be a non-negative integer.",
+    });
+  });
+
+  it("rejects version names that would break a Gradle string literal", () => {
+    const result = validateProjectInfoInput('1.2"3', "42");
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Version name cannot contain quotes, backslashes, or line breaks.",
+    });
+  });
+});

--- a/src/components/projects/ProjectInfoEditor.test.ts
+++ b/src/components/projects/ProjectInfoEditor.test.ts
@@ -22,7 +22,16 @@ describe("validateProjectInfoInput", () => {
 
     expect(result).toEqual({
       ok: false,
-      message: "Version name cannot contain quotes, backslashes, or line breaks.",
+      message: "Version name cannot contain quotes, backslashes, '$', or line breaks.",
+    });
+  });
+
+  it("rejects version names with Gradle string interpolation syntax", () => {
+    const result = validateProjectInfoInput("1.$0", "42");
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Version name cannot contain quotes, backslashes, '$', or line breaks.",
     });
   });
 });

--- a/src/components/projects/ProjectInfoEditor.tsx
+++ b/src/components/projects/ProjectInfoEditor.tsx
@@ -36,10 +36,10 @@ export function validateProjectInfoInput(
   if (!versionName) {
     return { ok: false, message: "Version name cannot be empty." };
   }
-  if (/["\\\r\n]/.test(versionName)) {
+  if (/["\\$\r\n]/.test(versionName)) {
     return {
       ok: false,
-      message: "Version name cannot contain quotes, backslashes, or line breaks.",
+      message: "Version name cannot contain quotes, backslashes, '$', or line breaks.",
     };
   }
   if (!/^\d+$/.test(versionCodeText)) {

--- a/src/components/projects/ProjectInfoEditor.tsx
+++ b/src/components/projects/ProjectInfoEditor.tsx
@@ -12,6 +12,8 @@ import { projectState } from "@/stores/project.store";
 import { showToast } from "@/components/ui";
 import type { ProjectAppInfo } from "@/bindings";
 
+const MAX_I64 = 9223372036854775807n;
+
 // ── Module-level open/close signal ────────────────────────────────────────────
 
 const [open, setOpen] = createSignal(false);
@@ -22,6 +24,34 @@ export function openProjectInfoEditor(): void {
 
 export function closeProjectInfoEditor(): void {
   setOpen(false);
+}
+
+export function validateProjectInfoInput(
+  rawVersionName: string,
+  rawVersionCode: string
+): { ok: true; versionName: string; versionCode: bigint } | { ok: false; message: string } {
+  const versionName = rawVersionName.trim();
+  const versionCodeText = rawVersionCode.trim();
+
+  if (!versionName) {
+    return { ok: false, message: "Version name cannot be empty." };
+  }
+  if (/["\\\r\n]/.test(versionName)) {
+    return {
+      ok: false,
+      message: "Version name cannot contain quotes, backslashes, or line breaks.",
+    };
+  }
+  if (!/^\d+$/.test(versionCodeText)) {
+    return { ok: false, message: "Version code must be a non-negative integer." };
+  }
+
+  const versionCode = BigInt(versionCodeText);
+  if (versionCode > MAX_I64) {
+    return { ok: false, message: "Version code is too large." };
+  }
+
+  return { ok: true, versionName, versionCode };
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -43,7 +73,11 @@ export function ProjectInfoEditor(): JSX.Element {
       .then((data) => {
         setInfo(data);
         setVersionName(data.versionName ?? "");
-        setVersionCode(data.versionCode !== null && data.versionCode !== undefined ? String(data.versionCode) : "");
+        setVersionCode(
+          data.versionCode !== null && data.versionCode !== undefined
+            ? String(data.versionCode)
+            : ""
+        );
       })
       .catch((err) => {
         showToast(`Failed to read app info: ${formatError(err)}`, "error");
@@ -53,21 +87,15 @@ export function ProjectInfoEditor(): JSX.Element {
   });
 
   async function handleSave() {
-    const name = versionName().trim();
-    const codeStr = versionCode().trim();
-    if (!name) {
-      showToast("Version name cannot be empty.", "error");
-      return;
-    }
-    const code = parseInt(codeStr, 10);
-    if (isNaN(code) || code < 0) {
-      showToast("Version code must be a non-negative integer.", "error");
+    const validation = validateProjectInfoInput(versionName(), versionCode());
+    if (!validation.ok) {
+      showToast(validation.message, "error");
       return;
     }
 
     setSaving(true);
     try {
-      await saveProjectAppInfo(name, BigInt(code));
+      await saveProjectAppInfo(validation.versionName, validation.versionCode);
       showToast("App info saved successfully.", "success");
       setOpen(false);
     } catch (err) {

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi, expectTypeOf } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
 import { cancelBuild, runAndDeploy, runBuild } from "@/services/build.service";
 import { buildState, resetBuildState, startBuild } from "@/stores/build.store";
@@ -102,5 +102,11 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
 
     resolvePicker(null);
     await deploy;
+  });
+
+  it("does not expose the deploy bypass in public runBuild options", () => {
+    type PublicOptions = NonNullable<Parameters<typeof runBuild>[1]>;
+
+    expectTypeOf<PublicOptions>().toEqualTypeOf<{ headerLines?: string[] }>();
   });
 });

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
-import { cancelBuild } from "@/services/build.service";
+import { cancelBuild, runBuild } from "@/services/build.service";
 import { buildState, resetBuildState, startBuild } from "@/stores/build.store";
 
 // The global setup in src/test/setup.ts already mocks @tauri-apps/api/core.
@@ -55,5 +55,22 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
 
     expect(cancelCalls).toHaveLength(1);
     expect(finalizeCalls).toHaveLength(0);
+  });
+
+  it("rejects a second build while the first build is still running", async () => {
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === "run_gradle_task") return Promise.resolve(1);
+      if (cmd === "cancel_build") return Promise.resolve(undefined);
+      if (cmd === "get_build_history") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+
+    const first = runBuild();
+    expect(buildState.phase).toBe("running");
+
+    await expect(runBuild()).rejects.toThrow("A build is already running.");
+
+    await cancelBuild();
+    await first;
   });
 });

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
-import { cancelBuild, runBuild } from "@/services/build.service";
+import { cancelBuild, runAndDeploy, runBuild } from "@/services/build.service";
 import { buildState, resetBuildState, startBuild } from "@/stores/build.store";
+import { resetDeviceState } from "@/stores/device.store";
+import { resetVariantState, selectVariant } from "@/stores/variant.store";
+
+const devicePickerMock = vi.hoisted(() => ({
+  showDevicePicker: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("@/components/device/DevicePickerDialog", () => devicePickerMock);
 
 // The global setup in src/test/setup.ts already mocks @tauri-apps/api/core.
 // We narrow it here so we can track which commands were called.
@@ -10,7 +18,10 @@ const mockInvoke = vi.mocked(invoke);
 describe("cancelBuild guard — no ghost records on project switch", () => {
   beforeEach(() => {
     resetBuildState();
+    resetDeviceState();
+    resetVariantState();
     mockInvoke.mockResolvedValue(undefined);
+    devicePickerMock.showDevicePicker.mockReset();
     vi.clearAllMocks();
   });
 
@@ -72,5 +83,24 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
 
     await cancelBuild();
     await first;
+  });
+
+  it("rejects a standalone build while deploy is resolving a device", async () => {
+    let resolvePicker: (serial: string | null) => void = () => {};
+    devicePickerMock.showDevicePicker.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePicker = resolve;
+      })
+    );
+
+    await selectVariant("debug");
+    const deploy = runAndDeploy();
+    await vi.waitFor(() => expect(devicePickerMock.showDevicePicker).toHaveBeenCalled());
+
+    expect(buildState.phase).toBe("idle");
+    await expect(runBuild()).rejects.toThrow("A build or deploy is already running.");
+
+    resolvePicker(null);
+    await deploy;
   });
 });

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -32,6 +32,11 @@ let buildCompleteUnlisten: (() => void) | null = null;
 let currentBuildPromise: Promise<void> | null = null;
 let deployInFlight = false;
 
+interface RunBuildOptions {
+  headerLines?: string[];
+  allowDuringDeploy?: boolean;
+}
+
 // ── Registration ──────────────────────────────────────────────────────────────
 
 /** Call once on app startup to register the build:complete event listener. */
@@ -87,7 +92,10 @@ let _resolveBuildComplete: ((result: { success: boolean; durationMs: number }) =
  * @param opts.headerLines  Lines injected at the top of the log right after it
  *                          clears — used by runAndDeploy to surface context.
  */
-export async function runBuild(task?: string, opts?: { headerLines?: string[] }): Promise<void> {
+export async function runBuild(task?: string, opts?: RunBuildOptions): Promise<void> {
+  if (deployInFlight && !opts?.allowDuringDeploy) {
+    throw new Error("A build or deploy is already running.");
+  }
   if (currentBuildPromise || buildState.phase === "running") {
     throw new Error("A build is already running.");
   }
@@ -103,7 +111,7 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
   }
 }
 
-async function runBuildInternal(task?: string, opts?: { headerLines?: string[] }): Promise<void> {
+async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<void> {
   const variant = variantState.activeVariant;
   const effectiveTask = task ?? (variant ? `assemble${capitalize(variant)}` : "assembleDebug");
 
@@ -221,6 +229,7 @@ export async function runAndDeploy(): Promise<void> {
     setDeployPhase("building");
     await runBuild(`assemble${capitalize(variant)}`, {
       headerLines: [`── Deploy: ${variant} → ${serial} ──`],
+      allowDuringDeploy: true,
     });
 
     const phase = buildState.phase;

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -29,6 +29,8 @@ import { settingsState } from "@/stores/settings.store";
 import type { BuildError } from "@/bindings";
 
 let buildCompleteUnlisten: (() => void) | null = null;
+let currentBuildPromise: Promise<void> | null = null;
+let deployInFlight = false;
 
 // ── Registration ──────────────────────────────────────────────────────────────
 
@@ -86,6 +88,22 @@ let _resolveBuildComplete: ((result: { success: boolean; durationMs: number }) =
  *                          clears — used by runAndDeploy to surface context.
  */
 export async function runBuild(task?: string, opts?: { headerLines?: string[] }): Promise<void> {
+  if (currentBuildPromise || buildState.phase === "running") {
+    throw new Error("A build is already running.");
+  }
+
+  const promise = runBuildInternal(task, opts);
+  currentBuildPromise = promise;
+  try {
+    await promise;
+  } finally {
+    if (currentBuildPromise === promise) {
+      currentBuildPromise = null;
+    }
+  }
+}
+
+async function runBuildInternal(task?: string, opts?: { headerLines?: string[] }): Promise<void> {
   const variant = variantState.activeVariant;
   const effectiveTask = task ?? (variant ? `assemble${capitalize(variant)}` : "assembleDebug");
 
@@ -170,23 +188,34 @@ export async function runBuild(task?: string, opts?: { headerLines?: string[] })
  * After a successful build the APK is installed and the app launched.
  */
 export async function runAndDeploy(): Promise<void> {
-  const variant = variantState.activeVariant;
-  if (!variant) {
-    throw new Error("No build variant selected. Open Build → Select Variant.");
+  if (
+    deployInFlight ||
+    currentBuildPromise ||
+    buildState.phase === "running" ||
+    buildState.deployPhase
+  ) {
+    throw new Error("A build or deploy is already running.");
   }
 
-  // Resolve a device before the build so we can bail early.
-  // We log this BEFORE startBuild clears the log — that's intentional; users
-  // will see the context when the build panel opens.
-  logStep("Resolving target device…");
-  const serial = await resolveDevice();
-  if (!serial) {
-    logStep("No device selected — run cancelled.");
-    return;
-  }
-  logStep(`Target device: ${serial}`);
+  deployInFlight = true;
+  const variant = variantState.activeVariant;
 
   try {
+    if (!variant) {
+      throw new Error("No build variant selected. Open Build → Select Variant.");
+    }
+
+    // Resolve a device before the build so we can bail early.
+    // We log this BEFORE startBuild clears the log — that's intentional; users
+    // will see the context when the build panel opens.
+    logStep("Resolving target device…");
+    const serial = await resolveDevice();
+    if (!serial) {
+      logStep("No device selected — run cancelled.");
+      return;
+    }
+    logStep(`Target device: ${serial}`);
+
     // 1. Build. startBuild() inside runBuild() clears the log, so we add a
     //    context header as the very first callback line from the Gradle channel.
     setDeployPhase("building");
@@ -254,6 +283,7 @@ export async function runAndDeploy(): Promise<void> {
     throw e;
   } finally {
     setDeployPhase(null);
+    deployInFlight = false;
   }
 }
 

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -34,7 +34,6 @@ let deployInFlight = false;
 
 interface RunBuildOptions {
   headerLines?: string[];
-  allowDuringDeploy?: boolean;
 }
 
 // ── Registration ──────────────────────────────────────────────────────────────
@@ -93,7 +92,15 @@ let _resolveBuildComplete: ((result: { success: boolean; durationMs: number }) =
  *                          clears — used by runAndDeploy to surface context.
  */
 export async function runBuild(task?: string, opts?: RunBuildOptions): Promise<void> {
-  if (deployInFlight && !opts?.allowDuringDeploy) {
+  return runBuildGuarded(task, opts, false);
+}
+
+async function runBuildGuarded(
+  task: string | undefined,
+  opts: RunBuildOptions | undefined,
+  allowDuringDeploy: boolean
+): Promise<void> {
+  if (deployInFlight && !allowDuringDeploy) {
     throw new Error("A build or deploy is already running.");
   }
   if (currentBuildPromise || buildState.phase === "running") {
@@ -227,10 +234,13 @@ export async function runAndDeploy(): Promise<void> {
     // 1. Build. startBuild() inside runBuild() clears the log, so we add a
     //    context header as the very first callback line from the Gradle channel.
     setDeployPhase("building");
-    await runBuild(`assemble${capitalize(variant)}`, {
-      headerLines: [`── Deploy: ${variant} → ${serial} ──`],
-      allowDuringDeploy: true,
-    });
+    await runBuildGuarded(
+      `assemble${capitalize(variant)}`,
+      {
+        headerLines: [`── Deploy: ${variant} → ${serial} ──`],
+      },
+      true
+    );
 
     const phase = buildState.phase;
     if (phase !== "success") {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -9,6 +9,9 @@
 // Mock @tauri-apps/api/core
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
+  Channel: class MockChannel<T = unknown> {
+    onmessage: ((message: T) => void) | null = null;
+  },
 }));
 
 // Mock @tauri-apps/api/event


### PR DESCRIPTION
## Summary

improviments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents overlapping Gradle builds and deploys, hardens emulator/SDK inputs, and fixes Logcat pause/resume to backfill missed entries. Also validates app version fields in both UI and backend and adds targeted tests.

- **Bug Fixes**
  - Reject concurrent builds and block standalone builds while a deploy resolves. Cancel works during the starting window. Spawn failures mark the build Failed (or preserve Cancelled). No ghost history on cancel.
  - Logcat resume backfills entries that arrived while paused; tests updated with buffered entries and `Channel` mock.

- **New Features**
  - Validate AVD names, device profile IDs, and system image IDs before SDK tool calls and in the MCP tool; emulator launch waits for the newly online emulator (not any existing one).
  - Validate/sanitize `versionName` and `versionCode` in the backend and UI, rejecting Gradle‑breaking characters and negative/overflow codes.
  - Device polling updates state once and emits a single `device:list_changed` payload.

<sup>Written for commit cd3eabad7a6b3ca149cd184bc9a2f9835e9b7103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thiagodmont/keynobi/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

