### PR TITLE
chore(deps): stop proposing TypeScript major bumps until eslint catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # TypeScript 7 (the native port) is not supported by typescript-eslint:
+      # even its canary pins `typescript: >=4.8.4 <6.1.0` and throws on load,
+      # so `npm run lint` dies before linting a file. TS 7 itself typechecks
+      # this repo clean — the block is entirely on the lint side. Drop this
+      # ignore once typescript-eslint ships TS 7 support. Minor and patch
+      # updates on the 6.x line keep flowing.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "cargo"
     directory: "/src-tauri"


### PR DESCRIPTION
Follow-up to closing #165.

## Why

Dependabot keeps proposing TypeScript 7, but it cannot pass CI:

- typescript-eslint has **no TS 7 support on any channel**. Latest stable (`8.67.0`) and canary (`8.67.1-alpha.17`) both declare `peerDependencies.typescript: ">=4.8.4 <6.1.0"`.
- Under TS 7, `@typescript-eslint/typescript-estree` throws at *require* time:
  ```
  TypeError: Cannot read properties of undefined (reading 'Cjs')
      at create-program/shared.js:59:18
  ```
- So `npm run lint` dies before linting a single file, failing both **Frontend** and **Design System**.

TypeScript 7 itself is not the problem — `tsc --noEmit` on 7.0.2 typechecks this tree clean. The block is entirely on the lint side, which is why this is a dependabot ignore rather than a code change.

## What

Scoped to `version-update:semver-major` only, so 6.x minor and patch bumps keep flowing. Remove the ignore once typescript-eslint ships TS 7 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop proposing TypeScript major upgrades via Dependabot to avoid CI failures until `typescript-eslint` supports TS 7. Previously, Dependabot opened TS 7 PRs that failed because `npm run lint` crashed at load time; now it will open only 6.x minor and patch updates.

- Update `.github/dependabot.yml` to ignore `typescript` with `update-types: ["version-update:semver-major"]`.
- `typescript-eslint` currently declares `peerDependencies.typescript: ">=4.8.4 <6.1.0"` and `@typescript-eslint/typescript-estree` throws under TS 7, causing lint to fail.
- TS 7 typechecks clean; the block is lint-only. Remove this ignore once `typescript-eslint` supports TS 7.

<sup>Written for commit fa84e85ba9e01511ba54997531f448853dc00032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thiagodmont/keynobi/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

