### PR TITLE
fix: close five verified defects across MCP server, adb, and build flow

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -103,13 +103,20 @@ pub async fn detect_java_path() -> Result<Option<String>, String> {
 mod tests {
     use super::SETTINGS_FLUSH_ACK;
 
-    /// The shutdown handler waits on this notifier; the frontend's
-    /// notify_settings_flushed command must wake it.
+    /// Mirrors the real shutdown contract: the Rust teardown handler waits on
+    /// the notifier first, then the frontend's notify_settings_flushed
+    /// command must wake it.
     #[tokio::test]
-    async fn flush_ack_notifies_waiters() {
-        // notify_one with no waiter stores a permit, so a later notified()
-        // resolves immediately — same ordering as the real close flow.
-        SETTINGS_FLUSH_ACK.notify_one();
-        SETTINGS_FLUSH_ACK.notified().await;
+    async fn flush_ack_command_wakes_registered_waiter() {
+        let waiter = tokio::spawn(SETTINGS_FLUSH_ACK.notified());
+        // Give the spawned waiter time to register before notifying.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        super::notify_settings_flushed().await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter should be woken by notify_settings_flushed")
+            .expect("waiter task should not panic");
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -108,15 +108,19 @@ mod tests {
     /// command must wake it.
     #[tokio::test]
     async fn flush_ack_command_wakes_registered_waiter() {
-        let waiter = tokio::spawn(SETTINGS_FLUSH_ACK.notified());
-        // Give the spawned waiter time to register before notifying.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        use futures_util::FutureExt;
+
+        let mut waiter = Box::pin(SETTINGS_FLUSH_ACK.notified());
+        // Poll until the future returns Pending — that is when its waker is
+        // registered with the notifier. Deterministic: no sleep heuristic.
+        while waiter.as_mut().now_or_never().is_some() {
+            tokio::task::yield_now().await;
+        }
 
         super::notify_settings_flushed().await;
 
         tokio::time::timeout(std::time::Duration::from_secs(5), waiter)
             .await
-            .expect("waiter should be woken by notify_settings_flushed")
-            .expect("waiter task should not panic");
+            .expect("waiter should be woken by notify_settings_flushed");
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -4,6 +4,23 @@ use crate::services::logcat::LogcatState;
 use crate::services::settings_manager;
 use tauri::State;
 
+/// Acknowledgement signal used to order window teardown behind the
+/// frontend's final settings flush.
+///
+/// On `CloseRequested`, the Rust shutdown handler (lib.rs) waits briefly on
+/// this notifier before cancelling builds and destroying the window. The
+/// frontend invokes [`notify_settings_flushed`] once its debounced settings
+/// save has been persisted, so a setting changed within the debounce window
+/// cannot be lost when the webview goes away.
+pub static SETTINGS_FLUSH_ACK: std::sync::LazyLock<tokio::sync::Notify> =
+    std::sync::LazyLock::new(tokio::sync::Notify::new);
+
+/// Called by the frontend after the close-time settings flush completes.
+#[tauri::command]
+pub async fn notify_settings_flushed() {
+    SETTINGS_FLUSH_ACK.notify_one();
+}
+
 #[tauri::command]
 pub async fn get_settings() -> Result<AppSettings, String> {
     let (settings, _) = tokio::task::spawn_blocking(settings_manager::load_settings)
@@ -80,4 +97,19 @@ pub async fn detect_java_path() -> Result<Option<String>, String> {
     }
     // 2. Slow path: login shell.
     Ok(settings_manager::detect_java_home_from_shell().await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SETTINGS_FLUSH_ACK;
+
+    /// The shutdown handler waits on this notifier; the frontend's
+    /// notify_settings_flushed command must wake it.
+    #[tokio::test]
+    async fn flush_ack_notifies_waiters() {
+        // notify_one with no waiter stores a permit, so a later notified()
+        // resolves immediately — same ordering as the real close flow.
+        SETTINGS_FLUSH_ACK.notify_one();
+        SETTINGS_FLUSH_ACK.notified().await;
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -258,6 +258,16 @@ pub fn run() {
                 api.prevent_close();
                 let app = window.app_handle().clone();
                 tauri::async_runtime::spawn(async move {
+                    // Give the frontend a moment to persist any settings
+                    // change still inside its 500 ms debounce window. The
+                    // frontend invokes notify_settings_flushed when done; if
+                    // it never does (webview already gone), don't wait long.
+                    let _ = tokio::time::timeout(
+                        std::time::Duration::from_secs(2),
+                        commands::settings::SETTINGS_FLUSH_ACK.notified(),
+                    )
+                    .await;
+
                     let cleanup = async {
                         // 1. Cancel any running Gradle build.
                         let build_state = app.state::<BuildState>();
@@ -307,6 +317,7 @@ pub fn run() {
             // Settings
             get_settings,
             save_settings,
+            notify_settings_flushed,
             get_default_settings,
             reset_settings,
             send_native_sentry_test_event,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -258,33 +258,34 @@ pub fn run() {
                 api.prevent_close();
                 let app = window.app_handle().clone();
                 tauri::async_runtime::spawn(async move {
-                    // Give the frontend a moment to persist any settings
-                    // change still inside its 500 ms debounce window. The
-                    // frontend invokes notify_settings_flushed when done; if
-                    // it never does (webview already gone), don't wait long.
-                    let _ = tokio::time::timeout(
-                        std::time::Duration::from_secs(2),
-                        commands::settings::SETTINGS_FLUSH_ACK.notified(),
-                    )
-                    .await;
+                    // One overall shutdown budget: wait briefly for the
+                    // frontend to persist any settings change still inside
+                    // its 500 ms debounce window (it invokes
+                    // notify_settings_flushed when done), then cancel the
+                    // build and stop streaming. If the ack never arrives
+                    // (webview already gone), don't stall the whole budget.
+                    let shutdown = async {
+                        let _ = tokio::time::timeout(
+                            std::time::Duration::from_secs(2),
+                            commands::settings::SETTINGS_FLUSH_ACK.notified(),
+                        )
+                        .await;
 
-                    let cleanup = async {
-                        // 1. Cancel any running Gradle build.
+                        // Cancel any running Gradle build.
                         let build_state = app.state::<BuildState>();
                         let process_manager = app.state::<ProcessManager>();
                         services::build_runner::cancel_build(&build_state, &process_manager).await;
 
-                        // 2. Stop logcat streaming (best-effort).
+                        // Stop logcat streaming (best-effort).
                         let logcat_state = app.state::<services::logcat::LogcatState>();
                         logcat_state.lock().await.streaming = false;
 
-                        // 3. Stop ADB device polling.
+                        // Stop ADB device polling.
                         let device_state = app.state::<DeviceState>();
                         device_state.0.lock().await.polling = false;
                     };
 
-                    // Never block shutdown longer than 3 seconds.
-                    if tokio::time::timeout(std::time::Duration::from_secs(3), cleanup)
+                    if tokio::time::timeout(std::time::Duration::from_secs(3), shutdown)
                         .await
                         .is_err()
                     {

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -513,12 +513,27 @@ pub async fn launch_app(
 
 /// Force-stop an app on a device.
 pub async fn stop_app(adb: &Path, serial: &str, package: &str) -> Result<(), String> {
-    Command::new(adb)
+    let out = Command::new(adb)
         .args(["-s", serial, "shell", "am", "force-stop", package])
         .output()
         .await
-        .map(|_| ())
-        .map_err(|e| format!("adb force-stop failed: {e}"))
+        .map_err(|e| format!("adb force-stop failed: {e}"))?;
+
+    if out.status.success() {
+        Ok(())
+    } else {
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        )
+        .trim()
+        .to_owned();
+        Err(format!(
+            "adb force-stop failed (exit {}): {combined}",
+            out.status.code().unwrap_or(-1)
+        ))
+    }
 }
 
 // ── AVD management ─────────────────────────────────────────────────────────────

--- a/src-tauri/src/services/mcp_server.rs
+++ b/src-tauri/src/services/mcp_server.rs
@@ -2986,6 +2986,21 @@ fn capitalize_first(s: &str) -> String {
     }
 }
 
+/// Truncate `s` to at most `max_bytes` bytes without splitting a multi-byte
+/// character. Slicing a `&str` at a raw byte index panics when the index falls
+/// inside a multi-byte sequence, so activity summaries built from arbitrary
+/// tool output (logcat lines, app UI text) must use this instead.
+fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut cut = max_bytes;
+    while !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    &s[..cut]
+}
+
 // ── Logging wrapper ────────────────────────────────────────────────────────────
 
 /// Wraps `AndroidMcpServer` to intercept all tool calls, resource reads, and
@@ -3058,7 +3073,7 @@ impl ServerHandler for LoggingMcpServer {
                 let first_text = r.content.first().and_then(|c| c.as_text()).map(|t| {
                     let s = &t.text;
                     if s.len() > 120 {
-                        format!("{}…", &s[..120])
+                        format!("{}…", truncate_at_char_boundary(s, 120))
                     } else {
                         s.clone()
                     }
@@ -3307,6 +3322,32 @@ mod tests {
         assert_eq!(capitalize_first("debug"), "Debug");
         assert_eq!(capitalize_first("release"), "Release");
         assert_eq!(capitalize_first(""), "");
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_handles_multibyte() {
+        // ASCII passes through unchanged.
+        assert_eq!(truncate_at_char_boundary("abcdefgh", 120), "abcdefgh");
+        assert_eq!(truncate_at_char_boundary(&"a".repeat(120), 120), "a".repeat(120));
+
+        // Multi-byte characters: byte 120 falls exactly on a char boundary
+        // (every 漢/字 is 3 bytes), so the full 40 chars are kept.
+        let cjk: String = "漢字".repeat(80); // 480 bytes, all 3-byte chars
+        let cut = truncate_at_char_boundary(&cjk, 120);
+        assert!(cut.len() <= 120);
+        assert_eq!(cut, "漢字".repeat(20));
+
+        // Byte 119 falls inside the 40th character — back off to its start.
+        assert_eq!(truncate_at_char_boundary(&cjk, 119), "漢字".repeat(19) + "漢");
+
+        // Emoji (4-byte chars) straddling the limit.
+        let emoji = "😀😀😀";
+        let cut = truncate_at_char_boundary(emoji, 6);
+        assert_eq!(cut, "😀");
+
+        // Cut index landing exactly on a boundary keeps it.
+        let mixed = format!("{}{}", "a".repeat(118), "漢字");
+        assert_eq!(truncate_at_char_boundary(&mixed, 121), format!("{}{}", "a".repeat(118), '漢'));
     }
 
     #[test]

--- a/src-tauri/src/services/mcp_server.rs
+++ b/src-tauri/src/services/mcp_server.rs
@@ -3328,7 +3328,10 @@ mod tests {
     fn truncate_at_char_boundary_handles_multibyte() {
         // ASCII passes through unchanged.
         assert_eq!(truncate_at_char_boundary("abcdefgh", 120), "abcdefgh");
-        assert_eq!(truncate_at_char_boundary(&"a".repeat(120), 120), "a".repeat(120));
+        assert_eq!(
+            truncate_at_char_boundary(&"a".repeat(120), 120),
+            "a".repeat(120)
+        );
 
         // Multi-byte characters: byte 120 falls exactly on a char boundary
         // (every 漢/字 is 3 bytes), so the full 40 chars are kept.
@@ -3338,7 +3341,10 @@ mod tests {
         assert_eq!(cut, "漢字".repeat(20));
 
         // Byte 119 falls inside the 40th character — back off to its start.
-        assert_eq!(truncate_at_char_boundary(&cjk, 119), "漢字".repeat(19) + "漢");
+        assert_eq!(
+            truncate_at_char_boundary(&cjk, 119),
+            "漢字".repeat(19) + "漢"
+        );
 
         // Emoji (4-byte chars) straddling the limit.
         let emoji = "😀😀😀";
@@ -3347,7 +3353,10 @@ mod tests {
 
         // Cut index landing exactly on a boundary keeps it.
         let mixed = format!("{}{}", "a".repeat(118), "漢字");
-        assert_eq!(truncate_at_char_boundary(&mixed, 121), format!("{}{}", "a".repeat(118), '漢'));
+        assert_eq!(
+            truncate_at_char_boundary(&mixed, 121),
+            format!("{}{}", "a".repeat(118), '漢')
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,12 @@ import { DeviceSidebar } from "@/components/device/DeviceSidebar";
 import { DevicePickerDialog } from "@/components/device/DevicePickerDialog";
 import { registerKeybinding, initKeybindings } from "@/lib/keybindings";
 import { registerAction, type ActionCategory } from "@/lib/action-registry";
-import { applyAppearanceSettings, loadSettings, settingsState } from "@/stores/settings.store";
+import {
+  applyAppearanceSettings,
+  flushPendingSettingsSave,
+  loadSettings,
+  settingsState,
+} from "@/stores/settings.store";
 import { captureSentryException, initSentryWeb } from "@/lib/telemetry/sentry-web";
 import { tryOpenOnboardingAfterLoad, openOnboardingWizard } from "@/stores/onboarding.store";
 import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
@@ -416,7 +421,9 @@ export function App(): JSX.Element {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
       const appWindow = getCurrentWindow();
       const unlisten = await appWindow.onCloseRequested(async (_event) => {
-        // No dirty files to check — allow close immediately.
+        // No dirty files to check — allow close immediately, but persist any
+        // settings change still sitting in the debounce window.
+        await flushPendingSettingsSave();
       });
       if (disposed) unlisten();
       else unlistenClose = unlisten;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -421,14 +421,13 @@ export function App(): JSX.Element {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
       const appWindow = getCurrentWindow();
       const unlisten = await appWindow.onCloseRequested(async (event) => {
-        // Hold the native close until any settings change still inside the
-        // 500 ms debounce window has been persisted, then close explicitly.
+        // Prevent the JS wrapper's auto-destroy: the Rust shutdown handler
+        // (lib.rs on_window_event) owns teardown — it cancels any running
+        // build, stops logcat/polling, and performs the final destroy().
+        // Here we only persist any settings change still inside the 500 ms
+        // debounce window before that teardown runs.
         event.preventDefault();
-        try {
-          await flushPendingSettingsSave();
-        } finally {
-          void appWindow.destroy();
-        }
+        await flushPendingSettingsSave();
       });
       if (disposed) unlisten();
       else unlistenClose = unlisten;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -420,10 +420,15 @@ export function App(): JSX.Element {
     try {
       const { getCurrentWindow } = await import("@tauri-apps/api/window");
       const appWindow = getCurrentWindow();
-      const unlisten = await appWindow.onCloseRequested(async (_event) => {
-        // No dirty files to check — allow close immediately, but persist any
-        // settings change still sitting in the debounce window.
-        await flushPendingSettingsSave();
+      const unlisten = await appWindow.onCloseRequested(async (event) => {
+        // Hold the native close until any settings change still inside the
+        // 500 ms debounce window has been persisted, then close explicitly.
+        event.preventDefault();
+        try {
+          await flushPendingSettingsSave();
+        } finally {
+          void appWindow.destroy();
+        }
       });
       if (disposed) unlisten();
       else unlistenClose = unlisten;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,7 @@ import {
 import { initBuildService, runBuild, runAndDeploy, cancelBuild } from "@/services/build.service";
 import { initDevices } from "@/stores/device.store";
 import { openVariantPicker } from "@/components/build/VariantSelector";
-import { formatError, sendNativeSentryTestEvent } from "@/lib/tauri-api";
+import { formatError, notifySettingsFlushed, sendNativeSentryTestEvent } from "@/lib/tauri-api";
 import { projectState } from "@/stores/project.store";
 import { openMcpPanel } from "@/components/mcp/McpPanel";
 import {
@@ -424,10 +424,15 @@ export function App(): JSX.Element {
         // Prevent the JS wrapper's auto-destroy: the Rust shutdown handler
         // (lib.rs on_window_event) owns teardown — it cancels any running
         // build, stops logcat/polling, and performs the final destroy().
-        // Here we only persist any settings change still inside the 500 ms
-        // debounce window before that teardown runs.
+        // Persist any settings change still inside the 500 ms debounce
+        // window, then acknowledge so the Rust handler can proceed without
+        // waiting out its full grace timeout.
         event.preventDefault();
-        await flushPendingSettingsSave();
+        try {
+          await flushPendingSettingsSave();
+        } finally {
+          await notifySettingsFlushed().catch(() => {});
+        }
       });
       if (disposed) unlisten();
       else unlistenClose = unlisten;

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -94,6 +94,11 @@ export async function saveSettings(settings: AppSettings): Promise<void> {
   return invoke<void>("save_settings", { settings });
 }
 
+/** Acknowledge that the close-time settings flush has completed (see lib.rs shutdown handler). */
+export async function notifySettingsFlushed(): Promise<void> {
+  return invoke<void>("notify_settings_flushed");
+}
+
 export async function getDefaultSettings(): Promise<AppSettings> {
   return invoke<AppSettings>("get_default_settings");
 }

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -135,7 +135,9 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
   it("times out after the configured buildTimeoutSec, not a hardcoded value", async () => {
     vi.useFakeTimers();
     try {
-      updateSetting("mcp", "buildTimeoutSec", 60);
+      // 120 sits above the 60 s clamp floor, so passing proves the
+      // configured value is honored rather than the minimum.
+      updateSetting("mcp", "buildTimeoutSec", 120);
       mockInvoke.mockImplementation((cmd) => {
         if (cmd === "run_gradle_task") return Promise.resolve(1);
         if (cmd === "cancel_build") return Promise.resolve(undefined);
@@ -145,16 +147,18 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
 
       const first = runBuild();
       const expectation = expect(first).rejects.toThrow(
-        "Build timed out waiting for the build:complete event after 60 seconds."
+        "Build timed out waiting for the build:complete event after 120 seconds."
       );
 
       // Just under the configured timeout: still pending.
-      await vi.advanceTimersByTimeAsync(59 * 1000);
+      await vi.advanceTimersByTimeAsync(119 * 1000);
 
-      // Past it: the promise rejects.
+      // Past it: the promise rejects and the still-running Gradle process
+      // is cancelled to release the shared build slot.
       await vi.advanceTimersByTimeAsync(2 * 1000);
       await expectation;
-      await cancelBuild();
+      const cancelCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "cancel_build");
+      expect(cancelCalls).toHaveLength(1);
     } finally {
       updateSetting("mcp", "buildTimeoutSec", 600);
       vi.useRealTimers();

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -4,6 +4,7 @@ import { cancelBuild, runAndDeploy, runBuild } from "@/services/build.service";
 import { buildState, resetBuildState, startBuild } from "@/stores/build.store";
 import { resetDeviceState } from "@/stores/device.store";
 import { resetVariantState, selectVariant } from "@/stores/variant.store";
+import { updateSetting } from "@/stores/settings.store";
 
 const devicePickerMock = vi.hoisted(() => ({
   showDevicePicker: vi.fn<() => Promise<string | null>>(),
@@ -129,5 +130,34 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
     type PublicOptions = NonNullable<Parameters<typeof runBuild>[1]>;
 
     expectTypeOf<PublicOptions>().toEqualTypeOf<{ headerLines?: string[] }>();
+  });
+
+  it("times out after the configured buildTimeoutSec, not a hardcoded value", async () => {
+    vi.useFakeTimers();
+    try {
+      updateSetting("mcp", "buildTimeoutSec", 60);
+      mockInvoke.mockImplementation((cmd) => {
+        if (cmd === "run_gradle_task") return Promise.resolve(1);
+        if (cmd === "cancel_build") return Promise.resolve(undefined);
+        if (cmd === "get_build_history") return Promise.resolve([]);
+        return Promise.resolve(undefined);
+      });
+
+      const first = runBuild();
+      const expectation = expect(first).rejects.toThrow(
+        "Build timed out waiting for the build:complete event after 60 seconds."
+      );
+
+      // Just under the configured timeout: still pending.
+      await vi.advanceTimersByTimeAsync(59 * 1000);
+
+      // Past it: the promise rejects.
+      await vi.advanceTimersByTimeAsync(2 * 1000);
+      await expectation;
+      await cancelBuild();
+    } finally {
+      updateSetting("mcp", "buildTimeoutSec", 600);
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -205,6 +205,9 @@ describe("late cancelled completion event after a timeout", () => {
     });
 
     await initBuildService();
+    // Fail loudly if the listener was never registered — otherwise the
+    // dispatch below would no-op and the test would pass vacuously.
+    expect(handlers.has("build:complete")).toBe(true);
 
     const first = runBuild();
     const expectation = expect(first).rejects.toThrow(/timed out/);
@@ -215,7 +218,7 @@ describe("late cancelled completion event after a timeout", () => {
     expect(buildState.phase).toBe("failed");
 
     // The dying Gradle process emits a late cancelled completion event.
-    handlers.get("build:complete")?.({
+    handlers.get("build:complete")!({
       payload: {
         success: false,
         cancelled: true,
@@ -240,6 +243,9 @@ describe("late cancelled completion event after a timeout", () => {
     });
 
     await initBuildService();
+    // Fail loudly if the listener was never registered — otherwise the
+    // dispatch below would no-op and the test would pass vacuously.
+    expect(handlers.has("build:complete")).toBe(true);
     mockInvoke.mockImplementation((cmd) => {
       if (cmd === "run_gradle_task") return Promise.resolve(1);
       if (cmd === "cancel_build") return Promise.resolve(undefined);
@@ -251,7 +257,7 @@ describe("late cancelled completion event after a timeout", () => {
     await vi.advanceTimersByTimeAsync(0);
     await cancelBuild();
 
-    handlers.get("build:complete")?.({
+    handlers.get("build:complete")!({
       payload: {
         success: false,
         cancelled: true,
@@ -262,6 +268,56 @@ describe("late cancelled completion event after a timeout", () => {
       },
     });
 
+    expect(buildState.phase).toBe("cancelled");
+  });
+
+  it("absorbs a stale cancelled event that arrives after a later build started", async () => {
+    vi.useFakeTimers();
+    const handlers = new Map<string, (e: { payload: unknown }) => void>();
+    vi.mocked(listen).mockImplementation(async (event, cb) => {
+      handlers.set(String(event), cb as unknown as (e: { payload: unknown }) => void);
+      return () => {};
+    });
+
+    await initBuildService();
+    // Fail loudly if the listener was never registered — otherwise the
+    // dispatch below would no-op and the test would pass vacuously.
+    expect(handlers.has("build:complete")).toBe(true);
+    updateSetting("mcp", "buildTimeoutSec", 120);
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === "run_gradle_task") return Promise.resolve(1);
+      if (cmd === "cancel_build") return Promise.resolve(undefined);
+      if (cmd === "get_build_history") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+
+    // Build A times out; its process is killed but slow to die.
+    const buildA = runBuild();
+    const expectationA = expect(buildA).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(121 * 1000);
+    await expectationA;
+    expect(buildState.phase).toBe("failed");
+
+    // Build B starts before A's completion event has been delivered.
+    void runBuild();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(buildState.phase).toBe("running");
+
+    // A's stale cancelled event must NOT cancel build B.
+    handlers.get("build:complete")!({
+      payload: {
+        success: false,
+        cancelled: true,
+        durationMs: 121_000,
+        errorCount: 0,
+        warningCount: 0,
+        task: "assembleDebug",
+      },
+    });
+    expect(buildState.phase).toBe("running");
+
+    // A genuine cancellation of B still lands in the cancelled phase.
+    await cancelBuild();
     expect(buildState.phase).toBe("cancelled");
   });
 });

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect, beforeEach, vi, expectTypeOf } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, expectTypeOf } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
-import { cancelBuild, runAndDeploy, runBuild } from "@/services/build.service";
+import { listen } from "@tauri-apps/api/event";
+import {
+  cancelBuild,
+  initBuildService,
+  resetBuildServiceForTests,
+  runAndDeploy,
+  runBuild,
+} from "@/services/build.service";
 import { buildState, resetBuildState, startBuild } from "@/stores/build.store";
 import { resetDeviceState } from "@/stores/device.store";
 import { resetVariantState, selectVariant } from "@/stores/variant.store";
@@ -163,5 +170,98 @@ describe("cancelBuild guard — no ghost records on project switch", () => {
       updateSetting("mcp", "buildTimeoutSec", 600);
       vi.useRealTimers();
     }
+  });
+});
+
+describe("late cancelled completion event after a timeout", () => {
+  beforeEach(() => {
+    resetBuildState();
+    resetDeviceState();
+    resetVariantState();
+    mockInvoke.mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetBuildServiceForTests();
+    vi.useRealTimers();
+  });
+
+  it("does not overwrite the timeout failure with a cancelled phase", async () => {
+    vi.useFakeTimers();
+    // Capture the build:complete handler registered by the service.
+    const handlers = new Map<string, (e: { payload: unknown }) => void>();
+    vi.mocked(listen).mockImplementation(async (event, cb) => {
+      handlers.set(String(event), cb as unknown as (e: { payload: unknown }) => void);
+      return () => {};
+    });
+
+    updateSetting("mcp", "buildTimeoutSec", 120);
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === "run_gradle_task") return Promise.resolve(1);
+      if (cmd === "cancel_build") return Promise.resolve(undefined);
+      if (cmd === "get_build_history") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+
+    await initBuildService();
+
+    const first = runBuild();
+    const expectation = expect(first).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(121 * 1000);
+    await expectation;
+
+    // The catch path marked the build failed.
+    expect(buildState.phase).toBe("failed");
+
+    // The dying Gradle process emits a late cancelled completion event.
+    handlers.get("build:complete")?.({
+      payload: {
+        success: false,
+        cancelled: true,
+        durationMs: 121_000,
+        errorCount: 0,
+        warningCount: 0,
+        task: "assembleDebug",
+      },
+    });
+
+    // Phase must stay failed, not flip to cancelled.
+    expect(buildState.phase).toBe("failed");
+    await expectation;
+  });
+
+  it("still applies cancelled phase for a genuine user cancellation", async () => {
+    vi.useFakeTimers();
+    const handlers = new Map<string, (e: { payload: unknown }) => void>();
+    vi.mocked(listen).mockImplementation(async (event, cb) => {
+      handlers.set(String(event), cb as unknown as (e: { payload: unknown }) => void);
+      return () => {};
+    });
+
+    await initBuildService();
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === "run_gradle_task") return Promise.resolve(1);
+      if (cmd === "cancel_build") return Promise.resolve(undefined);
+      if (cmd === "get_build_history") return Promise.resolve([]);
+      return Promise.resolve(undefined);
+    });
+
+    void runBuild();
+    await vi.advanceTimersByTimeAsync(0);
+    await cancelBuild();
+
+    handlers.get("build:complete")?.({
+      payload: {
+        success: false,
+        cancelled: true,
+        durationMs: 5_000,
+        errorCount: 0,
+        warningCount: 0,
+        task: "assembleDebug",
+      },
+    });
+
+    expect(buildState.phase).toBe("cancelled");
   });
 });

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -167,20 +167,24 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
   logBuildHeader(effectiveTask);
 
   // Create a promise that resolves when the build:complete event fires.
-  // A 5-minute timeout prevents the deploy from hanging forever if
-  // something goes wrong in the Rust on_exit callback.
+  // A timeout prevents the deploy from hanging forever if something goes
+  // wrong in the Rust on_exit callback. Uses the user-configured Gradle
+  // timeout (Settings → MCP → buildTimeoutSec) so long cold builds are not
+  // falsely failed while Gradle is still running.
+  const buildTimeoutSec = Math.max(60, settingsState.mcp?.buildTimeoutSec ?? 600);
   const buildComplete = new Promise<{ success: boolean; durationMs: number }>((resolve, reject) => {
     _resolveBuildComplete = resolve;
-    _buildCompleteTimer = setTimeout(
-      () => {
-        if (_resolveBuildComplete === resolve) {
-          _resolveBuildComplete = null;
-          _buildCompleteTimer = null;
-          reject(new Error("Build timed out waiting for build:complete event after 5 minutes."));
-        }
-      },
-      5 * 60 * 1000
-    );
+    _buildCompleteTimer = setTimeout(() => {
+      if (_resolveBuildComplete === resolve) {
+        _resolveBuildComplete = null;
+        _buildCompleteTimer = null;
+        reject(
+          new Error(
+            `Build timed out waiting for the build:complete event after ${buildTimeoutSec} seconds.`
+          )
+        );
+      }
+    }, buildTimeoutSec * 1000);
   });
 
   try {

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -59,6 +59,9 @@ export function resetBuildServiceForTests(): void {
   buildCompleteUnlisten?.();
   buildCompleteUnlisten = null;
   buildListenerInit = null;
+  _resolveBuildComplete = null;
+  clearBuildCompleteTimer();
+  _staleCompletionEventsExpected = 0;
 }
 
 async function registerBuildCompleteListener(): Promise<void> {
@@ -67,11 +70,10 @@ async function registerBuildCompleteListener(): Promise<void> {
     flushPendingLines();
 
     if (e.cancelled) {
-      if (_completionTimedOut) {
-        // Late event from the process we cancelled after the completion
-        // timeout — keep the timeout failure instead of flipping the UI to
-        // a plain user cancellation.
-        _completionTimedOut = false;
+      if (_staleCompletionEventsExpected > 0) {
+        // Late event from a process we killed after a completion timeout —
+        // absorb it so it cannot flip the UI to a plain user cancellation.
+        _staleCompletionEventsExpected--;
       } else {
         // Build was explicitly cancelled by the user — use dedicated cancelled phase.
         cancelBuildState();
@@ -111,11 +113,19 @@ async function registerBuildCompleteListener(): Promise<void> {
 let _resolveBuildComplete: ((result: { success: boolean; durationMs: number }) => void) | null =
   null;
 let _buildCompleteTimer: ReturnType<typeof setTimeout> | null = null;
-// Set when the completion timer fired and we cancelled the still-running
-// Gradle process. The process exit then emits a late `build:complete`
-// with `cancelled: true`; the listener must not let it overwrite the
-// timeout failure already shown to the user.
-let _completionTimedOut = false;
+/**
+ * Number of completion events still expected from Gradle processes we
+ * killed after a completion timeout. Each timeout increments this; the
+ * listener consumes one cancelled event per count instead of treating it
+ * as a genuine cancellation.
+ *
+ * This is deliberately NOT reset when a new build starts: the killed
+ * process's completion event can arrive after a later build has begun
+ * (slow process death), and events are delivered in order, so consuming
+ * them FIFO guarantees each stale event is absorbed before any genuine
+ * user cancellation of a subsequent build is processed.
+ */
+let _staleCompletionEventsExpected = 0;
 
 function clearBuildCompleteTimer(): void {
   if (_buildCompleteTimer !== null) {
@@ -186,7 +196,6 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
   const buildTimeoutSec = Math.min(3600, Math.max(60, settingsState.mcp?.buildTimeoutSec ?? 600));
   const buildComplete = new Promise<{ success: boolean; durationMs: number }>((resolve, reject) => {
     _resolveBuildComplete = resolve;
-    _completionTimedOut = false;
     _buildCompleteTimer = setTimeout(() => {
       if (_resolveBuildComplete === resolve) {
         _resolveBuildComplete = null;
@@ -226,11 +235,11 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
   } catch (e) {
     clearBuildCompleteTimer();
     // The only rejection path is the completion timeout: Gradle is still
-    // running. Cancel it so the shared build slot is released. The flag
-    // stays set until the listener consumes the late cancelled
-    // build:complete emitted by the dying process (or the next build
-    // starts) so that event cannot overwrite the timeout failure.
-    _completionTimedOut = true;
+    // running. Cancel it so the shared build slot is released, and expect
+    // one stale cancelled completion event from the dying process — it may
+    // arrive after a later build has started, so this count persists until
+    // the listener consumes it.
+    _staleCompletionEventsExpected++;
     try {
       await cancelBuild();
     } catch (cancelErr) {

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -171,7 +171,7 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
   // wrong in the Rust on_exit callback. Uses the user-configured Gradle
   // timeout (Settings → MCP → buildTimeoutSec) so long cold builds are not
   // falsely failed while Gradle is still running.
-  const buildTimeoutSec = Math.max(60, settingsState.mcp?.buildTimeoutSec ?? 600);
+  const buildTimeoutSec = Math.min(3600, Math.max(60, settingsState.mcp?.buildTimeoutSec ?? 600));
   const buildComplete = new Promise<{ success: boolean; durationMs: number }>((resolve, reject) => {
     _resolveBuildComplete = resolve;
     _buildCompleteTimer = setTimeout(() => {
@@ -212,7 +212,14 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
     await buildComplete;
   } catch (e) {
     clearBuildCompleteTimer();
-    // Timeout or unexpected rejection.
+    // The only rejection path is the completion timeout: Gradle is still
+    // running. Cancel it so the shared build slot is released and no stale
+    // completion event can arrive later.
+    try {
+      await cancelBuild();
+    } catch (cancelErr) {
+      console.error("[build] Failed to cancel timed-out build:", formatError(cancelErr));
+    }
     const msg = formatError(e);
     addBuildLine({
       kind: "error",

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -67,8 +67,15 @@ async function registerBuildCompleteListener(): Promise<void> {
     flushPendingLines();
 
     if (e.cancelled) {
-      // Build was explicitly cancelled by the user — use dedicated cancelled phase.
-      cancelBuildState();
+      if (_completionTimedOut) {
+        // Late event from the process we cancelled after the completion
+        // timeout — keep the timeout failure instead of flipping the UI to
+        // a plain user cancellation.
+        _completionTimedOut = false;
+      } else {
+        // Build was explicitly cancelled by the user — use dedicated cancelled phase.
+        cancelBuildState();
+      }
     } else {
       setBuildResult({ success: e.success, durationMs: e.durationMs });
     }
@@ -104,6 +111,11 @@ async function registerBuildCompleteListener(): Promise<void> {
 let _resolveBuildComplete: ((result: { success: boolean; durationMs: number }) => void) | null =
   null;
 let _buildCompleteTimer: ReturnType<typeof setTimeout> | null = null;
+// Set when the completion timer fired and we cancelled the still-running
+// Gradle process. The process exit then emits a late `build:complete`
+// with `cancelled: true`; the listener must not let it overwrite the
+// timeout failure already shown to the user.
+let _completionTimedOut = false;
 
 function clearBuildCompleteTimer(): void {
   if (_buildCompleteTimer !== null) {
@@ -174,6 +186,7 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
   const buildTimeoutSec = Math.min(3600, Math.max(60, settingsState.mcp?.buildTimeoutSec ?? 600));
   const buildComplete = new Promise<{ success: boolean; durationMs: number }>((resolve, reject) => {
     _resolveBuildComplete = resolve;
+    _completionTimedOut = false;
     _buildCompleteTimer = setTimeout(() => {
       if (_resolveBuildComplete === resolve) {
         _resolveBuildComplete = null;
@@ -213,8 +226,11 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
   } catch (e) {
     clearBuildCompleteTimer();
     // The only rejection path is the completion timeout: Gradle is still
-    // running. Cancel it so the shared build slot is released and no stale
-    // completion event can arrive later.
+    // running. Cancel it so the shared build slot is released. The flag
+    // stays set until the listener consumes the late cancelled
+    // build:complete emitted by the dying process (or the next build
+    // starts) so that event cannot overwrite the timeout failure.
+    _completionTimedOut = true;
     try {
       await cancelBuild();
     } catch (cancelErr) {

--- a/src/stores/build.store.test.ts
+++ b/src/stores/build.store.test.ts
@@ -81,6 +81,24 @@ describe("build.store", () => {
     expect(buildState.errors[0].line).toBe(10);
   });
 
+  it("caps accumulated problems and drops the oldest entries", () => {
+    const total = 1500;
+    for (let i = 0; i < total; i++) {
+      addBuildLine({
+        kind: "error",
+        content: `error ${i}`,
+        file: null,
+        line: null,
+        col: null,
+      });
+    }
+    flushPendingLines();
+    expect(buildState.errors.length).toBeLessThanOrEqual(1000);
+    // The newest errors survive the cap.
+    const last = buildState.errors[buildState.errors.length - 1];
+    expect(last.message).toBe(`error ${total - 1}`);
+  });
+
   it("clearBuild resets to idle and empties log", () => {
     startBuild("assembleDebug");
     const line: BuildLine = { kind: "output", content: "hello", file: null, line: null, col: null };

--- a/src/stores/build.store.ts
+++ b/src/stores/build.store.ts
@@ -59,6 +59,13 @@ export { buildState };
 /** Dedicated log store for build output (capped at 10,000 lines). */
 export const buildLogStore: LogStore = createLogStore({ maxEntries: 10_000 });
 
+/**
+ * Cap for the Problems-tab error/warning arrays. A noisy build can emit
+ * thousands of diagnostic lines; beyond this cap the oldest entries are
+ * dropped (the full log remains available in `buildLogStore`).
+ */
+const MAX_PROBLEMS = 1_000;
+
 // ── Derived ───────────────────────────────────────────────────────────────────
 
 /** Live elapsed time in milliseconds (only meaningful while running). */
@@ -137,8 +144,15 @@ function _executePendingFlush(): void {
   if (errors.length > 0 || warnings.length > 0) {
     setBuildState(
       produce((s) => {
-        for (const l of errors) s.errors.push(_lineToError(l));
-        for (const l of warnings) s.warnings.push(_lineToError(l));
+        for (const l of errors) {
+          s.errors.push(_lineToError(l));
+        }
+        if (s.errors.length > MAX_PROBLEMS) s.errors.splice(0, s.errors.length - MAX_PROBLEMS);
+        for (const l of warnings) {
+          s.warnings.push(_lineToError(l));
+        }
+        if (s.warnings.length > MAX_PROBLEMS)
+          s.warnings.splice(0, s.warnings.length - MAX_PROBLEMS);
       })
     );
   }

--- a/src/stores/build.store.ts
+++ b/src/stores/build.store.ts
@@ -62,7 +62,7 @@ export const buildLogStore: LogStore = createLogStore({ maxEntries: 10_000 });
 /**
  * Cap for the Problems-tab error/warning arrays. A noisy build can emit
  * thousands of diagnostic lines; beyond this cap the oldest entries are
- * dropped (the full log remains available in `buildLogStore`).
+ * dropped (the build log retains up to 10,000 entries in `buildLogStore`).
  */
 const MAX_PROBLEMS = 1_000;
 

--- a/src/stores/settings.store.flush.test.ts
+++ b/src/stores/settings.store.flush.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as tauriApi from "@/lib/tauri-api";
+import { updateSetting, flushPendingSettingsSave } from "@/stores/settings.store";
+
+// Suite lives in its own file because the store's debounce timer and
+// in-flight save are module-level state: sharing a file with suites that use
+// real timers lets their stray saves leak into these fake-timer tests.
+describe("flushPendingSettingsSave", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+    // Drain any debounced save left pending so each test starts from an
+    // idle timer regardless of execution order.
+    await flushPendingSettingsSave();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is a no-op when no save is pending", async () => {
+    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
+
+    await flushPendingSettingsSave();
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+
+  it("persists settings when the debounce window elapses", async () => {
+    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
+
+    updateSetting("appearance", "uiFontSize", 18);
+    expect(saveSpy).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy.mock.calls[0]?.[0].appearance.uiFontSize).toBe(18);
+
+    // Restore for subsequent tests.
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+  });
+
+  it("saves immediately instead of waiting for the debounce window", async () => {
+    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
+
+    updateSetting("appearance", "uiFontSize", 16);
+    await flushPendingSettingsSave();
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    // Restore state and drain the (now-cancelled) debounce timer.
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+    expect(saveSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("awaits an in-flight debounce save instead of returning early", async () => {
+    let resolveSave!: () => void;
+    // Only the FIRST call hangs on a manually-resolved promise; later calls
+    // (e.g. the trailing restore flush) resolve immediately.
+    const saveSpy = vi
+      .spyOn(tauriApi, "saveSettings")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve;
+          })
+      )
+      .mockResolvedValue(undefined);
+
+    // The debounce timer fires and puts a save in flight.
+    updateSetting("appearance", "uiFontSize", 17);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    // A close-time flush must NOT complete while that save is unresolved —
+    // otherwise shutdown could acknowledge Rust before the write lands.
+    let flushed = false;
+    const flushPromise = flushPendingSettingsSave().then(() => {
+      flushed = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(flushed).toBe(false);
+
+    resolveSave();
+    await flushPromise;
+    expect(flushed).toBe(true);
+
+    // Restore for subsequent tests.
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+  });
+
+  it("persists changes made while an earlier save is still in flight", async () => {
+    let resolveFirstSave!: () => void;
+    const saveSpy = vi
+      .spyOn(tauriApi, "saveSettings")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirstSave = resolve;
+          })
+      )
+      .mockResolvedValue(undefined);
+
+    // First change: timer fires, save #1 in flight.
+    updateSetting("appearance", "uiFontSize", 17);
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Second change arrives before save #1 finished; close-time flush must
+    // persist it too instead of dropping it with the cancelled timer.
+    updateSetting("appearance", "uiFontSize", 19);
+    const flushPromise = flushPendingSettingsSave();
+
+    resolveFirstSave();
+    await flushPromise;
+
+    expect(saveSpy).toHaveBeenCalledTimes(2);
+    expect(saveSpy.mock.calls[1]?.[0].appearance.uiFontSize).toBe(19);
+
+    // Restore for subsequent tests.
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+  });
+
+  it("propagates save failures through the toast path without throwing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(tauriApi, "saveSettings").mockRejectedValue(new Error("disk full"));
+
+    updateSetting("appearance", "uiFontSize", 16);
+    await expect(flushPendingSettingsSave()).resolves.toBeUndefined();
+
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/stores/settings.store.flush.test.ts
+++ b/src/stores/settings.store.flush.test.ts
@@ -122,6 +122,39 @@ describe("flushPendingSettingsSave", () => {
     await flushPendingSettingsSave();
   });
 
+  it("serializes overlapping saves so an older snapshot cannot land last", async () => {
+    let resolveFirst!: () => void;
+    const saveSpy = vi
+      .spyOn(tauriApi, "saveSettings")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockResolvedValue(undefined);
+
+    // Save #1 in flight (debounce fired).
+    updateSetting("appearance", "uiFontSize", 17);
+    await vi.advanceTimersByTimeAsync(500);
+
+    // A second debounce fires while #1 is still in flight: it must queue
+    // behind #1, not start concurrently.
+    updateSetting("appearance", "uiFontSize", 19);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    // Completing #1 lets the queued save run with the newest state.
+    resolveFirst();
+    await flushPendingSettingsSave();
+    expect(saveSpy).toHaveBeenCalledTimes(2);
+    expect(saveSpy.mock.calls[1]?.[0].appearance.uiFontSize).toBe(19);
+
+    // Restore for subsequent tests.
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+  });
+
   it("propagates save failures through the toast path without throwing", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(tauriApi, "saveSettings").mockRejectedValue(new Error("disk full"));

--- a/src/stores/settings.store.test.ts
+++ b/src/stores/settings.store.test.ts
@@ -118,8 +118,30 @@ describe("settings.store", () => {
 });
 
 describe("flushPendingSettingsSave", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.restoreAllMocks();
+    vi.useFakeTimers();
+    // Drain any debounced save left pending by another test so each test
+    // starts from an idle timer regardless of execution order.
+    await flushPendingSettingsSave();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("persists settings when the debounce window elapses", async () => {
+    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
+
+    updateSetting("appearance", "uiFontSize", 18);
+    expect(saveSpy).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+    expect(saveSpy.mock.calls[0]?.[0].appearance.uiFontSize).toBe(18);
+
+    // Restore for subsequent tests.
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
   });
 
   it("saves immediately instead of waiting for the debounce window", async () => {
@@ -134,7 +156,6 @@ describe("flushPendingSettingsSave", () => {
     updateSetting("appearance", "uiFontSize", 12);
     await flushPendingSettingsSave();
     expect(saveSpy).toHaveBeenCalledTimes(2);
-    vi.restoreAllMocks();
   });
 
   it("is a no-op when no save is pending", async () => {
@@ -142,7 +163,6 @@ describe("flushPendingSettingsSave", () => {
 
     await flushPendingSettingsSave();
     expect(saveSpy).not.toHaveBeenCalled();
-    vi.restoreAllMocks();
   });
 
   it("propagates save failures through the toast path without throwing", async () => {
@@ -155,7 +175,6 @@ describe("flushPendingSettingsSave", () => {
     updateSetting("appearance", "uiFontSize", 12);
     await flushPendingSettingsSave();
     expect(errorSpy).toHaveBeenCalled();
-    vi.restoreAllMocks();
   });
 });
 

--- a/src/stores/settings.store.test.ts
+++ b/src/stores/settings.store.test.ts
@@ -7,6 +7,7 @@ import {
   loadSettings,
   getDefaults,
   setAppSetting,
+  flushPendingSettingsSave,
 } from "@/stores/settings.store";
 
 describe("settings.store", () => {
@@ -113,6 +114,48 @@ describe("settings.store", () => {
     expect(settingsState.onboardingCompleted).toBe(true);
     setAppSetting("onboardingCompleted", false);
     expect(settingsState.onboardingCompleted).toBe(false);
+  });
+});
+
+describe("flushPendingSettingsSave", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("saves immediately instead of waiting for the debounce window", async () => {
+    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
+
+    updateSetting("appearance", "uiFontSize", 16);
+    await flushPendingSettingsSave();
+
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    // Restore state and drain the (now-cancelled) debounce timer.
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+    expect(saveSpy).toHaveBeenCalledTimes(2);
+    vi.restoreAllMocks();
+  });
+
+  it("is a no-op when no save is pending", async () => {
+    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
+
+    await flushPendingSettingsSave();
+    expect(saveSpy).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+
+  it("propagates save failures through the toast path without throwing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(tauriApi, "saveSettings").mockRejectedValue(new Error("disk full"));
+
+    updateSetting("appearance", "uiFontSize", 16);
+    await expect(flushPendingSettingsSave()).resolves.toBeUndefined();
+
+    updateSetting("appearance", "uiFontSize", 12);
+    await flushPendingSettingsSave();
+    expect(errorSpy).toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 });
 

--- a/src/stores/settings.store.test.ts
+++ b/src/stores/settings.store.test.ts
@@ -7,7 +7,6 @@ import {
   loadSettings,
   getDefaults,
   setAppSetting,
-  flushPendingSettingsSave,
 } from "@/stores/settings.store";
 
 describe("settings.store", () => {
@@ -31,9 +30,8 @@ describe("settings.store", () => {
   });
 
   it("has correct LSP defaults", () => {
-    const d = getDefaults();
-    expect(d.lsp.logLevel).toBe("INFO");
-    expect(d.lsp.requestTimeoutSec).toBe(30);
+    expect(getDefaults().lsp.logLevel).toBe("INFO");
+    expect(getDefaults().lsp.requestTimeoutSec).toBe(30);
   });
 
   it("has follow-tail defaults for logcat and build log", () => {
@@ -114,67 +112,6 @@ describe("settings.store", () => {
     expect(settingsState.onboardingCompleted).toBe(true);
     setAppSetting("onboardingCompleted", false);
     expect(settingsState.onboardingCompleted).toBe(false);
-  });
-});
-
-describe("flushPendingSettingsSave", () => {
-  beforeEach(async () => {
-    vi.restoreAllMocks();
-    vi.useFakeTimers();
-    // Drain any debounced save left pending by another test so each test
-    // starts from an idle timer regardless of execution order.
-    await flushPendingSettingsSave();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("persists settings when the debounce window elapses", async () => {
-    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
-
-    updateSetting("appearance", "uiFontSize", 18);
-    expect(saveSpy).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(500);
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-    expect(saveSpy.mock.calls[0]?.[0].appearance.uiFontSize).toBe(18);
-
-    // Restore for subsequent tests.
-    updateSetting("appearance", "uiFontSize", 12);
-    await flushPendingSettingsSave();
-  });
-
-  it("saves immediately instead of waiting for the debounce window", async () => {
-    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
-
-    updateSetting("appearance", "uiFontSize", 16);
-    await flushPendingSettingsSave();
-
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-
-    // Restore state and drain the (now-cancelled) debounce timer.
-    updateSetting("appearance", "uiFontSize", 12);
-    await flushPendingSettingsSave();
-    expect(saveSpy).toHaveBeenCalledTimes(2);
-  });
-
-  it("is a no-op when no save is pending", async () => {
-    const saveSpy = vi.spyOn(tauriApi, "saveSettings").mockResolvedValue(undefined);
-
-    await flushPendingSettingsSave();
-    expect(saveSpy).not.toHaveBeenCalled();
-  });
-
-  it("propagates save failures through the toast path without throwing", async () => {
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(tauriApi, "saveSettings").mockRejectedValue(new Error("disk full"));
-
-    updateSetting("appearance", "uiFontSize", 16);
-    await expect(flushPendingSettingsSave()).resolves.toBeUndefined();
-
-    updateSetting("appearance", "uiFontSize", 12);
-    await flushPendingSettingsSave();
-    expect(errorSpy).toHaveBeenCalled();
   });
 });
 

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -61,21 +61,33 @@ const [settingsState, setSettingsState] = createStore<AppSettings>(
 export { settingsState };
 
 let saveTimer: ReturnType<typeof setTimeout> | undefined;
-/** Save request currently in flight, if any. Never rejects. */
+/**
+ * Tail of the save chain: the most recent persist request, which transitively
+ * awaits every earlier one. Null when no save has been requested or the last
+ * chain entry has settled. Never rejects.
+ */
 let activeSave: Promise<void> | null = null;
 
 function persistNow(): Promise<void> {
-  const save = saveSettingsIpc(settingsState)
-    .catch((err) => {
+  const prev = activeSave;
+  const save = (async () => {
+    // Serialize behind the previous save so an older snapshot can never
+    // land on disk after a newer one (IPC completion order is not
+    // guaranteed), and so a second debounce firing mid-save cannot race.
+    await prev;
+    try {
+      await saveSettingsIpc(settingsState);
+    } catch (err) {
       const msg = formatError(err);
       console.error("Failed to save settings:", msg);
       showToast(`Settings could not be saved: ${msg}`, "error");
-    })
-    .finally(() => {
-      if (activeSave === save) activeSave = null;
-    });
-  activeSave = save;
-  return save;
+    }
+  })();
+  const tracked = save.finally(() => {
+    if (activeSave === tracked) activeSave = null;
+  });
+  activeSave = tracked;
+  return tracked;
 }
 
 function scheduleSave() {
@@ -89,10 +101,10 @@ function scheduleSave() {
 /**
  * Ensure every settings change made so far has been persisted.
  *
- * Waits out any save already in flight, then persists whatever change armed
- * a debounce timer meanwhile (possibly none). Called on window close so the
- * Rust shutdown handler's acknowledgement (notify_settings_flushed) is only
- * sent after the final write has actually completed.
+ * Waits out the whole save chain (saves are serialized), then persists
+ * whatever change armed a debounce timer meanwhile (possibly none). Called
+ * on window close so the Rust shutdown handler's acknowledgement
+ * (notify_settings_flushed) is only sent after the final write completed.
  */
 export async function flushPendingSettingsSave(): Promise<void> {
   for (;;) {

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -65,7 +65,6 @@ let saveTimer: ReturnType<typeof setTimeout> | undefined;
 function scheduleSave() {
   if (saveTimer) clearTimeout(saveTimer);
   saveTimer = setTimeout(async () => {
-    saveTimer = undefined;
     await flushPendingSettingsSave();
   }, 500);
 }

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -65,14 +65,27 @@ let saveTimer: ReturnType<typeof setTimeout> | undefined;
 function scheduleSave() {
   if (saveTimer) clearTimeout(saveTimer);
   saveTimer = setTimeout(async () => {
-    try {
-      await saveSettingsIpc(settingsState);
-    } catch (err) {
-      const msg = formatError(err);
-      console.error("Failed to save settings:", msg);
-      showToast(`Settings could not be saved: ${msg}`, "error");
-    }
+    saveTimer = undefined;
+    await flushPendingSettingsSave();
   }, 500);
+}
+
+/**
+ * Immediately persist any pending debounced settings change.
+ * Called on window close so a setting changed within the 500 ms debounce
+ * window is not silently lost when the app quits.
+ */
+export async function flushPendingSettingsSave(): Promise<void> {
+  if (saveTimer === undefined) return;
+  clearTimeout(saveTimer);
+  saveTimer = undefined;
+  try {
+    await saveSettingsIpc(settingsState);
+  } catch (err) {
+    const msg = formatError(err);
+    console.error("Failed to save settings:", msg);
+    showToast(`Settings could not be saved: ${msg}`, "error");
+  }
 }
 
 export async function loadSettings(): Promise<void> {

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -61,29 +61,50 @@ const [settingsState, setSettingsState] = createStore<AppSettings>(
 export { settingsState };
 
 let saveTimer: ReturnType<typeof setTimeout> | undefined;
+/** Save request currently in flight, if any. Never rejects. */
+let activeSave: Promise<void> | null = null;
+
+function persistNow(): Promise<void> {
+  const save = saveSettingsIpc(settingsState)
+    .catch((err) => {
+      const msg = formatError(err);
+      console.error("Failed to save settings:", msg);
+      showToast(`Settings could not be saved: ${msg}`, "error");
+    })
+    .finally(() => {
+      if (activeSave === save) activeSave = null;
+    });
+  activeSave = save;
+  return save;
+}
 
 function scheduleSave() {
   if (saveTimer) clearTimeout(saveTimer);
-  saveTimer = setTimeout(async () => {
-    await flushPendingSettingsSave();
+  saveTimer = setTimeout(() => {
+    saveTimer = undefined;
+    void persistNow();
   }, 500);
 }
 
 /**
- * Immediately persist any pending debounced settings change.
- * Called on window close so a setting changed within the 500 ms debounce
- * window is not silently lost when the app quits.
+ * Ensure every settings change made so far has been persisted.
+ *
+ * Waits out any save already in flight, then persists whatever change armed
+ * a debounce timer meanwhile (possibly none). Called on window close so the
+ * Rust shutdown handler's acknowledgement (notify_settings_flushed) is only
+ * sent after the final write has actually completed.
  */
 export async function flushPendingSettingsSave(): Promise<void> {
-  if (saveTimer === undefined) return;
-  clearTimeout(saveTimer);
-  saveTimer = undefined;
-  try {
-    await saveSettingsIpc(settingsState);
-  } catch (err) {
-    const msg = formatError(err);
-    console.error("Failed to save settings:", msg);
-    showToast(`Settings could not be saved: ${msg}`, "error");
+  for (;;) {
+    if (activeSave) {
+      await activeSave;
+      continue;
+    }
+    if (saveTimer === undefined) return;
+    clearTimeout(saveTimer);
+    saveTimer = undefined;
+    await persistNow();
+    // Loop: another change may have armed a timer while we persisted.
   }
 }
 

--- a/src/test/mock-backend/settings.ts
+++ b/src/test/mock-backend/settings.ts
@@ -61,6 +61,7 @@ export function settingsHandlers(): Record<string, (args: unknown) => unknown> {
       const { settings } = args as { settings: AppSettings };
       currentSettings = { ...settings };
     },
+    notify_settings_flushed: () => undefined,
     get_default_settings: () => ({ ...defaultSettings }),
     reset_settings: () => {
       currentSettings = { ...defaultSettings };


### PR DESCRIPTION
## Summary

Five verified defects fixed, each grounded in code review findings:

### Bugs
1. **UTF-8 char-boundary panic in MCP activity summary** — `mcp_server.rs` truncated tool-result text with `&s[..120]`, which panics when byte 120 falls inside a multi-byte character. Any tool returning emoji/CJK output (plausible via logcat/app text) would tear down the MCP session. Replaced with a boundary-safe `truncate_at_char_boundary()` helper.
2. **`stop_app` reported failure as success** — only spawn errors were mapped; non-zero adb exit (device offline/unauthorized) returned `Ok(())`. Now checks `status.success()` and includes captured output + exit code in the error, matching sibling functions.

### Gaps
3. **Debounced settings save lost on quick quit** — saves are debounced 500 ms but nothing flushed them at shutdown; the `onCloseRequested` handler was an empty no-op. Added exported `flushPendingSettingsSave()` and wired it into the close handler.
4. **Uncapped Problems arrays** — `buildState.errors`/`.warnings` grew without bound during noisy builds, violating the bounded-collections invariant (sibling log store is capped at 10k). Both are now capped at 1000 with oldest-dropped; full log remains available.
5. **Hardcoded 5-minute build timeout** — the frontend abandoned still-running Gradle builds after 5 min regardless of settings (`buildTimeoutSec` defaults to 600 s), enabling false failures and concurrent daemon invocations. The completion timeout now uses the configured value (clamped ≥60 s).

## Testing

- New Rust unit test: boundary-safe truncation (CJK, 4-byte emoji, exact-boundary cuts)
- New store tests: flush-on-close semantics (immediate save, idle no-op, failure path)
- New store test: problems cap drops oldest, keeps newest
- New service test: fake-timer proof that timeout fires at configured `buildTimeoutSec`

\`\`\`
npm test                  # 1174 passed (115 files)
cargo test                # all suites pass
npm run lint              # clean
npm run typescript:check  # clean
\`\`\`

No bindings changes (no Rust model types touched).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes five stability bugs across MCP server, ADB, settings shutdown, Problems list, and build flow. Previously: UTF‑8 truncation panicked, stop_app misreported failures, debounced or in‑flight settings saves were lost or reordered on quit, Problems lists grew unbounded, and the UI ignored the configured build timeout. Now: truncation is UTF‑8‑safe, stop_app fails on non‑zero exit with context, shutdown serializes and flushes settings within one 3 s budget, Problems cap at 1000, and builds honor the clamped 60–3600 s timeout, cancel Gradle on timeout, and preserve the timeout failure.

- MCP server: truncate activity summaries at character boundaries to avoid panics on multi‑byte output.
- ADB: stop_app checks exit status and returns an error with stdout/stderr and exit code on failure.
- Settings: add flushPendingSettingsSave(); on close, prevent default, await any in‑flight save, persist pending changes, then call notify_settings_flushed; Rust waits briefly (within a single 3 s shutdown budget) before cancelling builds and tearing down so debounced and in‑flight saves are not lost; overlapping saves are serialized so an older snapshot cannot land after a newer one.
- Build store: cap errors and warnings at 1000, dropping the oldest; full output remains in the capped log store.
- Build service: honor settings.mcp.buildTimeoutSec (clamped 60–3600 s); on timeout, cancel the running Gradle process and absorb late cancelled completion events (even across subsequent builds) so the UI keeps the timeout failure; genuine user cancellations still show as cancelled.

<sup>Written for commit bed7e8a9b5d9f699946084095958d6ca845b9ec2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thiagodmont/keynobi/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

