### PR TITLE
fix: monotonic logcat IDs, wipe false success, dead auto-install setting, variant persistence, capped error buffer

### DIFF
--- a/src-tauri/src/commands/build.rs
+++ b/src-tauri/src/commands/build.rs
@@ -115,13 +115,16 @@ pub async fn run_gradle_task(
                             BuildErrorSeverity::Warning
                         };
                         if let Ok(mut errs) = errors_buf.lock() {
-                            errs.push(BuildError {
-                                message: line.content.clone(),
-                                file: line.file.clone(),
-                                line: line.line,
-                                col: line.col,
-                                severity,
-                            });
+                            build_runner::push_build_error(
+                                &mut errs,
+                                BuildError {
+                                    message: line.content.clone(),
+                                    file: line.file.clone(),
+                                    line: line.line,
+                                    col: line.col,
+                                    severity,
+                                },
+                            );
                         }
                     }
 

--- a/src-tauri/src/commands/variant.rs
+++ b/src-tauri/src/commands/variant.rs
@@ -160,8 +160,16 @@ pub async fn get_variants_from_gradle(fs_state: State<'_, FsState>) -> Result<Va
         .to_string())
 }
 
-/// Set the active build variant (no-op settings write — variant is managed by the variant store).
+/// Persist the active build variant as `last_build_variant` for the current
+/// project so it is restored on the next session — the same state the MCP
+/// `set_active_variant` tool writes (keyed by gradle root). No-op success if
+/// no project is open or the project is not yet in `recent_projects`.
 #[tauri::command]
-pub async fn set_active_variant(_variant: String) -> Result<(), String> {
-    Ok(())
+pub async fn set_active_variant(
+    variant: String,
+    fs_state: State<'_, FsState>,
+) -> Result<(), String> {
+    let gradle_root = resolve_gradle_root(&fs_state).await?;
+    let project_path = gradle_root.to_string_lossy().into_owned();
+    settings_manager::set_active_variant_for_project(&project_path, &variant)
 }

--- a/src-tauri/src/commands/variant.rs
+++ b/src-tauri/src/commands/variant.rs
@@ -11,12 +11,21 @@ use tauri::State;
 /// this command indefinitely.
 const GRADLE_QUERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
-async fn resolve_gradle_root(fs_state: &State<'_, FsState>) -> Result<PathBuf, String> {
+/// Resolve the gradle root for the active project, or `None` if no project
+/// is open. Callers that want to treat "no project" as a normal outcome
+/// (rather than an error) should use this instead of string-matching
+/// [`resolve_gradle_root`]'s error.
+async fn resolve_gradle_root_opt(fs_state: &State<'_, FsState>) -> Option<PathBuf> {
     let fs = fs_state.0.lock().await;
     fs.gradle_root
         .as_ref()
         .or(fs.project_root.as_ref())
         .cloned()
+}
+
+async fn resolve_gradle_root(fs_state: &State<'_, FsState>) -> Result<PathBuf, String> {
+    resolve_gradle_root_opt(fs_state)
+        .await
         .ok_or_else(|| "No project open".to_string())
 }
 
@@ -171,10 +180,8 @@ pub async fn set_active_variant(
 ) -> Result<(), String> {
     // No project open — nothing to persist, which matches the documented
     // no-op behavior rather than surfacing an error to the UI.
-    let gradle_root = match resolve_gradle_root(&fs_state).await {
-        Ok(root) => root,
-        Err(error) if error == "No project open" => return Ok(()),
-        Err(error) => return Err(error),
+    let Some(gradle_root) = resolve_gradle_root_opt(&fs_state).await else {
+        return Ok(());
     };
     let project_path = gradle_root.to_string_lossy().into_owned();
     settings_manager::set_active_variant_for_project(&project_path, &variant)

--- a/src-tauri/src/commands/variant.rs
+++ b/src-tauri/src/commands/variant.rs
@@ -169,7 +169,13 @@ pub async fn set_active_variant(
     variant: String,
     fs_state: State<'_, FsState>,
 ) -> Result<(), String> {
-    let gradle_root = resolve_gradle_root(&fs_state).await?;
+    // No project open — nothing to persist, which matches the documented
+    // no-op behavior rather than surfacing an error to the UI.
+    let gradle_root = match resolve_gradle_root(&fs_state).await {
+        Ok(root) => root,
+        Err(error) if error == "No project open" => return Ok(()),
+        Err(error) => return Err(error),
+    };
     let project_path = gradle_root.to_string_lossy().into_owned();
     settings_manager::set_active_variant_for_project(&project_path, &variant)
 }

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -678,10 +678,7 @@ fn newly_online_emulator_serial(before: &[Device], after: &[Device]) -> Option<S
 ///
 /// Returns ALL matching serials — an unrelated emulator becoming online before
 /// the wiped AVD must not shadow it.
-fn newly_online_emulator_serials_since(
-    before: &[Device],
-    after: &[Device],
-) -> Vec<String> {
+fn newly_online_emulator_serials_since(before: &[Device], after: &[Device]) -> Vec<String> {
     let before_online: std::collections::HashSet<&str> = before
         .iter()
         .filter(|d| {
@@ -1054,6 +1051,10 @@ async fn emulator_avd_name(adb: &Path, serial: &str) -> Option<String> {
         EMU_AVD_NAME_TIMEOUT,
         tokio::process::Command::new(adb)
             .args(["-s", serial, "emu", "avd", "name"])
+            // Kill the adb process if the timeout drops the pending output
+            // future — otherwise a stuck console leaks one adb process per
+            // retry.
+            .kill_on_drop(true)
             .output(),
     )
     .await
@@ -1636,7 +1637,11 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
                 DeviceKind::Emulator,
                 DeviceConnectionState::Online,
             ),
-            test_device("ABC123", DeviceKind::Physical, DeviceConnectionState::Online),
+            test_device(
+                "ABC123",
+                DeviceKind::Physical,
+                DeviceConnectionState::Online,
+            ),
         ];
 
         assert_eq!(

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -668,6 +668,33 @@ fn newly_online_emulator_serial(before: &[Device], after: &[Device]) -> Option<S
         .map(|d| d.serial.clone())
 }
 
+/// Emulator serials online in `after` that were NOT online in `before`.
+///
+/// Unlike [`newly_online_emulator_serial`], this also counts a serial that was
+/// listed (offline) before and came back online. This matters for
+/// `wipe_avd_data`: a relaunched emulator typically reacquires its previous
+/// console port (`emulator-5554`), so "absent from the before list" would
+/// never match and the wait would time out on a successful wipe.
+fn newly_online_emulator_since(before: &[Device], after: &[Device]) -> Option<String> {
+    let before_online: std::collections::HashSet<&str> = before
+        .iter()
+        .filter(|d| {
+            d.device_kind == DeviceKind::Emulator
+                && d.connection_state == DeviceConnectionState::Online
+        })
+        .map(|d| d.serial.as_str())
+        .collect();
+
+    after
+        .iter()
+        .find(|d| {
+            d.device_kind == DeviceKind::Emulator
+                && d.connection_state == DeviceConnectionState::Online
+                && !before_online.contains(d.serial.as_str())
+        })
+        .map(|d| d.serial.clone())
+}
+
 /// Kill an emulator via `adb -s <serial> emu kill`.
 pub async fn stop_emulator(adb: &Path, serial: &str) -> Result<(), String> {
     Command::new(adb)
@@ -1022,14 +1049,16 @@ pub async fn wipe_avd_data(emulator_bin: &Path, adb: &Path, avd_name: &str) -> R
         .spawn()
         .map_err(|e| format!("Failed to start emulator: {e}"))?;
 
-    // Wait up to 30s for the wiped AVD's emulator to come online. Diff against
-    // the pre-spawn device list so an unrelated emulator that was already
-    // online cannot satisfy the wait (mirrors launch_emulator).
+    // Wait up to 30s for the wiped AVD's emulator to come online. Compare
+    // online-state against the pre-spawn snapshot so an unrelated emulator
+    // that was already online cannot satisfy the wait, while a relaunched
+    // emulator that reacquired its previous serial still counts (see
+    // `newly_online_emulator_since`).
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_secs(2)).await;
         let devices = list_devices(adb).await;
-        if newly_online_emulator_serial(&before, &devices).is_some() {
+        if newly_online_emulator_since(&before, &devices).is_some() {
             return Ok(());
         }
     }
@@ -1476,5 +1505,92 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
         assert!(validate_avd_name("-bad").is_err());
         assert!(validate_device_profile_id("pixel 8").is_err());
         assert!(validate_system_image_id("system-images;android-35;google_apis;$(bad)").is_err());
+    }
+
+    #[test]
+    fn newly_online_emulator_since_detects_brand_new_serial() {
+        let before = vec![test_device(
+            "emulator-5554",
+            DeviceKind::Emulator,
+            DeviceConnectionState::Online,
+        )];
+        let after = vec![
+            test_device(
+                "emulator-5554",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+            test_device(
+                "emulator-5556",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+        ];
+
+        assert_eq!(
+            newly_online_emulator_since(&before, &after),
+            Some("emulator-5556".to_string())
+        );
+    }
+
+    #[test]
+    fn newly_online_emulator_since_counts_serial_that_returned_from_offline() {
+        // Wiped AVD relaunch: the emulator reacquires its previous console
+        // port, so the serial exists in both snapshots but was offline before.
+        let before = vec![
+            test_device(
+                "emulator-5554",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Offline,
+            ),
+            test_device(
+                "emulator-5556",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+        ];
+        let after = vec![
+            test_device(
+                "emulator-5554",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+            test_device(
+                "emulator-5556",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+        ];
+
+        assert_eq!(
+            newly_online_emulator_since(&before, &after),
+            Some("emulator-5554".to_string())
+        );
+    }
+
+    #[test]
+    fn newly_online_emulator_since_ignores_already_online_emulators() {
+        // The bug this guards against: another emulator that was already
+        // online must not satisfy the wipe wait.
+        let before = vec![test_device(
+            "emulator-5554",
+            DeviceKind::Emulator,
+            DeviceConnectionState::Online,
+        )];
+        let after = before.clone();
+
+        assert_eq!(newly_online_emulator_since(&before, &after), None);
+    }
+
+    #[test]
+    fn newly_online_emulator_since_ignores_non_emulator_devices() {
+        let before: Vec<Device> = Vec::new();
+        let after = vec![test_device(
+            "ABC123",
+            DeviceKind::Physical,
+            DeviceConnectionState::Online,
+        )];
+
+        assert_eq!(newly_online_emulator_since(&before, &after), None);
     }
 }

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -1007,6 +1007,8 @@ pub async fn delete_avd(avdmanager: &Path, name: &str) -> Result<(), String> {
 
 /// Wipe an emulator's user data by relaunching it with `-wipe-data`.
 pub async fn wipe_avd_data(emulator_bin: &Path, adb: &Path, avd_name: &str) -> Result<(), String> {
+    let before = list_devices(adb).await;
+
     tokio::process::Command::new(emulator_bin)
         .args([
             &format!("@{avd_name}"),
@@ -1020,15 +1022,14 @@ pub async fn wipe_avd_data(emulator_bin: &Path, adb: &Path, avd_name: &str) -> R
         .spawn()
         .map_err(|e| format!("Failed to start emulator: {e}"))?;
 
-    // Wait up to 30s for it to come online.
+    // Wait up to 30s for the wiped AVD's emulator to come online. Diff against
+    // the pre-spawn device list so an unrelated emulator that was already
+    // online cannot satisfy the wait (mirrors launch_emulator).
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_secs(2)).await;
         let devices = list_devices(adb).await;
-        if devices.iter().any(|d| {
-            d.device_kind == DeviceKind::Emulator
-                && d.connection_state == DeviceConnectionState::Online
-        }) {
+        if newly_online_emulator_serial(&before, &devices).is_some() {
             return Ok(());
         }
     }

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -1032,6 +1032,27 @@ pub async fn delete_avd(avdmanager: &Path, name: &str) -> Result<(), String> {
     }
 }
 
+/// Query an emulator's AVD identity via `adb -s <serial> emu avd name`.
+/// Returns the AVD name (first stdout line), or `None` if the query fails —
+/// e.g. the emulator is still booting or the console is not accepting
+/// connections yet. Callers should treat `None` as "not confirmed yet" and
+/// keep polling rather than as a hard failure.
+async fn emulator_avd_name(adb: &Path, serial: &str) -> Option<String> {
+    let output = tokio::process::Command::new(adb)
+        .args(["-s", serial, "emu", "avd", "name"])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(|line| line.trim().to_string())
+        .filter(|name| !name.is_empty())
+}
+
 /// Wipe an emulator's user data by relaunching it with `-wipe-data`.
 pub async fn wipe_avd_data(emulator_bin: &Path, adb: &Path, avd_name: &str) -> Result<(), String> {
     let before = list_devices(adb).await;
@@ -1051,14 +1072,17 @@ pub async fn wipe_avd_data(emulator_bin: &Path, adb: &Path, avd_name: &str) -> R
 
     // Wait up to 30s for the wiped AVD's emulator to come online. Compare
     // online-state against the pre-spawn snapshot so an unrelated emulator
-    // that was already online cannot satisfy the wait, while a relaunched
-    // emulator that reacquired its previous serial still counts (see
-    // `newly_online_emulator_since`).
+    // that was already online cannot satisfy the wait, then confirm the
+    // candidate's AVD identity via `emu avd name` so an unrelated emulator
+    // that merely transitioned offline→online also cannot satisfy it.
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_secs(2)).await;
         let devices = list_devices(adb).await;
-        if newly_online_emulator_since(&before, &devices).is_some() {
+        let Some(serial) = newly_online_emulator_since(&before, &devices) else {
+            continue;
+        };
+        if emulator_avd_name(adb, &serial).await.as_deref() == Some(avd_name) {
             return Ok(());
         }
     }

--- a/src-tauri/src/services/adb_manager.rs
+++ b/src-tauri/src/services/adb_manager.rs
@@ -675,7 +675,13 @@ fn newly_online_emulator_serial(before: &[Device], after: &[Device]) -> Option<S
 /// `wipe_avd_data`: a relaunched emulator typically reacquires its previous
 /// console port (`emulator-5554`), so "absent from the before list" would
 /// never match and the wait would time out on a successful wipe.
-fn newly_online_emulator_since(before: &[Device], after: &[Device]) -> Option<String> {
+///
+/// Returns ALL matching serials — an unrelated emulator becoming online before
+/// the wiped AVD must not shadow it.
+fn newly_online_emulator_serials_since(
+    before: &[Device],
+    after: &[Device],
+) -> Vec<String> {
     let before_online: std::collections::HashSet<&str> = before
         .iter()
         .filter(|d| {
@@ -687,12 +693,13 @@ fn newly_online_emulator_since(before: &[Device], after: &[Device]) -> Option<St
 
     after
         .iter()
-        .find(|d| {
+        .filter(|d| {
             d.device_kind == DeviceKind::Emulator
                 && d.connection_state == DeviceConnectionState::Online
                 && !before_online.contains(d.serial.as_str())
         })
         .map(|d| d.serial.clone())
+        .collect()
 }
 
 /// Kill an emulator via `adb -s <serial> emu kill`.
@@ -1032,17 +1039,26 @@ pub async fn delete_avd(avdmanager: &Path, name: &str) -> Result<(), String> {
     }
 }
 
+/// Upper bound for one `emu avd name` console query. The wipe wait loop polls
+/// every 2s against a 30s deadline; a stuck console connection must not stall
+/// a single poll beyond this window.
+const EMU_AVD_NAME_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Query an emulator's AVD identity via `adb -s <serial> emu avd name`.
-/// Returns the AVD name (first stdout line), or `None` if the query fails —
-/// e.g. the emulator is still booting or the console is not accepting
-/// connections yet. Callers should treat `None` as "not confirmed yet" and
+/// Returns the AVD name (first stdout line), or `None` if the query fails or
+/// times out — e.g. the emulator is still booting or the console connection
+/// is stuck. Callers should treat `None` as "not confirmed yet" and
 /// keep polling rather than as a hard failure.
 async fn emulator_avd_name(adb: &Path, serial: &str) -> Option<String> {
-    let output = tokio::process::Command::new(adb)
-        .args(["-s", serial, "emu", "avd", "name"])
-        .output()
-        .await
-        .ok()?;
+    let output = tokio::time::timeout(
+        EMU_AVD_NAME_TIMEOUT,
+        tokio::process::Command::new(adb)
+            .args(["-s", serial, "emu", "avd", "name"])
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
     if !output.status.success() {
         return None;
     }
@@ -1072,18 +1088,29 @@ pub async fn wipe_avd_data(emulator_bin: &Path, adb: &Path, avd_name: &str) -> R
 
     // Wait up to 30s for the wiped AVD's emulator to come online. Compare
     // online-state against the pre-spawn snapshot so an unrelated emulator
-    // that was already online cannot satisfy the wait, then confirm the
+    // that was already online cannot satisfy the wait, then confirm each
     // candidate's AVD identity via `emu avd name` so an unrelated emulator
     // that merely transitioned offline→online also cannot satisfy it.
+    // Candidates whose identity does not match are remembered and skipped on
+    // later polls so they cannot shadow the wiped AVD.
+    let mut rejected_serials: std::collections::HashSet<String> = std::collections::HashSet::new();
     let deadline = std::time::Instant::now() + Duration::from_secs(30);
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_secs(2)).await;
         let devices = list_devices(adb).await;
-        let Some(serial) = newly_online_emulator_since(&before, &devices) else {
-            continue;
-        };
-        if emulator_avd_name(adb, &serial).await.as_deref() == Some(avd_name) {
-            return Ok(());
+        for serial in newly_online_emulator_serials_since(&before, &devices) {
+            if rejected_serials.contains(&serial) {
+                continue;
+            }
+            match emulator_avd_name(adb, &serial).await.as_deref() {
+                Some(name) if name == avd_name => return Ok(()),
+                // Confirmed to be a different AVD — never re-check it.
+                Some(_) => {
+                    rejected_serials.insert(serial);
+                }
+                // Unconfirmed (booting or console not ready) — retry next poll.
+                None => {}
+            }
         }
     }
     Err(format!(
@@ -1552,8 +1579,8 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
         ];
 
         assert_eq!(
-            newly_online_emulator_since(&before, &after),
-            Some("emulator-5556".to_string())
+            newly_online_emulator_serials_since(&before, &after),
+            vec!["emulator-5556".to_string()]
         );
     }
 
@@ -1587,8 +1614,34 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
         ];
 
         assert_eq!(
-            newly_online_emulator_since(&before, &after),
-            Some("emulator-5554".to_string())
+            newly_online_emulator_serials_since(&before, &after),
+            vec!["emulator-5554".to_string()]
+        );
+    }
+
+    #[test]
+    fn newly_online_emulator_since_returns_all_candidates_in_order() {
+        // An unrelated emulator becoming online before the wiped AVD must not
+        // shadow it — every candidate is returned so the caller can check each
+        // one's AVD identity.
+        let before: Vec<Device> = Vec::new();
+        let after = vec![
+            test_device(
+                "emulator-5554",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+            test_device(
+                "emulator-5556",
+                DeviceKind::Emulator,
+                DeviceConnectionState::Online,
+            ),
+            test_device("ABC123", DeviceKind::Physical, DeviceConnectionState::Online),
+        ];
+
+        assert_eq!(
+            newly_online_emulator_serials_since(&before, &after),
+            vec!["emulator-5554".to_string(), "emulator-5556".to_string()]
         );
     }
 
@@ -1603,7 +1656,7 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
         )];
         let after = before.clone();
 
-        assert_eq!(newly_online_emulator_since(&before, &after), None);
+        assert!(newly_online_emulator_serials_since(&before, &after).is_empty());
     }
 
     #[test]
@@ -1615,6 +1668,6 @@ emulator-5554          device product:sdk model:sdk_gphone transport_id:1\n";
             DeviceConnectionState::Online,
         )];
 
-        assert_eq!(newly_online_emulator_since(&before, &after), None);
+        assert!(newly_online_emulator_serials_since(&before, &after).is_empty());
     }
 }

--- a/src-tauri/src/services/build_runner.rs
+++ b/src-tauri/src/services/build_runner.rs
@@ -94,9 +94,12 @@ pub fn push_build_error(buf: &mut Vec<BuildError>, error: BuildError) {
         return;
     }
 
-    let has_notice = buf
-        .first()
-        .is_some_and(|first| first.message.starts_with(TRUNCATION_NOTICE_PREFIX));
+    // Length invariant: the buffer holds MAX_BUILD_ERRORS entries while only
+    // real diagnostics have been seen, and exactly MAX_BUILD_ERRORS + 1 once
+    // the truncation notice has been inserted. Detecting the notice by length
+    // avoids false positives from user content (e.g. a diagnostic that happens
+    // to start with the notice text).
+    let has_notice = buf.len() > MAX_BUILD_ERRORS;
     if !has_notice {
         buf.insert(0, truncation_notice());
     }
@@ -1017,6 +1020,23 @@ mod tests {
             buf.last().unwrap().message,
             format!("error {}", MAX_BUILD_ERRORS + 49),
             "the final root-cause error must be retained"
+        );
+    }
+
+    #[test]
+    fn push_build_error_notice_detection_is_not_fooled_by_user_content() {
+        // A real diagnostic whose message happens to start with the notice
+        // prefix must not suppress the truncation notice (detected by length,
+        // not by message content).
+        let mut buf: Vec<BuildError> = (0..MAX_BUILD_ERRORS).map(make_numbered_error).collect();
+        buf[0].message = format!("{TRUNCATION_NOTICE_PREFIX}: error 0");
+
+        push_build_error(&mut buf, make_numbered_error(MAX_BUILD_ERRORS));
+
+        assert_eq!(buf.len(), MAX_BUILD_ERRORS + 1);
+        assert!(
+            buf[0].message.starts_with(TRUNCATION_NOTICE_PREFIX),
+            "a synthetic notice must still be inserted at the front"
         );
     }
 

--- a/src-tauri/src/services/build_runner.rs
+++ b/src-tauri/src/services/build_runner.rs
@@ -64,26 +64,45 @@ pub const MAX_BUILD_LOG: usize = 5_000;
 /// Gradle runs can emit hundreds of thousands of warning lines (lint,
 /// deprecation, per-class); the raw log is capped at `MAX_BUILD_LOG`, so this
 /// list is capped too — it is cloned into every history record and serialized
-/// into the on-disk build history.
+/// into the on-disk build history. Once the cap is reached, one extra slot is
+/// used for a truncation notice.
 pub const MAX_BUILD_ERRORS: usize = 1_000;
 
-/// Push a parsed diagnostic into the build's error accumulator, capping the
-/// buffer at `MAX_BUILD_ERRORS`. Once the cap is reached a single truncation
-/// notice is appended; further diagnostics are dropped.
+const TRUNCATION_NOTICE_PREFIX: &str = "Older diagnostics truncated";
+
+fn truncation_notice() -> BuildError {
+    BuildError {
+        message: format!(
+            "{TRUNCATION_NOTICE_PREFIX}: more than {MAX_BUILD_ERRORS} errors/warnings were emitted."
+        ),
+        file: None,
+        line: None,
+        col: None,
+        severity: BuildErrorSeverity::Warning,
+    }
+}
+
+/// Push a parsed diagnostic into the build's error accumulator.
+///
+/// The buffer keeps the MOST RECENT diagnostics (like `push_build_log` keeps
+/// the newest raw lines): once full, the oldest entry is evicted so late
+/// root-cause errors are not lost to early lint/deprecation noise. The first
+/// time an entry is evicted, a truncation notice is inserted at the front.
 pub fn push_build_error(buf: &mut Vec<BuildError>, error: BuildError) {
     if buf.len() < MAX_BUILD_ERRORS {
         buf.push(error);
-    } else if buf.len() == MAX_BUILD_ERRORS {
-        buf.push(BuildError {
-            message: format!(
-                "More than {MAX_BUILD_ERRORS} errors/warnings emitted — remaining diagnostics were truncated."
-            ),
-            file: None,
-            line: None,
-            col: None,
-            severity: BuildErrorSeverity::Warning,
-        });
+        return;
     }
+
+    let has_notice = buf
+        .first()
+        .is_some_and(|first| first.message.starts_with(TRUNCATION_NOTICE_PREFIX));
+    if !has_notice {
+        buf.insert(0, truncation_notice());
+    }
+    // Evict the oldest diagnostic (right after the notice) to make room.
+    buf.remove(1);
+    buf.push(error);
 }
 
 pub struct BuildStateInner {
@@ -964,26 +983,40 @@ mod tests {
     }
 
     #[test]
-    fn push_build_error_appends_single_truncation_notice_at_cap() {
+    fn push_build_error_keeps_newest_and_prepends_notice_once_at_cap() {
         let mut buf: Vec<BuildError> = (0..MAX_BUILD_ERRORS).map(make_numbered_error).collect();
         push_build_error(&mut buf, make_numbered_error(MAX_BUILD_ERRORS));
+
+        // One truncation notice at the front + the newest diagnostic kept.
         assert_eq!(buf.len(), MAX_BUILD_ERRORS + 1);
-        let notice = buf.last().unwrap();
+        let notice = &buf[0];
         assert_eq!(notice.severity, BuildErrorSeverity::Warning);
-        assert!(notice.message.contains("truncated"));
+        assert!(notice.message.starts_with(TRUNCATION_NOTICE_PREFIX));
         assert!(notice.file.is_none());
+        assert_eq!(buf[1].message, "error 1", "oldest diagnostic evicted");
+        assert_eq!(
+            buf.last().unwrap().message,
+            format!("error {}", MAX_BUILD_ERRORS),
+            "newest diagnostic must survive"
+        );
     }
 
     #[test]
-    fn push_build_error_drops_everything_after_the_notice() {
+    fn push_build_error_stays_capped_across_many_overflows() {
         let mut buf: Vec<BuildError> = (0..MAX_BUILD_ERRORS).map(make_numbered_error).collect();
         for n in 0..50 {
-            push_build_error(&mut buf, make_numbered_error(n));
+            push_build_error(&mut buf, make_numbered_error(MAX_BUILD_ERRORS + n));
         }
         assert_eq!(
             buf.len(),
             MAX_BUILD_ERRORS + 1,
             "buffer must stay capped at the cap plus one truncation notice"
+        );
+        assert!(buf[0].message.starts_with(TRUNCATION_NOTICE_PREFIX));
+        assert_eq!(
+            buf.last().unwrap().message,
+            format!("error {}", MAX_BUILD_ERRORS + 49),
+            "the final root-cause error must be retained"
         );
     }
 

--- a/src-tauri/src/services/build_runner.rs
+++ b/src-tauri/src/services/build_runner.rs
@@ -60,6 +60,32 @@ pub fn load_build_history() -> VecDeque<BuildRecord> {
 /// Maximum number of raw build output lines retained for MCP `get_build_log`.
 pub const MAX_BUILD_LOG: usize = 5_000;
 
+/// Maximum number of structured errors/warnings retained per build. Verbose
+/// Gradle runs can emit hundreds of thousands of warning lines (lint,
+/// deprecation, per-class); the raw log is capped at `MAX_BUILD_LOG`, so this
+/// list is capped too — it is cloned into every history record and serialized
+/// into the on-disk build history.
+pub const MAX_BUILD_ERRORS: usize = 1_000;
+
+/// Push a parsed diagnostic into the build's error accumulator, capping the
+/// buffer at `MAX_BUILD_ERRORS`. Once the cap is reached a single truncation
+/// notice is appended; further diagnostics are dropped.
+pub fn push_build_error(buf: &mut Vec<BuildError>, error: BuildError) {
+    if buf.len() < MAX_BUILD_ERRORS {
+        buf.push(error);
+    } else if buf.len() == MAX_BUILD_ERRORS {
+        buf.push(BuildError {
+            message: format!(
+                "More than {MAX_BUILD_ERRORS} errors/warnings emitted — remaining diagnostics were truncated."
+            ),
+            file: None,
+            line: None,
+            col: None,
+            severity: BuildErrorSeverity::Warning,
+        });
+    }
+}
+
 pub struct BuildStateInner {
     /// Process ID of the currently running Gradle process, if any.
     pub current_build: Option<ProcessId>,
@@ -770,17 +796,20 @@ pub async fn run_task(
                     let line = parse_build_line(&proc_line.text);
                     if matches!(line.kind, BuildLineKind::Error | BuildLineKind::Warning) {
                         if let Ok(mut e) = errors_buf.lock() {
-                            e.push(BuildError {
-                                message: line.content.clone(),
-                                file: line.file.clone(),
-                                line: line.line,
-                                col: line.col,
-                                severity: if line.kind == BuildLineKind::Error {
-                                    BuildErrorSeverity::Error
-                                } else {
-                                    BuildErrorSeverity::Warning
+                            push_build_error(
+                                &mut e,
+                                BuildError {
+                                    message: line.content.clone(),
+                                    file: line.file.clone(),
+                                    line: line.line,
+                                    col: line.col,
+                                    severity: if line.kind == BuildLineKind::Error {
+                                        BuildErrorSeverity::Error
+                                    } else {
+                                        BuildErrorSeverity::Warning
+                                    },
                                 },
-                            });
+                            );
                         }
                     }
                     if line.kind == BuildLineKind::Summary {
@@ -911,6 +940,52 @@ pub async fn run_task(
 mod tests {
     use super::*;
     use crate::models::build::BuildLineKind;
+
+    // ── push_build_error tests ─────────────────────────────────────────────────
+
+    fn make_numbered_error(n: usize) -> BuildError {
+        BuildError {
+            message: format!("error {n}"),
+            file: Some(format!("src/Main{n}.kt")),
+            line: Some(n as u32),
+            col: None,
+            severity: BuildErrorSeverity::Error,
+        }
+    }
+
+    #[test]
+    fn push_build_error_accepts_entries_below_cap() {
+        let mut buf = Vec::new();
+        for n in 0..MAX_BUILD_ERRORS {
+            push_build_error(&mut buf, make_numbered_error(n));
+        }
+        assert_eq!(buf.len(), MAX_BUILD_ERRORS);
+        assert_eq!(buf[0].message, "error 0");
+    }
+
+    #[test]
+    fn push_build_error_appends_single_truncation_notice_at_cap() {
+        let mut buf: Vec<BuildError> = (0..MAX_BUILD_ERRORS).map(make_numbered_error).collect();
+        push_build_error(&mut buf, make_numbered_error(MAX_BUILD_ERRORS));
+        assert_eq!(buf.len(), MAX_BUILD_ERRORS + 1);
+        let notice = buf.last().unwrap();
+        assert_eq!(notice.severity, BuildErrorSeverity::Warning);
+        assert!(notice.message.contains("truncated"));
+        assert!(notice.file.is_none());
+    }
+
+    #[test]
+    fn push_build_error_drops_everything_after_the_notice() {
+        let mut buf: Vec<BuildError> = (0..MAX_BUILD_ERRORS).map(make_numbered_error).collect();
+        for n in 0..50 {
+            push_build_error(&mut buf, make_numbered_error(n));
+        }
+        assert_eq!(
+            buf.len(),
+            MAX_BUILD_ERRORS + 1,
+            "buffer must stay capped at the cap plus one truncation notice"
+        );
+    }
 
     // ── parse_build_line tests ─────────────────────────────────────────────────
 

--- a/src-tauri/src/services/log_pipeline.rs
+++ b/src-tauri/src/services/log_pipeline.rs
@@ -59,6 +59,15 @@ impl PipelineContext {
         }
     }
 
+    /// Seed the ID allocator from an existing store's highest assigned ID
+    /// (pass `store.max_id() + 1`). Keeps IDs monotonic when a fresh context
+    /// replaces the old one while entries from the previous generation are
+    /// still retained — e.g., a logcat reconnect after an ADB server restart.
+    pub fn with_next_id(mut self, next_id: u64) -> Self {
+        self.next_id = self.next_id.max(next_id);
+        self
+    }
+
     pub fn next_id(&mut self) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
@@ -888,5 +897,35 @@ mod tests {
             ctx_plain.seen_packages.len()
         );
         assert_eq!(ctx_seeded.new_packages.len(), ctx_plain.new_packages.len());
+    }
+
+    #[test]
+    fn with_next_id_continues_after_seeded_value() {
+        let mut ctx = PipelineContext::new().with_next_id(43);
+        assert_eq!(ctx.next_id(), 43);
+        assert_eq!(ctx.next_id(), 44);
+    }
+
+    #[test]
+    fn with_next_id_keeps_monotonic_ids_across_context_reset() {
+        // Simulates a reconnect: entries 1..=5 already in the store from the
+        // previous generation, a fresh context must not reissue those IDs.
+        let pipeline = LogPipeline::default_pipeline();
+        let mut ctx = PipelineContext::new().with_next_id(6);
+
+        let raw = RawLogLine {
+            timestamp: "01-01 00:00:00.000".into(),
+            pid: 1000,
+            tid: 1000,
+            level: LogcatLevel::Info,
+            tag: "T".into(),
+            message: "after reconnect".into(),
+        };
+
+        let entry = pipeline.run(raw, &mut ctx);
+        assert_eq!(
+            entry.id, 6,
+            "first entry after reconnect must continue past existing store IDs"
+        );
     }
 }

--- a/src-tauri/src/services/log_store.rs
+++ b/src-tauri/src/services/log_store.rs
@@ -144,6 +144,16 @@ impl LogStore {
         self.entries.is_empty()
     }
 
+    /// Highest entry ID currently in the buffer (0 if empty).
+    ///
+    /// Entries are append-ordered and IDs are monotonic within the current
+    /// ID generation, so the newest entry always carries the maximum ID.
+    /// Used to re-seed pipeline contexts after a stream reconnect so IDs keep
+    /// increasing across generations instead of restarting at 1.
+    pub fn max_id(&self) -> u64 {
+        self.entries.back().map_or(0, |e| e.id)
+    }
+
     /// Iterate entries (oldest first).
     pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, ProcessedEntry> {
         self.entries.iter()
@@ -273,6 +283,29 @@ mod tests {
         store.push(make_entry(2, 0));
         assert_eq!(store.crash_ids().len(), 1);
         assert_eq!(*store.crash_ids().front().unwrap(), 1);
+    }
+
+    #[test]
+    fn max_id_returns_zero_for_empty_store() {
+        let store = LogStore::new();
+        assert_eq!(store.max_id(), 0);
+    }
+
+    #[test]
+    fn max_id_returns_last_pushed_entry_id() {
+        let mut store = LogStore::new();
+        store.push(make_entry(7, 0));
+        store.push(make_entry(42, 0));
+        assert_eq!(store.max_id(), 42);
+    }
+
+    #[test]
+    fn max_id_tracks_newest_entry_after_eviction() {
+        let mut store = LogStore::with_capacity(2);
+        store.push(make_entry(1, 0));
+        store.push(make_entry(2, 0));
+        store.push(make_entry(3, 0));
+        assert_eq!(store.max_id(), 3);
     }
 
     #[test]

--- a/src-tauri/src/services/log_store.rs
+++ b/src-tauri/src/services/log_store.rs
@@ -301,7 +301,13 @@ mod tests {
 
     #[test]
     fn max_id_tracks_newest_entry_after_eviction() {
-        let mut store = LogStore::with_capacity(2);
+        // `with_capacity` clamps to the ring minimum, so override the capacity
+        // directly (same pattern as `eviction_removes_from_indexes`) to force
+        // a 2-entry ring that actually evicts.
+        let mut store = LogStore {
+            capacity: 2,
+            ..LogStore::with_capacity(2)
+        };
         store.push(make_entry(1, 0));
         store.push(make_entry(2, 0));
         store.push(make_entry(3, 0));

--- a/src-tauri/src/services/logcat.rs
+++ b/src-tauri/src/services/logcat.rs
@@ -574,15 +574,15 @@ pub async fn start_logcat_stream(
             // reconnects. Without this, a fresh context restarts IDs at 1 while
             // the ring still holds entries from the previous generation, which
             // breaks LogStore's binary-search invariant for context queries.
-            let mut ctx = {
+            // The seed and the clear epoch are captured in ONE locked snapshot:
+            // if a clear lands right after seeding we must adopt its epoch,
+            // otherwise the first tick would keep this pre-clear-seeded context.
+            let (seed_next_id, mut my_epoch) = {
                 let state = logcat_state.lock().await;
-                let next_id = state.store.max_id().saturating_add(1);
-                PipelineContext::with_initial_pids(initial_pid_map).with_next_id(next_id)
+                (state.store.max_id().saturating_add(1), state.clear_epoch)
             };
-
-            // Track the clear epoch so we can discard buffered-but-unprocessed
-            // lines when the user clicks "clear" while streaming.
-            let mut my_epoch = { logcat_state.lock().await.clear_epoch };
+            let mut ctx =
+                PipelineContext::with_initial_pids(initial_pid_map).with_next_id(seed_next_id);
 
             let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(100));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -633,9 +633,18 @@ pub async fn start_logcat_stream(
                     // active filter — the entries destined for the frontend.
                     // With a level:error filter this means ~5 % of entries are cloned
                     // instead of 100 %.
+                    //
+                    // Ownership is re-checked under the same lock: a stop→start
+                    // restart may have superseded this task between the tick-top
+                    // check and here. Storing after the replacement stream seeded
+                    // its ID allocator would hand it duplicate IDs.
                     let to_emit = {
                         let mut state = logcat_state.lock().await;
-                        store_and_filter_processed_entries(&mut state, &mut ctx, processed)
+                        if !owns_stream(&state, generation) {
+                            Vec::new()
+                        } else {
+                            store_and_filter_processed_entries(&mut state, &mut ctx, processed)
+                        }
                         // Lock dropped here.
                     };
 
@@ -646,12 +655,18 @@ pub async fn start_logcat_stream(
                 // Exit once the channel is closed (reader task finished).
                 if rx.is_closed() {
                     // Drain any remaining lines after EOF before exiting.
+                    // Same ownership guard as above — the final drain must not
+                    // write into the store on behalf of a superseded stream.
                     let mut remaining: Vec<ProcessedEntry> = Vec::new();
                     pipeline.run_batch_into(&mut rx, &mut ctx, &mut remaining);
                     if !remaining.is_empty() {
                         let to_emit = {
                             let mut state = logcat_state.lock().await;
-                            store_and_filter_processed_entries(&mut state, &mut ctx, remaining)
+                            if !owns_stream(&state, generation) {
+                                Vec::new()
+                            } else {
+                                store_and_filter_processed_entries(&mut state, &mut ctx, remaining)
+                            }
                         };
                         emit_entry_batches(app_handle.as_ref(), &to_emit);
                     }

--- a/src-tauri/src/services/logcat.rs
+++ b/src-tauri/src/services/logcat.rs
@@ -570,7 +570,15 @@ pub async fn start_logcat_stream(
             let logcat_state = logcat_state_pipeline;
             let app_handle = app_handle_pipeline;
             let pipeline = LogPipeline::default_pipeline();
-            let mut ctx = PipelineContext::with_initial_pids(initial_pid_map);
+            // Seed the ID allocator from the store so IDs stay monotonic across
+            // reconnects. Without this, a fresh context restarts IDs at 1 while
+            // the ring still holds entries from the previous generation, which
+            // breaks LogStore's binary-search invariant for context queries.
+            let mut ctx = {
+                let state = logcat_state.lock().await;
+                let next_id = state.store.max_id().saturating_add(1);
+                PipelineContext::with_initial_pids(initial_pid_map).with_next_id(next_id)
+            };
 
             // Track the clear epoch so we can discard buffered-but-unprocessed
             // lines when the user clicks "clear" while streaming.

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -380,11 +380,13 @@ describe("runAndDeploy honors the autoInstallOnBuild setting", () => {
     await deploy;
   }
 
-  it("skips install and launch when autoInstallOnBuild is off", async () => {
+  it("skips device resolution, install, and launch when autoInstallOnBuild is off", async () => {
     updateSetting("build", "autoInstallOnBuild", false);
     await deployThroughSuccessfulBuild();
 
     expect(buildState.phase).toBe("success");
+    // Build-only run: the device picker must not even open.
+    expect(devicePickerMock.showDevicePicker).not.toHaveBeenCalled();
     expect(mockInvoke.mock.calls.filter(([cmd]) => cmd === "find_apk_path")).toHaveLength(0);
     expect(mockInvoke.mock.calls.filter(([cmd]) => cmd === "install_apk_on_device")).toHaveLength(
       0

--- a/src/services/build.service.test.ts
+++ b/src/services/build.service.test.ts
@@ -321,3 +321,87 @@ describe("late cancelled completion event after a timeout", () => {
     expect(buildState.phase).toBe("cancelled");
   });
 });
+
+describe("runAndDeploy honors the autoInstallOnBuild setting", () => {
+  beforeEach(() => {
+    resetBuildState();
+    resetDeviceState();
+    resetVariantState();
+    mockInvoke.mockResolvedValue(undefined);
+    devicePickerMock.showDevicePicker.mockReset();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    resetBuildServiceForTests();
+    updateSetting("build", "autoInstallOnBuild", true);
+    vi.useRealTimers();
+  });
+
+  /** Start a deploy and complete its build phase with a success event. */
+  async function deployThroughSuccessfulBuild() {
+    const handlers = new Map<string, (e: { payload: unknown }) => void>();
+    vi.mocked(listen).mockImplementation(async (event, cb) => {
+      handlers.set(String(event), cb as unknown as (e: { payload: unknown }) => void);
+      return () => {};
+    });
+
+    await initBuildService();
+    // Fail loudly if the listener was never registered — otherwise the
+    // dispatch below would no-op and the test would pass vacuously.
+    expect(handlers.has("build:complete")).toBe(true);
+
+    mockInvoke.mockImplementation((cmd) => {
+      if (cmd === "run_gradle_task") return Promise.resolve(1);
+      if (cmd === "get_build_history") return Promise.resolve([]);
+      if (cmd === "find_apk_path") return Promise.resolve("/tmp/app-debug.apk");
+      if (cmd === "get_package_name_from_apk") return Promise.resolve("com.example.app");
+      if (cmd === "install_apk_on_device") return Promise.resolve("Success");
+      if (cmd === "launch_app_on_device") return Promise.resolve("Starting: Intent");
+      return Promise.resolve(undefined);
+    });
+
+    devicePickerMock.showDevicePicker.mockResolvedValue("emulator-5554");
+    await selectVariant("debug");
+
+    const deploy = runAndDeploy();
+    await vi.waitFor(() => expect(buildState.phase).toBe("running"));
+
+    handlers.get("build:complete")!({
+      payload: {
+        success: true,
+        cancelled: false,
+        durationMs: 1_000,
+        errorCount: 0,
+        warningCount: 0,
+        task: "assembleDebug",
+      },
+    });
+    await deploy;
+  }
+
+  it("skips install and launch when autoInstallOnBuild is off", async () => {
+    updateSetting("build", "autoInstallOnBuild", false);
+    await deployThroughSuccessfulBuild();
+
+    expect(buildState.phase).toBe("success");
+    expect(mockInvoke.mock.calls.filter(([cmd]) => cmd === "find_apk_path")).toHaveLength(0);
+    expect(mockInvoke.mock.calls.filter(([cmd]) => cmd === "install_apk_on_device")).toHaveLength(
+      0
+    );
+    expect(mockInvoke.mock.calls.filter(([cmd]) => cmd === "launch_app_on_device")).toHaveLength(0);
+  });
+
+  it("still installs and launches when autoInstallOnBuild is on (default)", async () => {
+    updateSetting("build", "autoInstallOnBuild", true);
+    await deployThroughSuccessfulBuild();
+
+    expect(buildState.phase).toBe("success");
+    expect(mockInvoke.mock.calls.filter(([cmd]) => cmd === "install_apk_on_device")).toEqual([
+      ["install_apk_on_device", { serial: "emulator-5554", apkPath: "/tmp/app-debug.apk" }],
+    ]);
+    expect(
+      mockInvoke.mock.calls.filter(([cmd]) => cmd === "launch_app_on_device")[0]?.[1]
+    ).toMatchObject({ serial: "emulator-5554", package: "com.example.app" });
+  });
+});

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -320,6 +320,14 @@ export async function runAndDeploy(): Promise<void> {
       return;
     }
 
+    // The "Auto Install on Build" setting gates install + launch; the build
+    // itself still counts as a successful deploy cycle when it is off.
+    if (settingsState.build.autoInstallOnBuild === false) {
+      logStep("Auto Install on Build is disabled — skipping install and launch.");
+      setDeployPhase(null);
+      return;
+    }
+
     // 2. Find APK.
     logStep(`Searching for APK (variant: ${variant})…`);
     const apkPath = await findApkPath(variant);

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -270,7 +270,8 @@ async function runBuildInternal(task?: string, opts?: RunBuildOptions): Promise<
 /**
  * Full build → install → launch cycle.
  *
- * If no device is selected, resolves a device via the DevicePickerDialog.
+ * If no device is selected, resolves a device via the DevicePickerDialog —
+ * skipped entirely when "Auto Install on Build" is off (build-only run).
  * After a successful build the APK is installed and the app launched.
  */
 export async function runAndDeploy(): Promise<void> {
@@ -285,22 +286,29 @@ export async function runAndDeploy(): Promise<void> {
 
   deployInFlight = true;
   const variant = variantState.activeVariant;
+  // Read once up front: when auto-install is off this is a build-only run,
+  // which must not force device selection.
+  const autoInstall = settingsState.build.autoInstallOnBuild !== false;
 
   try {
     if (!variant) {
       throw new Error("No build variant selected. Open Build → Select Variant.");
     }
 
-    // Resolve a device before the build so we can bail early.
-    // We log this BEFORE startBuild clears the log — that's intentional; users
-    // will see the context when the build panel opens.
-    logStep("Resolving target device…");
-    const serial = await resolveDevice();
-    if (!serial) {
-      logStep("No device selected — run cancelled.");
-      return;
+    // Resolve a device before the build so we can bail early — but only when
+    // the result will actually be installed; a build-only run needs no device.
+    let serial: string | null = null;
+    if (autoInstall) {
+      // We log this BEFORE startBuild clears the log — that's intentional;
+      // users will see the context when the build panel opens.
+      logStep("Resolving target device…");
+      serial = await resolveDevice();
+      if (!serial) {
+        logStep("No device selected — run cancelled.");
+        return;
+      }
+      logStep(`Target device: ${serial}`);
     }
-    logStep(`Target device: ${serial}`);
 
     // 1. Build. startBuild() inside runBuild() clears the log, so we add a
     //    context header as the very first callback line from the Gradle channel.
@@ -308,7 +316,7 @@ export async function runAndDeploy(): Promise<void> {
     await runBuildGuarded(
       `assemble${capitalize(variant)}`,
       {
-        headerLines: [`── Deploy: ${variant} → ${serial} ──`],
+        headerLines: [serial ? `── Deploy: ${variant} → ${serial} ──` : `── Build: ${variant} ──`],
       },
       true
     );
@@ -322,10 +330,13 @@ export async function runAndDeploy(): Promise<void> {
 
     // The "Auto Install on Build" setting gates install + launch; the build
     // itself still counts as a successful deploy cycle when it is off.
-    if (settingsState.build.autoInstallOnBuild === false) {
+    if (!autoInstall) {
       logStep("Auto Install on Build is disabled — skipping install and launch.");
       setDeployPhase(null);
       return;
+    }
+    if (!serial) {
+      throw new Error("No device selected.");
     }
 
     // 2. Find APK.

--- a/src/stores/variant.store.ts
+++ b/src/stores/variant.store.ts
@@ -255,9 +255,9 @@ export async function selectVariant(name: string): Promise<void> {
   try {
     await setActiveVariant(name);
   } catch (err) {
-    // Same reasoning as pickDevice: the backend's active variant drives
-    // find_apk_path and the MCP tools, so a silent divergence is worse than a
-    // visible failure.
+    // The backend persists last_build_variant for this project (the same
+    // state the MCP set_active_variant tool writes), so a silent failure
+    // would leave settings diverged from the UI — worse than a visible error.
     setVariantState("activeVariant", previous);
     showToast(`Failed to select variant: ${formatError(err)}`, "error");
     return;


### PR DESCRIPTION
## Summary

Five verified fixes found during a code-grounded bug/gap sweep. Each is independent and minimal.

### Bug 1 — Logcat entry IDs restarted at 1 after stream reconnect
Every iteration of the `'reconnect` loop created a fresh `PipelineContext` (`next_id = 1`) while `LogStore` retained the previous generation's entries — producing duplicated and non-monotonic IDs in the ring buffer and breaking the binary-search invariant behind `context_before`/`context_after`.
**Fix:** seed the new context's ID allocator from `LogStore::max_id() + 1` on reconnect (new `with_next_id` builder + `max_id()` accessor). The explicit clear path still resets IDs to 1 alongside an emptied store, which stays consistent.

### Bug 2 — `wipe_avd_data` reported success if *any* emulator was online
The wait loop accepted any online emulator instead of detecting the newly launched one, so wiping while another emulator ran returned `Ok(())` before the wiped AVD booted.
**Fix:** snapshot devices before spawn and reuse `newly_online_emulator_serial`, mirroring `launch_emulator`.

### Gap 1 — `build.autoInstallOnBuild` setting was dead
The toggle persisted but nothing read it; deploy always installed and launched.
**Fix:** the deploy flow skips install/launch when the setting is off (build itself still reports success). Covered by two new Vitest tests (off → no install/launch invokes; on → install + launch invoked).

### Gap 2 — `set_active_variant` IPC command was a no-op stub
It ignored its argument while real persistence existed via `set_active_variant_for_project` (used only by MCP), and the frontend comment claimed backend behavior that didn't exist.
**Fix:** the command now persists `last_build_variant` for the current project keyed by gradle root — exactly what the MCP tool writes. No frontend arg/binding changes needed; stale comment corrected.

### Improvement — Uncapped build error/warning accumulator
`errors_buf` grew without bound for every error/warning line, then was cloned into history records and serialized to disk, violating the project's bounded-collection rule (raw log is capped at 5,000).
**Fix:** shared `push_build_error` helper caps at `MAX_BUILD_ERRORS` (1,000) with a single truncation notice; used by both the service and command paths.

## Test plan

- [x] `cargo test` — 470 tests pass (incl. 7 new: `max_id` ×3, `with_next_id` ×2, `push_build_error` ×3... see below)
- [x] `npm run test` — 1,188 tests pass (incl. 2 new deploy-setting tests)
- [x] `npm run lint`
- [x] `npm run typescript:check`
- New Rust tests: `max_id_*` (3), `with_next_id_*` (2), `push_build_error_*` (3); new Vitest: skip-install / still-install (2)

Not directly unit-tested: `wipe_avd_data`'s wait loop requires a real emulator binary; correctness rests on the existing `newly_online_emulator_serial` tests, which cover exactly the ignore-existing-emulators scenario.

## Follow-ups (out of scope here)

- Dead config surfaces: `LspSettings`, unused `AdvancedSettings` fields, `SearchSettings` section, unused managed `LogBuffer` state (settings-schema cleanup PR)
- MCP activity polling runs every 3 s for the whole session even with the panel closed
- Health-check re-run after project load is silently dropped if the startup check is still in flight