### PR TITLE
Make setAgeInQuery and setPackageInQuery in src/lib/logcat-query.ts stri

### DIFF
--- a/src/lib/logcat-query.test.ts
+++ b/src/lib/logcat-query.test.ts
@@ -545,6 +545,14 @@ describe("setAgeInQuery", () => {
   it("returns empty string when only age is removed", () => {
     expect(setAgeInQuery("age:5m", null)).toBe("");
   });
+
+  it("strips a negated age token whole instead of leaving an orphan '-'", () => {
+    expect(setAgeInQuery("-age:5m level:error", "1h")).toBe("level:error age:1h");
+  });
+
+  it("returns empty string when only a negated age token is removed", () => {
+    expect(setAgeInQuery("-age:5m", null)).toBe("");
+  });
 });
 
 // ── getActiveTokenContext ─────────────────────────────────────────────────────
@@ -1045,6 +1053,21 @@ describe("setPackageInQuery", () => {
     // Round-trip: removing both leaves empty
     const cleared = setPackageInQuery(setAgeInQuery(withBoth, null), null);
     expect(cleared).toBe("");
+  });
+
+  it("strips a negated package token whole instead of leaving an orphan '-'", () => {
+    expect(setPackageInQuery("-package:com.a level:error", "com.b")).toBe(
+      "level:error package:com.b"
+    );
+  });
+
+  it("returns empty string when only a negated package token is removed", () => {
+    expect(setPackageInQuery("-package:com.a", null)).toBe("");
+  });
+
+  it("does not produce an orphan negated-empty freetext token", () => {
+    const tokens = parseQuery(setPackageInQuery("-package:com.a level:error", "com.b"));
+    expect(tokens.every((t) => !(t.type === "freetext" && t.value === ""))).toBe(true);
   });
 });
 

--- a/src/lib/logcat-query.ts
+++ b/src/lib/logcat-query.ts
@@ -510,7 +510,7 @@ function safeRegexTest(pattern: string, target: string): boolean {
 /** Replace or insert an `age:` token in a raw query string. */
 export function setAgeInQuery(query: string, age: string | null): string {
   const withoutAge = query
-    .replace(/\bage:\S+/g, "")
+    .replace(/(^|\s)-?age:\S+/g, "$1")
     .replace(/\s+/g, " ")
     .trim();
   if (!age) return withoutAge;
@@ -520,7 +520,7 @@ export function setAgeInQuery(query: string, age: string | null): string {
 /** Replace or insert a `package:` token in a raw query string. */
 export function setPackageInQuery(query: string, pkg: string | null): string {
   const withoutPkg = query
-    .replace(/\bpackage:\S+/g, "")
+    .replace(/(^|\s)-?package:\S+/g, "$1")
     .replace(/\s+/g, " ")
     .trim();
   if (!pkg) return withoutPkg;


### PR DESCRIPTION
## Make setAgeInQuery and setPackageInQuery in src/lib/logcat-query.ts strip a negated `-age:`/`-package:` token whole, instead of removing only the `key:value` part and leaving an orphan `-` that parseQuery turns into a negated empty freetext token which filters out every log entry, and cover the behaviour with unit tests.

Confirmed in the checkout: line 513 uses /\bage:\S+/g and line 523 uses /\bpackage:\S+/g. `\b` matches at the boundary between `-` and `p`/`a`, so for the input `-package:com.a level:error` only `package:com.a` is removed and the leading `-` survives whitespace collapsing as a standalone part. parseQuery (lines 274-275, 348) sets negate=true and p="" for that part, emitting {type:"freetext", value:"", negate:true}; matchToken's freetext branch (lines 464-471) computes includes("") === true and then returns !matches, so every entry is rejected and the logcat list appears empty. The path is user-reachable from the package dropdown (src/components/logcat/LogcatPanel.tsx:398) and the age dropdown (LogcatPanel.tsx:858) whenever the user already has a negated package/age filter. Anchoring the strip regexes to a token start and letting them consume an optional `-` removes the whole token, which matches the existing intent of these helpers ("replace or insert the token") and keeps all current tests' expectations intact.

### Acceptance criteria

- setPackageInQuery("-package:com.a level:error", "com.b") returns a string with no standalone "-" part; specifically it equals "level:error package:com.b".  
  _verified by: New unit test in src/lib/logcat-query.test.ts inside the existing describe("setPackageInQuery") block asserting the exact string; run the `test` gate._
- setAgeInQuery("-age:5m level:error", "1h") equals "level:error age:1h".  
  _verified by: New unit test in the existing describe("setAgeInQuery") block asserting the exact string; run the `test` gate._
- parseQuery(setPackageInQuery("-package:com.a level:error", "com.b")) contains no token of type "freetext" with value "" (no orphan negated-empty token).  
  _verified by: Unit test asserting tokens.every(t => !(t.type === "freetext" && t.value === "")) — or equivalently that the token list is exactly the level and package tokens; run the `test` gate._
- Clearing a negated token still works: setPackageInQuery("-package:com.a", null) === "" and setAgeInQuery("-age:5m", null) === "".  
  _verified by: Unit tests asserting both equal the empty string; run the `test` gate._
- All pre-existing behaviour of both helpers is unchanged (non-negated replace, append, remove, 'mine' shorthand, composition, and the QueryBar state tests that call these helpers).  
  _verified by: Existing tests in src/lib/logcat-query.test.ts, src/components/logcat/querybar-query-state.test.ts and src/components/logcat/LogcatPanel.auto-filter.test.ts pass unmodified under the `test` gate._
- The project still compiles/type-checks with no new errors.  
  _verified by: Run the `build` gate._

### Local gate results

- ✅ `test` — `npm test` (exit 0, 10101ms)
- ✅ `build` — `npm run build` (exit 0, 902ms)

### Automated review: approve

The fix anchors the age/package strip regexes to a token start with an optional leading '-' (/(^|\s)-?age:\S+/g and /(^|\s)-?package:\S+/g), replacing with the captured separator "$1". This removes the whole negated token instead of leaving an orphan '-' that parseQuery turns into a negated empty freetext token (which previously caused matchToken to reject every entry). This is exactly the recommended form from the planner's open questions (avoiding lookbehind). Manual trace through start-of-string, mid-string single/double-space, and adjacent-negated-token cases confirms correct behavior with no overlap issues from the /g flag. All four acceptance-criteria test cases were added in the correct existing describe blocks and assert exact expected strings/booleans that would fail under the old \b-based regex. Pre-existing tests for non-negated replace/append/remove/mine-shorthand/composition are unmodified and unaffected since -? is optional. Diff is scoped strictly to the two declared files; no scope creep. Gate results report both test and build passing.

### Questions I answered myself

_Each was answered from a source, not from judgement. The citations are the point: check one you doubt._

**Use the non-lookbehind, whitespace-consuming form: /(^|\s)-?package:\S+/g and /(^|\s)-?age:\S+/g, relying on the existing .replace(/\s+/g, " ").trim() pass to normalize spacing. The codebase does not use regex lookbehind anywhere (searched all of src/ for '(?<' — no matches), so there is no existing convention to follow that would favor the lookbehind form, and the current setPackageInQuery/setAgeInQuery already use a similarly simple anchoring style (\b) rather than lookaround. Since Tauri ships this UI inside the OS's native webview (WKWebView on macOS, WebView2 on Windows) rather than a controlled evergreen browser, avoiding lookbehind removes a portability risk for no cost — the capturing-group form is strictly safer and matches the plan's own recommendation.**  
_codebase · medium confidence · tier 0_
  - `src/lib/logcat-query.ts:513` — ".replace(/\bage:\S+/g, "")"
  - `src/lib/logcat-query.ts:523` — ".replace(/\bpackage:\S+/g, "")"
  - _also considered:_ Lookbehind form /(?<![^\s])-?package:\S+/g — functionally equivalent but introduces a lookaround pattern with no precedent in this codebase and a (small, but non-zero) portability risk in a native-webview desktop app.

**Yes, treating dropdown selection as replacing any existing (negated or not) package/age token with a positive one matches this codebase's existing convention, not just the finding's assumption. getPackageFromQuery, which drives the dropdown's 'active package' highlighting, already matches `-package:X` and reports X as active — it has no negation awareness. setPackageInQuery/setAgeInQuery are documented and tested only as 'replace or insert' operations with no negated variant anywhere in the codebase or test suite (checked src/lib/logcat-query.test.ts, src/components/logcat/*.test.ts, and all call sites of both helpers). There is no negation-aware sibling API, no pill-negation-preserving code path reachable from these dropdown handlers, and QueryBar's own negation concept (-tag, -package, etc.) is a manual query-text feature, separate from and not wired into the dropdowns. So silently converting -package:com.a to package:com.b on dropdown select is consistent with how the rest of the UI already treats these helpers, not an undocumented behavior change.**  
_codebase · medium confidence · tier 0_
  - `src/lib/logcat-query.ts:624` — "const match = query.match(/\bpackage:(\S+)/);"
  - `src/lib/logcat-query.ts:521` — "/** Replace or insert a `package:` token in a raw query string. */"
  - `src/components/logcat/LogcatPanel.tsx:398` — "const q = setPackageInQuery(query(), pkg);"
  - _also considered:_ Detect a leading '-' on the matched token before stripping and re-emit '-package:<new>' to preserve negation intent — defensible, but would be a new capability with no existing precedent, no reachable UI to invoke it (the dropdown has no 'negate' toggle), and no test coverage requesting it.


### Deliberately out of scope

- Fixing matchToken's freetext branch so a negated empty-value token is harmless (defensive fix at src/lib/logcat-query.ts:464-471) — the empty token should not be produced in the first place; treat as a separate hardening finding.
- Making parseQuery ignore a bare "-" part instead of emitting a negated empty freetext token.
- Quoted values such as package:"com.a b": \S+ already truncates them and the helpers never emit quotes; not addressed here.
- OR-group / parenthesised queries such as (package:a|level:error): the old \b regex mangled them into an orphan "(", the anchored regex will leave them untouched (possibly yielding two package tokens). Neither behaviour is specified; leave as follow-up work.
- Any change to LogcatPanel.tsx or QueryBar rendering.

### Notes from the implementing step

- All 6 acceptance criteria verified: new tests for criteria 1-4 pass, and the full pre-existing suite (1191 tests across 116 files, including querybar-query-state.test.ts and LogcatPanel.auto-filter.test.ts) passes unmodified — satisfying criterion 5. `npm run build` succeeds with only pre-existing, unrelated Vite chunking warnings — satisfying criterion 6.
- Used the recommended (^|\s)-?key:\S+ form with a captured group replacement (avoids lookbehind, per the planning step's stated preference) rather than a lookbehind regex.
- Per the open product-behaviour question in the spec, negation is dropped (not preserved) when the dropdown sets a new value — this matches the spec's assumed/recommended behaviour and the acceptance criteria's exact expected strings (e.g. setPackageInQuery('-package:com.a level:error','com.b') === 'level:error package:com.b', a positive filter). This was called out as an open question for human confirmation in the spec; I followed the spec's stated assumption rather than guessing further.
- Left out of scope per spec: matchToken's freetext branch hardening, parseQuery's handling of bare '-' parts, quoted-value truncation, and OR-group/parenthesised query behavior — none of these files/behaviors were touched.

Closes #218 — the run's full log is on the issue.

---

🤖 Opened by agentpipe run `r-20260904-012751-6T99` · estimated cost $0.00 (client-side estimate, not a billing figure)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `setAgeInQuery` and `setPackageInQuery` so they strip negated `-age:` and `-package:` tokens whole instead of leaving an orphan `-` behind, which `parseQuery` turned into a negated empty freetext token that filtered out every log entry. The strip regexes are now anchored to a token start and consume an optional leading dash.

- Replaces `/\bage:\S+/g` with `/(^|\s)-?age:\S+/g` (and the same for `package`) so the leading `-` is removed with the token.
- Drops negation when the dropdown replaces a negated token with a positive one, matching existing helper behavior.
- Adds unit tests for stripping negated tokens, clearing them, and verifying no orphan negated-empty token is produced.

<sup>Written for commit 51705b3871e76c43000a2e4e5ff541265827f6d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/thiagodmont/keynobi/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

